### PR TITLE
Fix bugs: poison, walls, HUD overlap, loot, use-items

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ---
 
+## v0.10 – 2026-03-29
+
+### Bugfikser
+- **Gift tikker saktere (#10):** Gift tikker nå hvert ~900ms (før: ~380ms). Gir tid til å åpne inventory og bruke motgift
+- **Motgift kurerer gift (#10):** Motgift fjerner nå gifteffekten (i tillegg til +1 hjerte)
+- **Sprukne vegger fikset (#11):** Facing-retning oppdateres nå også når bevegelse blokkeres av vegger/dører, slik at man alltid kan bryte sprekket vegg ved å trykke mot den + SPACE/F
+- **HUD overlapper ikke lenger (#12):** Kamera følger helten med offset nedover slik at HUD-baren ikke skjuler figuren i øverste rader
+- **Redusert item-drop (#13):** Monster drop rate senket fra 45% til 25%; 70% sjanse for consumable fremfor utstyr; kiste-item nr 2 er nå alltid consumable
+- **Bruksgjenstand-knapp (#14):** Ny Q-tast (+ USE touch-knapp) bruker første consumable i ryggsekken direkte i spill — bomber, blendgranater, drikker osv. fungerer nå i kamp
+
+### Tekniske endringer
+- `GameScene.poisonTickTimer` – egen timer for gift, uavhengig av monstertick
+- `GameScene._handleUseItem()` – ny quick-use metode (Q / touch USE)
+- `GameScene._tryMoveHero()` – setter `hero.facing` før bevegelsessjekk
+- `GameScene.cameras.main.setFollowOffset(0, -30)` – kameraoffset for HUD
+- `TouchControls` – ny USE-knapp i action button grid
+- `antidote.use()` – nullstiller `poisonTurns` + refresher sprite
+
+---
+
 ## v0.9 – 2026-03-29
 
 ### Nye funksjoner

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,5 +1,5 @@
 # Labyrint Hero – Game Design Document
-**Versjon:** 0.9
+**Versjon:** 0.10
 **Sist oppdatert:** 2026-03-29
 
 ---
@@ -122,6 +122,7 @@ Heltens grunnstats gjør at verden 1 er farlig uten noe utstyr. Utstyr og evner 
 | WASD / Piltaster / D-pad (touch) | Beveg helt |
 | SPACE / F / Angrepsknapp (touch) | Angrip i sett retning (eller nærmeste monster) |
 | R / Bueknapp (touch) | Skyt pil (krever bue utstyrt) |
+| Q / USE-knapp (touch) | Bruk første consumable i ryggsekken (bombe, drikk, etc.) |
 | E / Inventarknapp (touch) | Åpne/lukk inventory |
 | ESC | Lukk overlay |
 | +/- eller muskjul | Zoom inn/ut |

--- a/src/data/items.js
+++ b/src/data/items.js
@@ -104,8 +104,13 @@ const ITEM_DEFS = {
     },
     antidote: {
         id: 'antidote', name: 'Motgift', type: 'consumable',
-        color: 0x88ee44, desc: 'Gjenoppretter 1 hjerte', tier: 1,
-        use(hero) { hero.hearts = Math.min(hero.hearts + 1, hero.maxHearts); return true; }
+        color: 0x88ee44, desc: 'Kurerer gift og gjenoppretter 1 hjerte', tier: 1,
+        use(hero) {
+            hero.poisonTurns = 0;
+            hero.hearts = Math.min(hero.hearts + 1, hero.maxHearts);
+            hero._drawSprite();
+            return true;
+        }
     },
     bomb: {
         id: 'bomb', name: 'Bombe', type: 'consumable',

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -84,6 +84,8 @@ class GameScene extends Phaser.Scene {
         // ── Camera ───────────────────────────────────────────────────────────
         this.cameras.main.setBounds(0, 0, this.tileW * TILE_SIZE, this.tileH * TILE_SIZE);
         this.cameras.main.startFollow(this.hero.graphics, true, 0.08, 0.08);
+        // Offset camera follow downward so HUD (54px) doesn't obscure the hero
+        this.cameras.main.setFollowOffset(0, -30);
         this.cameras.main.setZoom(ZOOM_DEFAULT);
 
         // ── Input ─────────────────────────────────────────────────────────────
@@ -97,6 +99,7 @@ class GameScene extends Phaser.Scene {
         this.zoomOutKey   = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.MINUS);
         this.zoomInAlt    = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.NUMPAD_ADD);
         this.zoomOutAlt   = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.NUMPAD_SUBTRACT);
+        this.useItemKey   = this.input.keyboard.addKey('Q');
         this.moveTimer    = 0;
 
         // Mouse wheel zoom
@@ -110,6 +113,7 @@ class GameScene extends Phaser.Scene {
 
         // ── Monster tick ──────────────────────────────────────────────────────
         this.monsterTick = 0;
+        this.poisonTickTimer = 0;
 
         // ── Exit portal pulse ─────────────────────────────────────────────────
         this._spawnExitPortal();
@@ -540,11 +544,12 @@ class GameScene extends Phaser.Scene {
                 onComplete: () => chest.graphic.destroy()
             });
 
-            // Contents: 2 items guaranteed; first always weapon or armor
+            // Contents: 2 items; first is equipment (weapon/armor), second is consumable
             const item1 = Math.random() < 0.5
                 ? randomItemByType(this.worldNum, 'weapon', new Set())
                 : randomItemByType(this.worldNum, 'armor',  new Set());
-            const item2 = randomItemForWorld(this.worldNum);
+            const item2 = randomItemByType(this.worldNum, 'consumable', new Set())
+                || randomItemForWorld(this.worldNum);
 
             let givenCount = 0;
             for (const item of [item1, item2]) {
@@ -733,6 +738,7 @@ class GameScene extends Phaser.Scene {
             this._handleInput(delta);
             this._handleAttack();
             this._handleBow();
+            this._handleUseItem();
             this._handleZoom();
 
             const touchInv = this.game.registry.get('touch_inventory');
@@ -772,6 +778,9 @@ class GameScene extends Phaser.Scene {
     }
 
     _tryMoveHero(dx, dy) {
+        // Always update facing direction, even when movement is blocked
+        this.hero.facing = { dx, dy };
+
         const nx = this.hero.gridX + dx, ny = this.hero.gridY + dy;
         if (nx < 0 || nx >= this.tileW || ny < 0 || ny >= this.tileH) return;
 
@@ -891,6 +900,29 @@ class GameScene extends Phaser.Scene {
         this._shootArrow(dx, dy, weapon.atk || 3);
     }
 
+    // ── Quick-Use Item (Q key / touch USE button) ──────────────────────────
+
+    _handleUseItem() {
+        const touchUse = this.game.registry.get('touch_use');
+        if (touchUse) this.game.registry.set('touch_use', false);
+        if (!Phaser.Input.Keyboard.JustDown(this.useItemKey) && !touchUse) return;
+
+        // Find first consumable in backpack
+        const bp = this.hero.inventory.backpack;
+        const idx = bp.findIndex(item => item && item.type === 'consumable');
+        if (idx === -1) {
+            this._showMessage('Ingen bruksgjenstander i ryggsekken!', '#ff8844');
+            return;
+        }
+        const item = bp[idx];
+        const consumed = item.use(this.hero, this);
+        if (consumed) {
+            bp[idx] = null;
+            Audio.playPickup();
+            this._floatingText(this.hero.gridX, this.hero.gridY, `✦ ${item.name}`, '#44ccff');
+        }
+    }
+
     _shootArrow(dx, dy, damage) {
         Audio.playArrow();
         let ax = this.hero.gridX + dx, ay = this.hero.gridY + dy;
@@ -1008,8 +1040,13 @@ class GameScene extends Phaser.Scene {
             // Boss always drops a guaranteed item from a higher tier
             const bossItem = randomItemForWorld(Math.min(this.worldNum + 1, 7));
             if (bossItem) this._spawnItemAt(monster.gridX, monster.gridY, bossItem);
-        } else if (Math.random() < 0.45) {
-            this._spawnItemAt(monster.gridX, monster.gridY, randomItemForWorld(this.worldNum));
+        } else if (Math.random() < 0.25) {
+            // Favor consumables over equipment (70% consumable, 30% any)
+            const item = Math.random() < 0.7
+                ? randomItemByType(this.worldNum, 'consumable', new Set())
+                  || randomItemForWorld(this.worldNum)
+                : randomItemForWorld(this.worldNum);
+            this._spawnItemAt(monster.gridX, monster.gridY, item);
         }
         if (leveled) this._onLevelUp();
     }
@@ -1053,17 +1090,24 @@ class GameScene extends Phaser.Scene {
 
     _tickMonsters(delta) {
         this.monsterTick += delta;
+
+        // Poison ticks on its own slower timer (every ~900ms instead of every monster tick)
+        if (this.hero.poisonTurns > 0) {
+            this.poisonTickTimer += delta;
+            if (this.poisonTickTimer >= 900) {
+                this.poisonTickTimer = 0;
+                this.hero.poisonTurns--;
+                const died = this.hero.takeDamage(1);
+                this._floatingText(this.hero.gridX, this.hero.gridY, '☠ -1', '#44ee66');
+                this.hero._drawSprite();
+                if (died) { this._heroDied(); return; }
+            }
+        } else {
+            this.poisonTickTimer = 0;
+        }
+
         if (this.monsterTick < MONSTER_TICK_MS) return;
         this.monsterTick = 0;
-
-        // Poison damage tick
-        if (this.hero.poisonTurns > 0) {
-            this.hero.poisonTurns--;
-            const died = this.hero.takeDamage(1);
-            this._floatingText(this.hero.gridX, this.hero.gridY, '☠ -1', '#44ee66');
-            this.hero._drawSprite();  // refresh tint (clears when poisonTurns hits 0)
-            if (died) { this._heroDied(); return; }
-        }
 
         for (const m of [...this.monsters]) {
             if (!m.alive) continue;

--- a/src/scenes/UIScene.js
+++ b/src/scenes/UIScene.js
@@ -36,7 +36,7 @@ class UIScene extends Phaser.Scene {
         this.levelText  = this.add.text(W - 50, 22, '', ts).setOrigin(1, 0);
         this.atkText    = this.add.text(W - 50, 36, '', ts).setOrigin(1, 0);
         this.eqText     = this.add.text(10, 56, '', { fontSize: '10px', color: '#556677', fontFamily: 'monospace' });
-        this.eHint      = this.add.text(W - 50, 56, '[SPACE/F] Angrep  [R] Pil  [E] Inventar  [+/-] Zoom', { fontSize: '10px', color: '#334455', fontFamily: 'monospace' }).setOrigin(1, 0);
+        this.eHint      = this.add.text(W - 50, 56, '[SPACE/F] Angrep  [R] Pil  [Q] Bruk  [E] Inventar  [+/-] Zoom', { fontSize: '10px', color: '#334455', fontFamily: 'monospace' }).setOrigin(1, 0);
 
         // Poison indicator (hidden until poisoned)
         this.poisonText = this.add.text(10, 70, '', {

--- a/src/systems/TouchControls.js
+++ b/src/systems/TouchControls.js
@@ -17,6 +17,7 @@ class TouchControls {
         reg.set('touch_bow', false);
         reg.set('touch_inventory', false);
         reg.set('touch_minimap', false);
+        reg.set('touch_use', false);
 
         this._createDpad();
         this._createActionButtons();
@@ -91,6 +92,7 @@ class TouchControls {
         const buttons = [
             { label: 'ATK', key: 'touch_attack',    color: 0xaa3333, ox: 0,           oy: 0           },
             { label: 'BOW', key: 'touch_bow',       color: 0x997722, ox: -(sz + gap), oy: 0           },
+            { label: 'USE', key: 'touch_use',       color: 0x339988, ox: -(sz + gap) * 2, oy: 0       },
             { label: 'INV', key: 'touch_inventory', color: 0x335588, ox: 0,           oy: -(sz + gap) },
             { label: 'MAP', key: 'touch_minimap',   color: 0x338844, ox: -(sz + gap), oy: -(sz + gap) },
         ];


### PR DESCRIPTION
## Summary
Fixes all 5 reported bugs:

- **#10** Poison ticks slowed from 380ms to 900ms; antidote now cures poison
- **#11** Facing direction updates on blocked movement, so cracked walls can always be broken
- **#12** Camera follow offset prevents HUD from obscuring hero in top rows
- **#13** Monster drop rate reduced 45%→25%, weighted 70% toward consumables; chest item #2 always consumable
- **#14** New quick-use button (Q key / USE touch) uses first consumable in backpack during gameplay

## Test plan
- [ ] Get poisoned by an orc — verify slower tick rate, use antidote to cure
- [ ] Stand next to cracked wall, face it, press SPACE — should break
- [ ] Move hero to top rows — verify HUD doesn't obscure character
- [ ] Kill several monsters — verify fewer drops, more consumables
- [ ] Pick up a bomb, press Q — verify it explodes and damages nearby monsters

https://claude.ai/code/session_011Tt6skU8aVN8qCpq4mKaJt