### PR TITLE
Consumable stacking and quick-use slot

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ---
 
+## v0.11 – 2026-03-29
+
+### Nye funksjoner
+- **Stabling av gjenstander (#14):** Consumables og verktøy stabler nå opp til 10 stykk per slot i ryggsekken. Antall vises som tall-badge i inventory
+- **Hurtig-bruk-slot (#14):** Nytt utstyrsfelt «Hurtig (Q)» i inventory for å tildele en consumable til hurtigknappen. Klikk en consumable i ryggsekken for å sette den i hurtigsloten. Trykk Q / USE for å bruke den i spill
+- **Forbedret inventory-layout:** Tre utstyrsfelt side om side (Våpen – Rustning – Hurtig)
+
+### Tekniske endringer
+- `Inventory.quickUse` – nytt felt `{ id, count }` for hurtigbruk-slot
+- `Inventory.addItem()` – automatisk stabling for consumables/tools
+- `Inventory._getItemDef()` / `_getCount()` – hjelpere for nytt entry-format
+- `Inventory.serialize()` / `deserialize()` – støtter stabel-format `{ id, count }` + bakoverkompatibelt med gamle saves
+- `InventoryScene._makeQuickUseSlot()` – ny UI-komponent
+- `InventoryScene._makeBackpackSlot()` – viser stabelantall-badge
+- `GameScene._handleUseItem()` – bruker `inventory.useQuickItem()` istedenfor direkte backpack-søk
+- `GameScene._findItemInBackpack()` – kompatibel med nytt entry-format
+- Nøkkel/hakke-forbruk bruker nå `dropSlot()` for korrekt stabel-dekrementering
+
+---
+
 ## v0.10 – 2026-03-29
 
 ### Bugfikser

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,5 +1,5 @@
 # Labyrint Hero – Game Design Document
-**Versjon:** 0.10
+**Versjon:** 0.11
 **Sist oppdatert:** 2026-03-29
 
 ---

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -814,7 +814,7 @@ class GameScene extends Phaser.Scene {
                 return;
             }
             Audio.playDoor();
-            this.hero.inventory.backpack[keyIdx] = null;
+            this.hero.inventory.dropSlot(keyIdx);
             this.maze[ny][nx] = TILE.FLOOR;
             this._drawMap();
             this.cameras.main.shake(50, 0.003);
@@ -860,7 +860,7 @@ class GameScene extends Phaser.Scene {
                 const pickIdx = this._findItemInBackpack('pickaxe');
                 if (pickIdx !== -1) {
                     Audio.playBreak();
-                    this.hero.inventory.backpack[pickIdx] = null;
+                    this.hero.inventory.dropSlot(pickIdx);
                     this.maze[fy][fx] = TILE.FLOOR;
                     this._drawMap();
                     this.cameras.main.shake(100, 0.006);
@@ -907,19 +907,13 @@ class GameScene extends Phaser.Scene {
         if (touchUse) this.game.registry.set('touch_use', false);
         if (!Phaser.Input.Keyboard.JustDown(this.useItemKey) && !touchUse) return;
 
-        // Find first consumable in backpack
-        const bp = this.hero.inventory.backpack;
-        const idx = bp.findIndex(item => item && item.type === 'consumable');
-        if (idx === -1) {
-            this._showMessage('Ingen bruksgjenstander i ryggsekken!', '#ff8844');
-            return;
-        }
-        const item = bp[idx];
-        const consumed = item.use(this.hero, this);
-        if (consumed) {
-            bp[idx] = null;
+        // Use item from quick-use slot
+        const used = this.hero.inventory.useQuickItem(this.hero, this);
+        if (used) {
             Audio.playPickup();
-            this._floatingText(this.hero.gridX, this.hero.gridY, `✦ ${item.name}`, '#44ccff');
+            this._floatingText(this.hero.gridX, this.hero.gridY, `✦ ${used.name}`, '#44ccff');
+        } else {
+            this._showMessage('Ingen hurtiggjenstand valgt! (åpne inventar med E)', '#ff8844');
         }
     }
 
@@ -1153,7 +1147,10 @@ class GameScene extends Phaser.Scene {
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     _findItemInBackpack(id) {
-        return this.hero.inventory.backpack.findIndex(item => item && item.id === id);
+        return this.hero.inventory.backpack.findIndex(entry => {
+            if (!entry) return false;
+            return entry.id === id;
+        });
     }
 
     // ── Level up ──────────────────────────────────────────────────────────────

--- a/src/scenes/InventoryScene.js
+++ b/src/scenes/InventoryScene.js
@@ -89,8 +89,9 @@ class InventoryScene extends Phaser.Scene {
 
         // Equipment slots
         const eqY = cy - panelH / 2 + 110;
-        this._makeEquipSlot(cx - 80, eqY, 'weapon', 'Våpen');
-        this._makeEquipSlot(cx + 80, eqY, 'armor',  'Rustning');
+        this._makeEquipSlot(cx - 120, eqY, 'weapon', 'Våpen');
+        this._makeEquipSlot(cx,       eqY, 'armor',  'Rustning');
+        this._makeQuickUseSlot(cx + 120, eqY);
 
         // Skills
         this._drawSkills(cx, cy - panelH / 2 + 185);
@@ -175,26 +176,95 @@ class InventoryScene extends Phaser.Scene {
         }
     }
 
+    // ── Quick-Use slot ─────────────────────────────────────────────────────────
+
+    _makeQuickUseSlot(x, y) {
+        const size = 64;
+        const qu = this.inv.quickUse;
+        const itemDef = qu ? ITEM_DEFS[qu.id] : null;
+
+        const bg = this._d(this.add.rectangle(x, y, size, size, 0x0a0918).setStrokeStyle(
+            itemDef ? 2 : 1,
+            itemDef ? 0x33aa88 : 0x223344
+        ));
+
+        this._d(this.add.text(x, y + size / 2 + 10, 'Hurtig (Q)', {
+            fontSize: '10px', color: '#33aa88', fontFamily: 'monospace'
+        }).setOrigin(0.5));
+
+        if (itemDef) {
+            this._drawItemIcon(x, y, itemDef, size - 12);
+            const label = qu.count > 1 ? `${itemDef.name} ×${qu.count}` : itemDef.name;
+            this._d(this.add.text(x, y - size / 2 - 10, label, {
+                fontSize: '10px', color: '#ccddff', fontFamily: 'monospace'
+            }).setOrigin(0.5));
+
+            bg.setInteractive({ useHandCursor: true });
+            bg.on('pointerdown', (pointer) => {
+                if (pointer.rightButtonDown()) {
+                    const dropped = this.inv.dropQuickUse();
+                    if (dropped) this.gs._spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
+                    this._refresh();
+                    return;
+                }
+                bg._lpTimer = this.time.delayedCall(500, () => {
+                    bg._lpTimer = null;
+                    const dropped = this.inv.dropQuickUse();
+                    if (dropped) this.gs._spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
+                    this._refresh();
+                });
+            });
+            bg.on('pointerup', () => {
+                if (bg._lpTimer) {
+                    bg._lpTimer.remove();
+                    bg._lpTimer = null;
+                    // Tap: unequip back to backpack
+                    this.inv.unequipQuickUse();
+                    this._refresh();
+                }
+            });
+            bg.on('pointerover', () => { bg.setFillStyle(0x1a1830); this._showTooltip(x, y - size/2 - 20, itemDef); });
+            bg.on('pointerout',  () => {
+                bg.setFillStyle(0x0a0918); this._hideTooltip();
+                if (bg._lpTimer) { bg._lpTimer.remove(); bg._lpTimer = null; }
+            });
+        } else {
+            this._d(this.add.text(x, y, 'Tom', {
+                fontSize: '11px', color: '#223344', fontFamily: 'monospace'
+            }).setOrigin(0.5));
+        }
+    }
+
     // ── Backpack slot ─────────────────────────────────────────────────────────
 
     _makeBackpackSlot(x, y, size, index) {
-        const item = this.inv.backpack[index];
-        const col  = item
-            ? (item.type === 'weapon' ? 0xff8800 : item.type === 'armor' ? 0x4488ff : 0xff2244)
+        const entry   = this.inv.backpack[index];
+        const itemDef = this.inv._getItemDef(entry);
+        const count   = this.inv._getCount(entry);
+        const col     = itemDef
+            ? (itemDef.type === 'weapon' ? 0xff8800 : itemDef.type === 'armor' ? 0x4488ff : 0xff2244)
             : 0x112233;
 
         const bg = this._d(this.add.rectangle(x, y, size, size, 0x0a0918).setStrokeStyle(1, col));
 
-        if (item) {
-            this._drawItemIcon(x, y, item, size - 10);
-            this._d(this.add.text(x, y + size / 2 - 2, this._shortName(item.name), {
+        if (itemDef) {
+            this._drawItemIcon(x, y, itemDef, size - 10);
+            this._d(this.add.text(x, y + size / 2 - 2, this._shortName(itemDef.name), {
                 fontSize: '8px', color: '#aabbcc', fontFamily: 'monospace'
             }).setOrigin(0.5, 1));
+
+            // Stack count badge
+            if (count > 1) {
+                this._d(this.add.text(x + size / 2 - 4, y - size / 2 + 2, `${count}`, {
+                    fontSize: '10px', color: '#ffee88', fontFamily: 'monospace', fontStyle: 'bold'
+                }).setOrigin(1, 0));
+            }
 
             bg.setInteractive({ useHandCursor: true });
             bg.on('pointerover', () => {
                 bg.setFillStyle(0x1a2030);
-                this._showTooltip(x, y - size / 2 - 4, item);
+                const tip = count > 1 ? { ...itemDef, name: `${itemDef.name} ×${count}` } : itemDef;
+                this._showTooltip(x, y - size / 2 - 4, tip);
             });
             bg.on('pointerout', () => {
                 bg.setFillStyle(0x0a0918);
@@ -208,7 +278,6 @@ class InventoryScene extends Phaser.Scene {
                     this._refresh();
                     return;
                 }
-                // Long-press (touch) = drop, short tap = use/equip
                 bg._lpTimer = this.time.delayedCall(500, () => {
                     bg._lpTimer = null;
                     const dropped = this.inv.dropSlot(index);

--- a/src/systems/Inventory.js
+++ b/src/systems/Inventory.js
@@ -1,10 +1,12 @@
 // ─── Labyrint Hero – Inventory System ────────────────────────────────────────
-// Manages two equipment slots (weapon, armor) + 10-slot backpack.
+// Manages equipment slots (weapon, armor, quickUse) + 10-slot backpack.
+// Consumables and tools stack up to 10 in a single backpack slot.
 
 class Inventory {
     constructor() {
         this.equipped = { weapon: null, armor: null };
-        this.backpack  = new Array(10).fill(null); // null = empty slot
+        this.quickUse = null;       // { id, count } – assigned consumable for Q/USE button
+        this.backpack = new Array(10).fill(null); // null or { id, count } for stackable, or itemDef for equipment
     }
 
     // ── Queries ───────────────────────────────────────────────────────────────
@@ -17,10 +19,47 @@ class Inventory {
         return this.backpack.filter(Boolean).length;
     }
 
+    // ── Stack helpers ─────────────────────────────────────────────────────────
+
+    _isStackable(itemDef) {
+        return itemDef.type === 'consumable' || itemDef.type === 'tool';
+    }
+
+    _getItemDef(entry) {
+        if (!entry) return null;
+        // Stacked entry: { id, count }
+        if (entry.id && entry.count !== undefined) return ITEM_DEFS[entry.id];
+        // Plain item def (equipment)
+        return entry;
+    }
+
+    _getCount(entry) {
+        if (!entry) return 0;
+        if (entry.count !== undefined) return entry.count;
+        return 1;
+    }
+
     // ── Pick up / add ─────────────────────────────────────────────────────────
 
     /** Returns true if item was successfully added to backpack */
     addItem(itemDef) {
+        // Stackable: try to add to existing stack first
+        if (this._isStackable(itemDef)) {
+            for (let i = 0; i < this.backpack.length; i++) {
+                const entry = this.backpack[i];
+                if (entry && entry.id === itemDef.id && entry.count < 10) {
+                    entry.count++;
+                    return true;
+                }
+            }
+            // No existing stack or all full – create new stack
+            const slot = this.backpack.indexOf(null);
+            if (slot === -1) return false;
+            this.backpack[slot] = { id: itemDef.id, count: 1 };
+            return true;
+        }
+
+        // Non-stackable (equipment)
         const slot = this.backpack.indexOf(null);
         if (slot === -1) return false;
         this.backpack[slot] = itemDef;
@@ -32,21 +71,62 @@ class Inventory {
     /**
      * Activate a backpack slot.
      * - Equipment: equip it (swapping current if any, putting old back in slot)
-     * - Consumable: use it (remove if consumed)
+     * - Consumable/tool: assign to quick-use slot (left-click) or use directly
      * @param {number} slotIndex  backpack index 0–9
      * @param {Hero}   hero
      * @param {GameScene} scene   needed for some consumables (e.g. bomb)
      */
     useSlot(slotIndex, hero, scene = null) {
-        const item = this.backpack[slotIndex];
-        if (!item) return;
+        const entry = this.backpack[slotIndex];
+        if (!entry) return;
+        const itemDef = this._getItemDef(entry);
+        if (!itemDef) return;
 
-        if (item.type === 'weapon' || item.type === 'armor') {
+        if (itemDef.type === 'weapon' || itemDef.type === 'armor') {
             this._equip(slotIndex, hero);
-        } else if (item.type === 'consumable') {
-            const consumed = item.use(hero, scene);
-            if (consumed) this.backpack[slotIndex] = null;
+        } else if (itemDef.type === 'consumable' || itemDef.type === 'tool') {
+            // Assign to quick-use slot
+            this._assignQuickUse(slotIndex);
         }
+    }
+
+    /** Assign a consumable/tool backpack slot to quick-use */
+    _assignQuickUse(slotIndex) {
+        const entry = this.backpack[slotIndex];
+        if (!entry) return;
+        const itemDef = this._getItemDef(entry);
+        if (!itemDef || (itemDef.type !== 'consumable' && itemDef.type !== 'tool')) return;
+
+        // If quick-use already has something, put it back in backpack
+        if (this.quickUse) {
+            // Try to stack back
+            const oldDef = ITEM_DEFS[this.quickUse.id];
+            if (oldDef) {
+                for (let i = 0; i < this.quickUse.count; i++) {
+                    this.addItem(oldDef);
+                }
+            }
+        }
+
+        // Move from backpack to quick-use
+        this.quickUse = { id: entry.id, count: entry.count || 1 };
+        this.backpack[slotIndex] = null;
+    }
+
+    /** Use the item in quick-use slot. Returns the itemDef if used, null otherwise. */
+    useQuickItem(hero, scene) {
+        if (!this.quickUse || this.quickUse.count <= 0) return null;
+        const itemDef = ITEM_DEFS[this.quickUse.id];
+        if (!itemDef) return null;
+
+        if (itemDef.type === 'tool') return null; // Tools are auto-consumed elsewhere
+
+        const consumed = itemDef.use(hero, scene);
+        if (consumed) {
+            this.quickUse.count--;
+            if (this.quickUse.count <= 0) this.quickUse = null;
+        }
+        return consumed ? itemDef : null;
     }
 
     /** Unequip a slot ('weapon' or 'armor') back into backpack, if space */
@@ -60,15 +140,43 @@ class Inventory {
         return true;
     }
 
-    /** Remove item from backpack slot and return it (null if empty). */
-    dropSlot(index) {
-        const item = this.backpack[index];
-        if (!item) return null;
-        this.backpack[index] = null;
-        return item;
+    /** Unequip quick-use back into backpack */
+    unequipQuickUse() {
+        if (!this.quickUse) return false;
+        const itemDef = ITEM_DEFS[this.quickUse.id];
+        if (!itemDef) { this.quickUse = null; return false; }
+        for (let i = 0; i < this.quickUse.count; i++) {
+            if (!this.addItem(itemDef)) return false; // backpack full
+        }
+        this.quickUse = null;
+        return true;
     }
 
-    /** Unequip and drop equipped item (returns item or null if nothing equipped / backpack full). */
+    /** Remove item from backpack slot and return itemDef (null if empty). Decrements stack. */
+    dropSlot(index) {
+        const entry = this.backpack[index];
+        if (!entry) return null;
+        const itemDef = this._getItemDef(entry);
+
+        if (entry.count !== undefined) {
+            entry.count--;
+            if (entry.count <= 0) this.backpack[index] = null;
+        } else {
+            this.backpack[index] = null;
+        }
+        return itemDef;
+    }
+
+    /** Drop from quick-use slot (one item). Returns itemDef or null. */
+    dropQuickUse() {
+        if (!this.quickUse) return null;
+        const itemDef = ITEM_DEFS[this.quickUse.id];
+        this.quickUse.count--;
+        if (this.quickUse.count <= 0) this.quickUse = null;
+        return itemDef;
+    }
+
+    /** Unequip and drop equipped item (returns item or null). */
     dropEquipped(slot, hero) {
         const item = this.equipped[slot];
         if (!item) return null;
@@ -80,13 +188,11 @@ class Inventory {
     // ── Private ───────────────────────────────────────────────────────────────
 
     _equip(slotIndex, item_or_index, hero) {
-        // Allow calling as _equip(slotIndex, hero) with item already in backpack[slotIndex]
         let item, h;
         if (item_or_index instanceof Hero) {
-            item = this.backpack[slotIndex];
+            item = this._getItemDef(this.backpack[slotIndex]);
             h    = item_or_index;
         } else {
-            // legacy: shouldn't happen
             return;
         }
         if (!item) return;
@@ -95,7 +201,6 @@ class Inventory {
         const current   = this.equipped[equipSlot];
 
         if (current) {
-            // Swap: put old item into same backpack slot
             this._unapply(current, h);
             this.backpack[slotIndex] = current;
         } else {
@@ -132,7 +237,12 @@ class Inventory {
                 weapon: this.equipped.weapon?.id || null,
                 armor:  this.equipped.armor?.id  || null
             },
-            backpack: this.backpack.map(i => i?.id || null)
+            quickUse: this.quickUse ? { id: this.quickUse.id, count: this.quickUse.count } : null,
+            backpack: this.backpack.map(entry => {
+                if (!entry) return null;
+                if (entry.count !== undefined) return { id: entry.id, count: entry.count };
+                return entry.id || null;
+            })
         };
     }
 
@@ -150,9 +260,31 @@ class Inventory {
             }
         });
 
-        data.backpack.forEach((id, i) => {
-            inv.backpack[i] = restoreItem(id);
-        });
+        // Restore quick-use slot
+        if (data.quickUse && data.quickUse.id && ITEM_DEFS[data.quickUse.id]) {
+            inv.quickUse = { id: data.quickUse.id, count: data.quickUse.count || 1 };
+        }
+
+        // Restore backpack (supports both old format [id, ...] and new [{id, count}, ...])
+        if (data.backpack) {
+            data.backpack.forEach((entry, i) => {
+                if (!entry) { inv.backpack[i] = null; return; }
+                if (typeof entry === 'string') {
+                    // Old format: plain item ID
+                    const def = restoreItem(entry);
+                    if (def && (def.type === 'consumable' || def.type === 'tool')) {
+                        inv.backpack[i] = { id: entry, count: 1 };
+                    } else {
+                        inv.backpack[i] = def;
+                    }
+                } else if (entry.id) {
+                    // New format: { id, count }
+                    if (ITEM_DEFS[entry.id]) {
+                        inv.backpack[i] = { id: entry.id, count: entry.count || 1 };
+                    }
+                }
+            });
+        }
 
         return inv;
     }


### PR DESCRIPTION
## Summary
- Consumables and tools now **stack up to 10** per backpack slot
- New **quick-use equipment slot** in inventory — click a consumable to assign it, press Q/USE to activate in gameplay
- Bombs, flash grenades, potions etc. are now practical to use in combat
- Backward-compatible save/load for old inventory format

## Test plan
- [ ] Pick up multiple health potions — verify they stack in one slot with count badge
- [ ] Click a consumable in backpack — verify it moves to quick-use slot
- [ ] Press Q during gameplay — verify quick-use item activates
- [ ] Pick up a bomb, assign to quick-use, press Q near monsters — verify damage
- [ ] Save and reload — verify stacks and quick-use slot persist
- [ ] Load an old save — verify backward compatibility

https://claude.ai/code/session_011Tt6skU8aVN8qCpq4mKaJt