### PR TITLE
Improve pet system: re-spawn eggs, more HP, healing, pet inventory #41

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ---
 
+## v0.20 – 2026-04-01
+
+### Nye funksjoner
+- **Forbedret kjæledyr-system (#41):**
+  - **Pet re-spawn:** Når kjæledyret dør i et level, kan nye kjæledyr-egg spawne i neste level (35% sjanse) slik at helten kan få en ny følgesvenn
+  - **Økt kjæledyr-HP:** Alle kjæledyr har nå dobbelt så mye base-HP (Rev: 8, Katt: 6, Drage: 10, Ugle: 6) for bedre overlevelse mot monstre
+  - **Kjæledyr-healing:** Dyrevokter T2 «Dyrisk livskraft» lar nå livspotion også heale kjæledyret. Vanlig livspotte healer 2 HP, stor livspotte full-healer kjæledyret
+  - **Kjæledyr-ryggsekk:** Kjæledyret har nå 4 ekstra ryggsekk-plasser for å bære gjenstander for helten. Gjenstander overflyter automatisk til kjæledyrets ryggsekk når heltens er full. Visning i inventory-overlay med mulighet for å flytte gjenstander mellom helt og kjæledyr
+
+---
+
 ## v0.19 – 2026-03-31
 
 ### Nye funksjoner

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,6 +1,6 @@
 # Labyrint Hero – Game Design Document
-**Versjon:** 0.19
-**Sist oppdatert:** 2026-03-31
+**Versjon:** 0.20
+**Sist oppdatert:** 2026-04-01
 
 ---
 
@@ -120,15 +120,17 @@ Helten kan finne et mystisk egg i labyrinten. Egget klekkes til et tilfeldig kj�
 
 | Type | Navn | Farge | Angrep | HP |
 |------|------|-------|--------|----|
-| fox | Rev | Oransje | 1 | 4 |
-| cat | Katt | Gyllen | 1 | 3 |
-| dragon | Drage | Rød | 2 | 5 |
-| owl | Ugle | Blå | 1 | 3 |
+| fox | Rev | Oransje | 1 | 8 |
+| cat | Katt | Gyllen | 1 | 6 |
+| dragon | Drage | Rød | 2 | 10 |
+| owl | Ugle | Blå | 1 | 6 |
 
-- **Oppdagelse:** Egg spawner på gulvet (80% sjanse i verden 1, 35% deretter). Kun om helten ikke allerede har et kjæledyr.
+- **Oppdagelse:** Egg spawner på gulvet (80% sjanse i verden 1, 35% deretter). Spawner også når kjæledyret har dødd i forrige level.
 - **AI:** Følger helten (beveger seg ett steg mot helten per monster-tick). Angriper monster som er innen 1 rute.
 - **Kamp:** Kjæledyret gjør automatisk skade mot nærliggende monstre. Monstre har 25% sjanse for å angripe kjæledyret i stedet for helten.
-- **Død:** Kjæledyret kan dø. Det gjenopplives med full HP ved neste verdensovergang.
+- **Død:** Kjæledyret kan dø. Nye egg kan spawne i neste level (35% sjanse).
+- **Healing:** Med Dyrevokter T2-evnen «Dyrisk livskraft» healer livspotion også kjæledyret.
+- **Kjæledyr-ryggsekk:** Kjæledyret har 4 ryggsekk-plasser. Gjenstander overflyter automatisk til kjæledyrets ryggsekk ved full helte-ryggsekk. Gjenstander kan flyttes mellom helt og kjæledyr i inventory.
 - **Persistens:** Lagres med hero-stats mellom verdener og sessions.
 
 ### Kamp – skalering
@@ -229,8 +231,9 @@ Våpen og rustning har sjeldenhetsgrader som påvirker stats:
 ### Inventory
 - 2 utstyrsplasser (Våpen + Rustning)
 - 10-spors ryggsekk
+- Kjæledyr-ryggsekk (4 plasser, kun når kjæledyr er i live)
 - **E** åpner/lukker; bruk holder inventory åpent (refresh-in-place)
-- **Venstreklikk:** bruk/utstyr — **Høyreklikk:** slipp gjenstand på gulvet
+- **Venstreklikk:** bruk/utstyr — **Høyreklikk/Hold:** flytt til kjæledyr (eller slipp på gulvet)
 
 ### Våpen (tier 1–4)
 Melee: Dolk, Tresverd, Spyd, Jernsverd, Stridsøks, Krigshammer, Trollstav
@@ -375,6 +378,7 @@ Fem spesialiseringsveier med 3 tiers. T1 alltid tilgjengelig; T2 krever at T1 er
 | **Vokter** | Forsvar | Tykk hud (+1 DEF) | Festning (+1 DEF +1 HP) | Jernhelse (+2 HP) |
 | **Jeger** | Syn/Krit | Skarpsyn (+2 syn) | Vitalt anslag (+25% krit) | Presisjon (+3 ATK) |
 | **Skurk** | Nytte | Kunnskap (+30% XP) | Unnvikelse (+20% dodge) | Blomstersaft (hel 2 HP) |
+| **Dyrevokter** | Kjæledyr | Villskap (+2 pet ATK) | Dyrisk livskraft (+3 pet HP, +1 pet DEF, potion healer pet) | Sjelsbånd (+3 pet ATK, +3 pet HP) |
 
 Spilleren kan spre poeng på tvers av veier (generalist) eller gå dypt i én (spesialist).
 

--- a/src/data/items.js
+++ b/src/data/items.js
@@ -138,12 +138,20 @@ const ITEM_DEFS = {
     health_pot: {
         id: 'health_pot', name: 'Livspotte', type: 'consumable',
         color: 0xff2244, desc: 'Gjenoppretter 2 hjerter', tier: 1,
-        use(hero) { hero.hearts = Math.min(hero.hearts + 2, hero.maxHearts); return true; }
+        use(hero, scene) {
+            hero.hearts = Math.min(hero.hearts + 2, hero.maxHearts);
+            if (hero.petHealShare && scene && scene.pet && scene.pet.alive) scene.pet.heal(2);
+            return true;
+        }
     },
     big_health_pot: {
         id: 'big_health_pot', name: 'Stor livspotte', type: 'consumable',
         color: 0xff0000, desc: 'Gjenoppretter alle hjerter', tier: 2,
-        use(hero) { hero.hearts = hero.maxHearts; return true; }
+        use(hero, scene) {
+            hero.hearts = hero.maxHearts;
+            if (hero.petHealShare && scene && scene.pet && scene.pet.alive) scene.pet.heal(scene.pet.effectiveMaxHp);
+            return true;
+        }
     },
     strength_brew: {
         id: 'strength_brew', name: 'Styrkebrygg', type: 'consumable',

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -164,10 +164,10 @@ const SKILL_TREE_PATHS = [
             {
                 id:       'beast_vitality',
                 name:     'Dyrisk livskraft',
-                desc:     '+3 kjæledyr-HP\n+1 kjæledyr-forsvar',
+                desc:     '+3 kjæledyr-HP\n+1 kjæledyr-forsvar\nPotion healer kjæledyr',
                 category: 'PET',
                 maxStack: 2,
-                apply(hero) { hero.petBonusHp = (hero.petBonusHp || 0) + 3; hero.petBonusDef = (hero.petBonusDef || 0) + 1; }
+                apply(hero) { hero.petBonusHp = (hero.petBonusHp || 0) + 3; hero.petBonusDef = (hero.petBonusDef || 0) + 1; hero.petHealShare = true; }
             },
             {
                 id:       'beast_bond',

--- a/src/entities/Hero.js
+++ b/src/entities/Hero.js
@@ -30,6 +30,7 @@ class Hero {
         this.petBonusAtk = 0;
         this.petBonusHp  = 0;
         this.petBonusDef = 0;
+        this.petHealShare = false; // life potions also heal pet
 
         // Progression
         this.level    = 1;
@@ -239,9 +240,10 @@ class Hero {
             xpMultiplier:  this.xpMultiplier,
             counterChance: this.counterChance,
             thornsDamage:  this.thornsDamage,
-            petBonusAtk:  this.petBonusAtk,
-            petBonusHp:   this.petBonusHp,
-            petBonusDef:  this.petBonusDef,
+            petBonusAtk:   this.petBonusAtk,
+            petBonusHp:    this.petBonusHp,
+            petBonusDef:   this.petBonusDef,
+            petHealShare:  this.petHealShare,
             gold:         this.gold,
             poisonTurns:  this.poisonTurns,
             burnTurns:    this.burnTurns,
@@ -272,6 +274,7 @@ class Hero {
         this.petBonusAtk  = stats.petBonusAtk  || 0;
         this.petBonusHp   = stats.petBonusHp   || 0;
         this.petBonusDef  = stats.petBonusDef  || 0;
+        this.petHealShare = stats.petHealShare  || false;
         this.gold         = stats.gold         || 0;
         this.poisonTurns  = stats.poisonTurns  || 0;
         this.burnTurns    = stats.burnTurns    || 0;

--- a/src/entities/Pet.js
+++ b/src/entities/Pet.js
@@ -2,10 +2,10 @@
 // A companion that follows the hero, assists in combat, and persists across worlds.
 
 const PET_TYPES = {
-    fox:    { name: 'Rev',      color: 0xff8833, attack: 1, maxHp: 4, desc: 'Rask og lojal' },
-    cat:    { name: 'Katt',     color: 0xccaa66, attack: 1, maxHp: 3, desc: 'Stille og presis' },
-    dragon: { name: 'Drage',    color: 0xff4466, attack: 2, maxHp: 5, desc: 'Liten men farlig' },
-    owl:    { name: 'Ugle',     color: 0x88aacc, attack: 1, maxHp: 3, desc: 'Klok og skarpsynt' },
+    fox:    { name: 'Rev',      color: 0xff8833, attack: 1, maxHp: 8,  desc: 'Rask og lojal' },
+    cat:    { name: 'Katt',     color: 0xccaa66, attack: 1, maxHp: 6,  desc: 'Stille og presis' },
+    dragon: { name: 'Drage',    color: 0xff4466, attack: 2, maxHp: 10, desc: 'Liten men farlig' },
+    owl:    { name: 'Ugle',     color: 0x88aacc, attack: 1, maxHp: 6,  desc: 'Klok og skarpsynt' },
 };
 
 class Pet {
@@ -22,6 +22,9 @@ class Pet {
         this.maxHp    = def.maxHp;
         this.hp       = def.maxHp;
         this.attack   = def.attack;
+
+        // Pet backpack (4 slots for carrying items)
+        this.backpack = new Array(4).fill(null);
 
         this.graphics = scene.add.graphics();
         this.graphics.setDepth(4);
@@ -343,6 +346,12 @@ class Pet {
         });
     }
 
+    /** Heal pet by amount, capped at effectiveMaxHp */
+    heal(amount) {
+        if (!this.alive) return;
+        this.hp = Math.min(this.hp + amount, this.effectiveMaxHp);
+    }
+
     /** Revive pet at full HP (e.g. on new world) */
     revive(gridX, gridY) {
         this.alive = true;
@@ -356,15 +365,77 @@ class Pet {
         this._draw();
     }
 
+    // ── Pet Inventory ─────────────────────────────────────────────────────────
+
+    get backpackFull() { return !this.backpack.includes(null); }
+    get backpackCount() { return this.backpack.filter(Boolean).length; }
+
+    /** Add item to pet backpack. Returns true on success. */
+    addItem(itemDef) {
+        const isStackable = itemDef.type === 'consumable' || itemDef.type === 'tool';
+        if (isStackable) {
+            for (let i = 0; i < this.backpack.length; i++) {
+                const entry = this.backpack[i];
+                if (entry && entry.id === itemDef.id && entry.count < 10) {
+                    entry.count++;
+                    return true;
+                }
+            }
+            const slot = this.backpack.indexOf(null);
+            if (slot === -1) return false;
+            this.backpack[slot] = { id: itemDef.id, count: 1 };
+            return true;
+        }
+        const slot = this.backpack.indexOf(null);
+        if (slot === -1) return false;
+        this.backpack[slot] = itemDef;
+        return true;
+    }
+
+    /** Remove item from pet backpack slot. Returns itemDef or null. */
+    dropSlot(index) {
+        const entry = this.backpack[index];
+        if (!entry) return null;
+        let itemDef;
+        if (entry.id && entry.count !== undefined) {
+            itemDef = ITEM_DEFS[entry.id];
+            entry.count--;
+            if (entry.count <= 0) this.backpack[index] = null;
+        } else {
+            itemDef = entry;
+            this.backpack[index] = null;
+        }
+        return itemDef;
+    }
+
+    /** Get item def for a backpack entry */
+    getItemDef(entry) {
+        if (!entry) return null;
+        if (entry.id && entry.count !== undefined) return ITEM_DEFS[entry.id];
+        return entry;
+    }
+
+    getCount(entry) {
+        if (!entry) return 0;
+        if (entry.count !== undefined) return entry.count;
+        return 1;
+    }
+
     // ── Serialisation ─────────────────────────────────────────────────────────
 
     serialize() {
         return {
-            typeId: this.typeId,
-            hp:     this.hp,
-            maxHp:  this.maxHp,
-            attack: this.attack,
-            alive:  this.alive,
+            typeId:   this.typeId,
+            hp:       this.hp,
+            maxHp:    this.maxHp,
+            attack:   this.attack,
+            alive:    this.alive,
+            backpack: this.backpack.map(entry => {
+                if (!entry) return null;
+                if (entry.count !== undefined) return { id: entry.id, count: entry.count };
+                if (entry.rarity && entry.rarity !== 'common') return { id: entry.id, rarity: entry.rarity };
+                return entry.id || null;
+            }),
         };
     }
 
@@ -377,6 +448,24 @@ class Pet {
         pet.alive  = data.alive !== false;
         if (!pet.alive) {
             pet.graphics.setVisible(false);
+        }
+        // Restore pet backpack
+        if (data.backpack) {
+            data.backpack.forEach((entry, i) => {
+                if (i >= 4 || !entry) return;
+                if (typeof entry === 'string') {
+                    const def = ITEM_DEFS[entry];
+                    if (!def) return;
+                    pet.backpack[i] = (def.type === 'consumable' || def.type === 'tool')
+                        ? { id: entry, count: 1 } : makeRarityItem(def, 'common');
+                } else if (entry.id && ITEM_DEFS[entry.id]) {
+                    if (entry.count !== undefined) {
+                        pet.backpack[i] = { id: entry.id, count: entry.count || 1 };
+                    } else {
+                        pet.backpack[i] = makeRarityItem(ITEM_DEFS[entry.id], entry.rarity || 'common');
+                    }
+                }
+            });
         }
         return pet;
     }

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -84,10 +84,13 @@ class GameScene extends Phaser.Scene {
         // ── Pet companion ────────────────────────────────────────────────────
         this.pet = null;
         if (this.heroStats && this.heroStats.pet) {
-            this.pet = Pet.deserialize(this.heroStats.pet, this, this.hero.gridX, this.hero.gridY);
-            if (this.pet && this.pet.alive) {
-                this.pet.revive(this.hero.gridX, this.hero.gridY);
+            if (this.heroStats.pet.alive !== false) {
+                this.pet = Pet.deserialize(this.heroStats.pet, this, this.hero.gridX, this.hero.gridY);
+                if (this.pet && this.pet.alive) {
+                    this.pet.revive(this.hero.gridX, this.hero.gridY);
+                }
             }
+            // Dead pet: leave this.pet null so a new egg can spawn
         }
         this.petTickTimer = 0;
 

--- a/src/scenes/InventoryScene.js
+++ b/src/scenes/InventoryScene.js
@@ -12,6 +12,7 @@ class InventoryScene extends Phaser.Scene {
         this.hero = gs.hero;
         this.inv  = gs.hero.inventory;
         this.gs   = gs;
+        this.pet  = gs.pet;
 
         this._dyn = [];  // dynamic objects – destroyed on _refresh()
 
@@ -19,33 +20,38 @@ class InventoryScene extends Phaser.Scene {
         const cx = W / 2, cy = H / 2;
         this.add.rectangle(cx, cy, W, H, 0x000000, 0.78);
 
-        const panelW = 520, panelH = 420;
-        this.add.rectangle(cx, cy, panelW, panelH, 0x0d0b1e).setStrokeStyle(2, 0x334466);
+        const panelW = 520;
+        const hasPet = this.pet && this.pet.alive;
+        const panelH = hasPet ? 500 : 420;
+        const panelY = cy;
+        this.add.rectangle(cx, panelY, panelW, panelH, 0x0d0b1e).setStrokeStyle(2, 0x334466);
 
-        this.add.text(cx, cy - panelH / 2 + 18, 'INVENTAR', {
+        this.add.text(cx, panelY - panelH / 2 + 18, 'INVENTAR', {
             fontSize: '20px', color: '#ccddff', fontFamily: 'monospace', fontStyle: 'bold'
         }).setOrigin(0.5);
 
-        this.add.rectangle(cx, cy - panelH / 2 + 54, panelW - 40, 1, 0x223344);
+        this.add.rectangle(cx, panelY - panelH / 2 + 54, panelW - 40, 1, 0x223344);
 
         // Stats line – dynamic so it refreshes
-        this._statsText = this.add.text(cx, cy - panelH / 2 + 40, '', {
+        this._statsText = this.add.text(cx, panelY - panelH / 2 + 40, '', {
             fontSize: '11px', color: '#667788', fontFamily: 'monospace'
         }).setOrigin(0.5);
 
         // Section labels (static)
-        this.add.text(cx - panelW / 2 + 20, cy - panelH / 2 + 62, 'UTSTYR', {
+        this.add.text(cx - panelW / 2 + 20, panelY - panelH / 2 + 62, 'UTSTYR', {
             fontSize: '11px', color: '#445566', fontFamily: 'monospace'
         });
-        this.add.text(cx, cy - panelH / 2 + 168, 'EVNER', {
+        this.add.text(cx, panelY - panelH / 2 + 168, 'EVNER', {
             fontSize: '11px', color: '#445566', fontFamily: 'monospace'
         }).setOrigin(0.5);
-        this.add.text(cx - panelW / 2 + 20, cy - panelH / 2 + 220, 'RYGGSEKK', {
+        this.add.text(cx - panelW / 2 + 20, panelY - panelH / 2 + 220, 'RYGGSEKK', {
             fontSize: '11px', color: '#445566', fontFamily: 'monospace'
         });
 
-        this.add.text(cx, cy + panelH / 2 - 14,
-            '[Trykk] Bruk/utstyr  ·  [Hold] Slipp  ·  [E/ESC] Lukk', {
+        const helpText = hasPet
+            ? '[Trykk] Bruk/utstyr  ·  [Hold] → Kjæledyr/Slipp  ·  [E/ESC] Lukk'
+            : '[Trykk] Bruk/utstyr  ·  [Hold] Slipp  ·  [E/ESC] Lukk';
+        this.add.text(cx, panelY + panelH / 2 - 14, helpText, {
             fontSize: '11px', color: '#334455', fontFamily: 'monospace'
         }).setOrigin(0.5);
 
@@ -79,7 +85,10 @@ class InventoryScene extends Phaser.Scene {
 
         const { width: W, height: H } = this.cameras.main;
         const cx = W / 2, cy = H / 2;
-        const panelW = 520, panelH = 420;
+        const hasPet = this.pet && this.pet.alive;
+        const panelW = 520;
+        const panelH = hasPet ? 500 : 420;
+        const panelY = cy;
 
         // Update stats line
         const h = this.hero;
@@ -88,22 +97,22 @@ class InventoryScene extends Phaser.Scene {
         );
 
         // Equipment slots
-        const eqY = cy - panelH / 2 + 110;
+        const eqY = panelY - panelH / 2 + 110;
         this._makeEquipSlot(cx - 120, eqY, 'weapon', 'Våpen');
         this._makeEquipSlot(cx,       eqY, 'armor',  'Rustning');
         this._makeQuickUseSlot(cx + 120, eqY);
 
         // Skills
-        this._drawSkills(cx, cy - panelH / 2 + 185);
+        this._drawSkills(cx, panelY - panelH / 2 + 185);
 
         // Backpack label with count
-        this._d(this.add.text(cx + 80, cy - panelH / 2 + 220,
+        this._d(this.add.text(cx + 80, panelY - panelH / 2 + 220,
             `(${this.inv.itemCount}/10)`, {
             fontSize: '11px', color: '#334455', fontFamily: 'monospace'
         }));
 
         // Backpack slots
-        const bpY     = cy - panelH / 2 + 245;
+        const bpY     = panelY - panelH / 2 + 245;
         const slotSize = 52, cols = 5, gap = 8;
         const bpTotalW = cols * slotSize + (cols - 1) * gap;
         const bpStartX = cx - bpTotalW / 2;
@@ -113,6 +122,11 @@ class InventoryScene extends Phaser.Scene {
             const sx  = bpStartX + col * (slotSize + gap) + slotSize / 2;
             const sy  = bpY + row * (slotSize + gap) + slotSize / 2;
             this._makeBackpackSlot(sx, sy, slotSize, i);
+        }
+
+        // Pet inventory section
+        if (hasPet) {
+            this._drawPetInventory(cx, panelY - panelH / 2, panelW);
         }
     }
 
@@ -295,15 +309,27 @@ class InventoryScene extends Phaser.Scene {
             bg.on('pointerdown', (pointer) => {
                 this._hideTooltip();
                 if (pointer.rightButtonDown()) {
-                    const dropped = this.inv.dropSlot(index);
-                    if (dropped) this.gs._spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
+                    // Right-click: move to pet if possible, otherwise drop
+                    const item = this.inv._getItemDef(this.inv.backpack[index]);
+                    if (item && this.pet && this.pet.alive && this.pet.addItem(item)) {
+                        this.inv.dropSlot(index);
+                    } else {
+                        const dropped = this.inv.dropSlot(index);
+                        if (dropped) this.gs._spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
+                    }
                     this._refresh();
                     return;
                 }
                 bg._lpTimer = this.time.delayedCall(500, () => {
                     bg._lpTimer = null;
-                    const dropped = this.inv.dropSlot(index);
-                    if (dropped) this.gs._spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
+                    // Long press: move to pet if possible, otherwise drop
+                    const item = this.inv._getItemDef(this.inv.backpack[index]);
+                    if (item && this.pet && this.pet.alive && this.pet.addItem(item)) {
+                        this.inv.dropSlot(index);
+                    } else {
+                        const dropped = this.inv.dropSlot(index);
+                        if (dropped) this.gs._spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
+                    }
                     this._refresh();
                 });
             });
@@ -315,6 +341,116 @@ class InventoryScene extends Phaser.Scene {
                     this._refresh();
                 }
             });
+        }
+    }
+
+    // ── Pet inventory ──────────────────────────────────────────────────────────
+
+    _drawPetInventory(cx, panelTop, panelW) {
+        const pet = this.pet;
+        const baseY = panelTop + 370;
+
+        // Separator
+        this._d(this.add.rectangle(cx, baseY - 8, panelW - 40, 1, 0x223344));
+
+        // Pet label with name and HP
+        const hpText = `${pet.petName}  HP: ${pet.hp}/${pet.effectiveMaxHp}  ATK: ${pet.effectiveAttack}`;
+        this._d(this.add.text(cx - panelW / 2 + 20, baseY, `KJÆLEDYR  ·  ${hpText}`, {
+            fontSize: '11px', color: '#ffaadd', fontFamily: 'monospace'
+        }));
+        this._d(this.add.text(cx + panelW / 2 - 20, baseY,
+            `(${pet.backpackCount}/4)`, {
+            fontSize: '11px', color: '#334455', fontFamily: 'monospace'
+        }).setOrigin(1, 0));
+
+        // Pet backpack slots (4 slots in a row)
+        const slotSize = 52, gap = 8;
+        const totalW = 4 * slotSize + 3 * gap;
+        const startX = cx - totalW / 2;
+        const slotsY = baseY + 20;
+
+        for (let i = 0; i < 4; i++) {
+            const sx = startX + i * (slotSize + gap) + slotSize / 2;
+            const sy = slotsY + slotSize / 2;
+            this._makePetBackpackSlot(sx, sy, slotSize, i);
+        }
+    }
+
+    _makePetBackpackSlot(x, y, size, index) {
+        const pet = this.pet;
+        const entry   = pet.backpack[index];
+        const itemDef = pet.getItemDef(entry);
+        const count   = pet.getCount(entry);
+
+        let col = 0x112233;
+        if (itemDef) {
+            const r = itemDef.rarity ? RARITY_BY_ID[itemDef.rarity] : null;
+            if (r && itemDef.rarity !== 'common') {
+                col = r.color;
+            } else {
+                col = itemDef.type === 'weapon' ? 0xff8800 : itemDef.type === 'armor' ? 0x4488ff : 0xff2244;
+            }
+        }
+
+        // Pink tint to distinguish pet slots
+        const bg = this._d(this.add.rectangle(x, y, size, size, 0x120a18).setStrokeStyle(1, col));
+
+        if (itemDef) {
+            this._drawItemIcon(x, y, itemDef, size - 10);
+            const nameCol = this._rarityTextColor(itemDef);
+            this._d(this.add.text(x, y + size / 2 - 2, this._shortName(itemDef.name), {
+                fontSize: '8px', color: nameCol, fontFamily: 'monospace'
+            }).setOrigin(0.5, 1));
+
+            if (count > 1) {
+                this._d(this.add.text(x + size / 2 - 4, y - size / 2 + 2, `${count}`, {
+                    fontSize: '10px', color: '#ffee88', fontFamily: 'monospace', fontStyle: 'bold'
+                }).setOrigin(1, 0));
+            }
+
+            bg.setInteractive({ useHandCursor: true });
+            bg.on('pointerover', () => {
+                bg.setFillStyle(0x1a1830);
+                const tip = count > 1 ? { ...itemDef, name: `${itemDef.name} ×${count}` } : itemDef;
+                this._showTooltip(x, y - size / 2 - 4, tip);
+            });
+            bg.on('pointerout', () => {
+                bg.setFillStyle(0x120a18);
+                this._hideTooltip();
+            });
+            bg.on('pointerdown', (pointer) => {
+                this._hideTooltip();
+                if (pointer.rightButtonDown()) {
+                    // Drop from pet backpack to ground
+                    const dropped = pet.dropSlot(index);
+                    if (dropped) this.gs.itemSpawner.spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
+                    this._refresh();
+                    return;
+                }
+                bg._lpTimer = this.time.delayedCall(500, () => {
+                    bg._lpTimer = null;
+                    const dropped = pet.dropSlot(index);
+                    if (dropped) this.gs.itemSpawner.spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
+                    this._refresh();
+                });
+            });
+            bg.on('pointerup', () => {
+                if (bg._lpTimer) {
+                    bg._lpTimer.remove();
+                    bg._lpTimer = null;
+                    // Tap: move item from pet to hero backpack
+                    const item = pet.getItemDef(pet.backpack[index]);
+                    if (item && this.inv.addItem(item)) {
+                        pet.dropSlot(index);
+                    }
+                    this._refresh();
+                }
+            });
+        } else {
+            // Empty slot: allow moving from hero to pet by checking if hero inventory is the source
+            bg.setInteractive({ useHandCursor: true });
+            bg.on('pointerover', () => bg.setFillStyle(0x1a1830));
+            bg.on('pointerout',  () => bg.setFillStyle(0x120a18));
         }
     }
 

--- a/src/systems/ItemSpawner.js
+++ b/src/systems/ItemSpawner.js
@@ -25,8 +25,10 @@ class ItemSpawner {
         const toolStart  = chestCount;
         this._placeTools(eligible, Math.min(toolStart, eligible.length));
 
-        // 3. Pet egg (one per world, only if hero has no pet)
-        if (!scene.pet) {
+        // 3. Pet egg (one per world, if hero has no pet or pet is dead)
+        if (!scene.pet || !scene.pet.alive) {
+            // Clear dead pet so a new one can be hatched
+            if (scene.pet && !scene.pet.alive) scene.pet = null;
             const eggChance = scene.worldNum === 1 ? 0.8 : 0.35;
             if (Math.random() < eggChance) {
                 // Find a free floor tile not used by chests or items
@@ -416,13 +418,21 @@ class ItemSpawner {
         for (let i = scene.itemObjects.length - 1; i >= 0; i--) {
             const obj = scene.itemObjects[i];
             if (obj.gridX === hx && obj.gridY === hy) {
-                if (scene.hero.inventory.addItem(obj.item)) {
+                // Try hero backpack first, then pet backpack as overflow
+                let picked = scene.hero.inventory.addItem(obj.item);
+                let toPet = false;
+                if (!picked && scene.pet && scene.pet.alive) {
+                    picked = scene.pet.addItem(obj.item);
+                    toPet = true;
+                }
+                if (picked) {
                     Audio.playPickup();
                     obj.graphic.destroy();
                     scene.itemObjects.splice(i, 1);
                     const rarDef = obj.item.rarity ? RARITY_BY_ID[obj.item.rarity] : null;
                     const pickupColor = (rarDef && obj.item.rarity !== 'common') ? rarDef.textColor : '#ffee88';
-                    scene._floatingText(hx, hy, `+ ${obj.item.name}`, pickupColor);
+                    const suffix = toPet ? ` (${scene.pet.petName})` : '';
+                    scene._floatingText(hx, hy, `+ ${obj.item.name}${suffix}`, pickupColor);
                 } else {
                     scene._showMessage('Ryggsekken er full! (Høyreklikk for å droppe)', '#ff8844');
                 }


### PR DESCRIPTION
- Pet eggs now spawn in next level when pet dies (35% chance)
- Double pet base HP (fox:8, cat:6, dragon:10, owl:6) for better survival
- Dyrevokter T2 (beast_vitality) now enables life potions to heal pets
- Add 4-slot pet backpack with item overflow from hero inventory
- Pet inventory UI section in InventoryScene with transfer support
- Right-click/hold hero backpack items to move to pet (or drop if pet full)
- Update docs to v0.20

https://claude.ai/code/session_01QDoXp2WDgD6MPRPdifQu34