### PR TITLE
Slow boss attack speed, increase HP to compensate #40

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ---
 
+## v0.21 – 2026-04-01
+
+### Balanseendringer
+- **Saktere boss-angrep, mer boss-HP (#40):** Boss angriper nå hvert 570ms (opp fra 380ms), ca. 50% saktere. Fase 2 dobbeltangrep fjernet. Boss-HP økt til 50 + verden×35 (opp fra 35 + verden×25). Gir spilleren mer tid til å bruke potions og reagere i bosskamp
+
+---
+
 ## v0.20 – 2026-04-01
 
 ### Nye funksjoner

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,5 +1,5 @@
 # Labyrint Hero – Game Design Document
-**Versjon:** 0.20
+**Versjon:** 0.21
 **Sist oppdatert:** 2026-04-01
 
 ---
@@ -165,7 +165,7 @@ Heltens grunnstats gjør at verden 1 er farlig uten noe utstyr. Utstyr og evner 
 | Goblin | 10 | 2 | 10 | +50% per verden | +25% per verden |
 | Orc | 18 | 4 | 25 | +50% per verden | +25% per verden |
 | Troll | 30 | 6 | 50 | +50% per verden | +25% per verden |
-| Boss | 35 + V×25 | 3 + V×2 | 150 | – (eget uttrykk) | – (eget uttrykk) |
+| Boss | 50 + V×35 | 3 + V×2 | 150 | – (eget uttrykk) | – (570ms tick) |
 
 Verdensnummer V brukes til å skalere både HP og skade – kamp bør alltid føles risikofylt.
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -56,6 +56,7 @@ const COLORS = {
 // Gameplay tuning
 const VISION_RADIUS   = 5;    // tiles
 const MONSTER_TICK_MS = 380;  // ms between monster AI ticks
+const BOSS_TICK_MS   = 570;  // ms between boss attack ticks (slower than regular)
 const MOVE_DELAY_MS   = 140;  // ms between steps when key held
 const MOVE_ANIM_MS    = 90;   // ms for hero/monster slide tween
 

--- a/src/entities/Monster.js
+++ b/src/entities/Monster.js
@@ -21,7 +21,7 @@ class Monster {
 
         // Bosses scale aggressively – always a significant threat
         if (type === 'boss') {
-            this.maxHp  = 35 + worldMul * 25;
+            this.maxHp  = 50 + worldMul * 35;
             this.hp     = this.maxHp;
             this.attack = 3 + worldMul * 2;
         }

--- a/src/systems/MonsterManager.js
+++ b/src/systems/MonsterManager.js
@@ -119,11 +119,23 @@ class MonsterManager {
         scene.hero.tickTempBuffs(delta);
 
         scene.monsterTick += delta;
-        if (scene.monsterTick < MONSTER_TICK_MS) return;
-        scene.monsterTick = 0;
+        scene.bossTickTimer = (scene.bossTickTimer || 0) + delta;
+
+        // Regular monsters tick
+        const regularReady = scene.monsterTick >= MONSTER_TICK_MS;
+        if (regularReady) scene.monsterTick = 0;
+
+        // Boss uses slower tick for attacks, giving player time to use potions
+        const bossReady = scene.bossTickTimer >= BOSS_TICK_MS;
+        if (bossReady) scene.bossTickTimer = 0;
+
+        if (!regularReady && !bossReady) return;
 
         for (const m of [...scene.monsters]) {
             if (!m.alive) continue;
+            const isBoss = m.type === 'boss';
+            if (isBoss && !bossReady) continue;
+            if (!isBoss && !regularReady) continue;
             this._moveMonster(m);
         }
     }
@@ -136,10 +148,6 @@ class MonsterManager {
         if (dist > AGGRO_RADIUS || scene.fog[m.gridY][m.gridX] === FOG.DARK) return;
         if (dist === 1) {
             scene.combat.monsterAttack(m);
-            // Phase 2 boss attacks a second time each tick!
-            if (m.type === 'boss' && m.phase === 2 && scene.hero.alive) {
-                scene.combat.monsterAttack(m);
-            }
             return;
         }
 


### PR DESCRIPTION
## Summary
- **Boss attacks ~50% slower:** New `BOSS_TICK_MS` (570ms) gives the player more time to use potions and react during boss fights (regular monsters still attack at 380ms)
- **Phase 2 double-attack removed:** Boss no longer attacks twice per tick in phase 2 (still gets +40% ATK boost and 15% stun chance)
- **Boss HP increased:** Formula changed from `35 + world×25` to `50 + world×35` to compensate for slower attacks

## Test plan
- [ ] Fight boss in world 1 — verify attacks feel noticeably slower than regular monsters
- [ ] Verify regular monster attack speed is unchanged (380ms)
- [ ] Verify boss phase 2 still triggers at ≤50% HP with +40% ATK and stun
- [ ] Verify boss HP is higher (world 1: 85 HP instead of 60)
- [ ] Use potions during boss fight — verify there is time to open inventory and use them
- [ ] Test on multiple difficulty levels

Closes #40