### PR TITLE
Fix inventory drop freeze on touch screens

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ---
 
+## v0.22 – 2026-04-03
+
+### Feilrettinger
+- **Fjerne gjenstander fra inventar på touchskjerm (#45):** Lang-trykk for å droppe gjenstander fra utstyr, hurtigplass og ryggsekk frøs skjermen. Årsaken var kall til en ikke-eksisterende metode (`_spawnItemAt`), nå rettet til `itemSpawner.spawnItemAt()`
+
+---
+
 ## v0.21 – 2026-04-01
 
 ### Balanseendringer

--- a/src/scenes/InventoryScene.js
+++ b/src/scenes/InventoryScene.js
@@ -172,7 +172,7 @@ class InventoryScene extends Phaser.Scene {
             bg.on('pointerdown', (pointer) => {
                 if (pointer.rightButtonDown()) {
                     const dropped = this.inv.dropEquipped(slot, this.hero);
-                    if (dropped) this.gs._spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
+                    if (dropped) this.gs.itemSpawner.spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
                     this._refresh();
                     return;
                 }
@@ -180,7 +180,7 @@ class InventoryScene extends Phaser.Scene {
                 bg._lpTimer = this.time.delayedCall(500, () => {
                     bg._lpTimer = null;
                     const dropped = this.inv.dropEquipped(slot, this.hero);
-                    if (dropped) this.gs._spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
+                    if (dropped) this.gs.itemSpawner.spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
                     this._refresh();
                 });
             });
@@ -231,14 +231,14 @@ class InventoryScene extends Phaser.Scene {
             bg.on('pointerdown', (pointer) => {
                 if (pointer.rightButtonDown()) {
                     const dropped = this.inv.dropQuickUse();
-                    if (dropped) this.gs._spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
+                    if (dropped) this.gs.itemSpawner.spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
                     this._refresh();
                     return;
                 }
                 bg._lpTimer = this.time.delayedCall(500, () => {
                     bg._lpTimer = null;
                     const dropped = this.inv.dropQuickUse();
-                    if (dropped) this.gs._spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
+                    if (dropped) this.gs.itemSpawner.spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
                     this._refresh();
                 });
             });
@@ -315,7 +315,7 @@ class InventoryScene extends Phaser.Scene {
                         this.inv.dropSlot(index);
                     } else {
                         const dropped = this.inv.dropSlot(index);
-                        if (dropped) this.gs._spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
+                        if (dropped) this.gs.itemSpawner.spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
                     }
                     this._refresh();
                     return;
@@ -328,7 +328,7 @@ class InventoryScene extends Phaser.Scene {
                         this.inv.dropSlot(index);
                     } else {
                         const dropped = this.inv.dropSlot(index);
-                        if (dropped) this.gs._spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
+                        if (dropped) this.gs.itemSpawner.spawnItemAt(this.hero.gridX, this.hero.gridY, dropped);
                     }
                     this._refresh();
                 });


### PR DESCRIPTION
## Summary
- **Fixes #45** — Long-press to drop items from inventory froze the screen on touch devices
- Root cause: 6 call sites in `InventoryScene.js` called non-existent `this.gs._spawnItemAt()`, causing a TypeError that broke the UI
- Changed all instances to use the correct `this.gs.itemSpawner.spawnItemAt()` method (already used correctly in pet backpack slots)

## Test plan
- [ ] Open game on a touch device or touch-emulating browser
- [ ] Long-press an equipped weapon/armor to drop it — should drop without freezing
- [ ] Long-press a quick-use item to drop it — should drop without freezing
- [ ] Long-press a backpack item to drop it — should drop without freezing
- [ ] Verify pet backpack drop still works as before
- [ ] Verify right-click drop still works on desktop

https://claude.ai/code/session_01QhWtZpbVez3SdfyFPutfaM