### PR TITLE
Restore Chem Lab as separate room, gated by zone boss

### DIFF
--- a/src/maze.js
+++ b/src/maze.js
@@ -154,6 +154,15 @@ class MazeGenerator {
             }
         }
 
+        // Chem Lab: world 4+, 35% chance – gated by zone boss at interaction time
+        if (worldNum >= 4 && deadEnds.length > 0 && Math.random() < 0.35) {
+            const de = deadEnds.shift();
+            const tiles = this._gatherRoomTiles(de.x, de.y, 2 + Math.floor(Math.random() * 2));
+            if (tiles.length >= 1) {
+                this.specialRooms.push({ type: 'chem_lab', tiles });
+            }
+        }
+
         // Ore Chamber: world 5+, 25% chance – concentrated T2-T3 ores
         if (worldNum >= 5 && deadEnds.length > 0 && Math.random() < 0.25) {
             const de = deadEnds.shift();

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -155,7 +155,7 @@ class GameScene extends Phaser.Scene {
 
     update(time, delta) {
         if (!this.hero || !this.hero.alive) return;
-        const blocked = this.scene.isActive('SkillScene') || this.scene.isActive('InventoryScene') || this.scene.isActive('MerchantScene') || this.scene.isActive('ElementBookScene') || this.scene.isActive('SmelteryScene');
+        const blocked = this.scene.isActive('SkillScene') || this.scene.isActive('InventoryScene') || this.scene.isActive('MerchantScene') || this.scene.isActive('ElementBookScene') || this.scene.isActive('SmelteryScene') || this.scene.isActive('ChemLabScene');
 
         if (!blocked) {
             this.inputHandler.handleInput(delta);
@@ -178,8 +178,19 @@ class GameScene extends Phaser.Scene {
                 this.scene.launch('SmelteryScene', { heroRef: this.hero, gameScene: this });
             }
 
+            const touchChem = this.game.registry.get('touch_chemlab');
+            if (touchChem) this.game.registry.set('touch_chemlab', false);
+            if ((Phaser.Input.Keyboard.JustDown(this.chemLabKey) || touchChem) && !this.scene.isActive('ChemLabScene') && this._isInChemLab()) {
+                if (this.hero.chemLabUnlocked) {
+                    this.scene.launch('ChemLabScene', { heroRef: this.hero, gameScene: this });
+                } else {
+                    this._showMessage('Beseir en soneboss for å låse opp laboratoriet!', '#33dd88');
+                }
+            }
+
             // Auto-open prompts for special rooms
             this._checkCampRoom();
+            this._checkChemLab();
 
             this.monsterMgr.tickMonsters(delta);
             this._tickPet(delta);
@@ -205,6 +216,27 @@ class GameScene extends Phaser.Scene {
             this._showMessage('Leirplass! Trykk V for å smelte og smi.', '#ff7722');
         } else if (!this._isInCampRoom()) {
             this._campRoomShown = false;
+        }
+    }
+
+    _isInChemLab() {
+        if (!this._gen || !this._gen.specialRooms) return false;
+        const hx = this.hero.gridX, hy = this.hero.gridY;
+        return this._gen.specialRooms.some(room =>
+            room.type === 'chem_lab' && room.tiles.some(t => t.x === hx && t.y === hy)
+        );
+    }
+
+    _checkChemLab() {
+        if (!this._chemLabShown && this._isInChemLab()) {
+            this._chemLabShown = true;
+            if (this.hero.chemLabUnlocked) {
+                this._showMessage('Kjemisk lab! Trykk C for å lage kjemikalier.', '#33dd88');
+            } else {
+                this._showMessage('Kjemisk lab funnet! Beseir en soneboss for å aktivere.', '#556644');
+            }
+        } else if (!this._isInChemLab()) {
+            this._chemLabShown = false;
         }
     }
 

--- a/src/scenes/SmelteryScene.js
+++ b/src/scenes/SmelteryScene.js
@@ -61,11 +61,7 @@ class SmelteryScene extends Phaser.Scene {
             { id: 'alloy', label: 'Legering' },
             { id: 'forge', label: 'Smi' },
         ];
-        // Add Chemistry tab if unlocked (after first zone boss kill)
-        if (this.heroRef.chemLabUnlocked) {
-            tabs.push({ id: 'chem', label: 'Kjemi' });
-        }
-        const tabW = tabs.length <= 4 ? 110 : 90;
+        const tabW = 110;
         const tabY = this.py + 50;
         tabs.forEach((tab, i) => {
             const tx = this.px + 30 + i * (tabW + 10) + tabW / 2;
@@ -118,7 +114,6 @@ class SmelteryScene extends Phaser.Scene {
             case 'smelt': this._drawSmeltTab(); break;
             case 'alloy': this._drawAlloyTab(); break;
             case 'forge': this._drawForgeTab(); break;
-            case 'chem':  this._drawChemTab(); break;
         }
     }
 

--- a/src/systems/InputHandler.js
+++ b/src/systems/InputHandler.js
@@ -23,6 +23,7 @@ class InputHandler {
         scene.useItemKey   = scene.input.keyboard.addKey('Q');
         scene.elementBookKey = scene.input.keyboard.addKey('B');
         scene.smelteryKey    = scene.input.keyboard.addKey('V');
+        scene.chemLabKey     = scene.input.keyboard.addKey('C');
         scene.moveTimer    = 0;
 
         // Mouse wheel zoom

--- a/src/systems/MapRenderer.js
+++ b/src/systems/MapRenderer.js
@@ -458,6 +458,15 @@ class MapRenderer {
                     );
                     g.fillStyle(0xffffff, 0.15);
                     g.fillCircle(px + (seed >> 3 & 11) + 6, py + (seed2 >> 3 & 11) + 6, 1);
+                } else if (room.type === 'chem_lab') {
+                    g.fillStyle(0x33dd88, 0.10);
+                    g.fillCircle(px + S / 2, py + S / 2, S / 2.5);
+                    g.fillStyle(0x33dd88, 0.25);
+                    g.fillRoundedRect(px + (seed & 5) + 6, py + (seed2 & 5) + 8, 4, 8, 1);
+                    g.fillRect(px + (seed & 5) + 5, py + (seed2 & 5) + 6, 6, 3);
+                    g.fillStyle(0x66ffaa, 0.2);
+                    g.fillCircle(px + (seed >> 2 & 7) + 14, py + (seed2 >> 2 & 5) + 6, 1);
+                    g.fillCircle(px + (seed >> 3 & 5) + 10, py + (seed2 >> 3 & 5) + 4, 1);
                 } else if (room.type === 'camp_room') {
                     // Warm campfire glow
                     g.fillStyle(0xff7722, 0.12);

--- a/src/systems/TouchControls.js
+++ b/src/systems/TouchControls.js
@@ -19,6 +19,7 @@ class TouchControls {
         reg.set('touch_minimap', false);
         reg.set('touch_use', false);
         reg.set('touch_smeltery', false);
+        reg.set('touch_chemlab', false);
 
         this._createDpad();
         this._createActionButtons();
@@ -97,6 +98,7 @@ class TouchControls {
             { label: 'INV', key: 'touch_inventory', color: 0x335588, ox: 0,           oy: -(sz + gap) },
             { label: 'MAP', key: 'touch_minimap',   color: 0x338844, ox: -(sz + gap), oy: -(sz + gap) },
             { label: 'SMI', key: 'touch_smeltery',  color: 0xff7722, ox: -(sz + gap) * 2, oy: -(sz + gap) },
+            { label: 'LAB', key: 'touch_chemlab',   color: 0x33dd88, ox: 0,            oy: -(sz + gap) * 2 },
         ];
 
         for (const btn of buttons) {


### PR DESCRIPTION
## Summary
- Restore Chem Lab as its own separate special room (world 4+, 35% chance)
- Gated by zone boss: room spawns but is locked until first zone boss is defeated
- Remove Kjemi tab from Camp Room – each crafting station keeps its own identity

## Changes
- **maze.js**: Chem Lab room generation restored (world 4+, 35% chance)
- **MapRenderer.js**: Green glow decoration for chem_lab tiles
- **GameScene.js**: C key + touch LAB button opens ChemLabScene when in lab; shows hint if locked
- **InputHandler.js**: C key registered
- **TouchControls.js**: LAB touch button (green) added back
- **SmelteryScene.js**: Removed Kjemi tab – Camp Room stays as Lager/Smelt/Legering/Smi

## Player experience
1. **World 1-3**: Camp Room for smelting/stash, no chemistry
2. **World 3 zone boss**: Defeats boss → `chemLabUnlocked = true` + "Kjemisk lab ulåst!"
3. **World 4+**: Chem Lab rooms appear with green glow
4. **Walk into lab**: "Trykk C for å lage kjemikalier"
5. **Before zone boss**: "Beseir en soneboss for å aktivere" hint

## Test plan
- [ ] World 1-3: No Chem Lab rooms spawn
- [ ] World 4+: Chem Lab spawns (green glow)
- [ ] Walk into lab before zone boss kill → locked message
- [ ] Defeat zone boss on world 3 → unlock message
- [ ] Walk into lab after unlock → C key opens ChemLabScene
- [ ] Camp Room has 4 tabs only (no Kjemi)
- [ ] Touch: LAB button works

https://claude.ai/code/session_016YgTTg2NgSkDJ1xgCTgZW1