### PR TITLE
v0.9: UI/UX overhaul and skill rebalancing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ---
 
+## v0.9 – 2026-04-09
+
+### Nye funksjoner
+- **Større og lesbar tekst (#79):** Alle fontstørrelser i spillet økt med 2-3px. Minimumsstørrelse er nå 10px (fra 7px). Bedre lesbarhet i alle scener og menyer
+- **Forbedret karakterskaper (#80):** CharacterCreatorScene bruker nå hele 1280×800-lerret. Større rasetabs (120px), bredere stat-barer (220px), større bonusknapper, større navnefelt. Alle fonter økt til 13-15px
+- **Touch-zoom og fullskjerm (#78):** Nye knapper for zoom inn (+), zoom ut (−) og fullskjerm (⛶) øverst til høyre for berøringsskjermer. Fullskjerm bruker Fullscreen API med webkit-fallback
+- **Geolog-skillz styrket (#81):** Malmøye gir nå også mineral-identifisering – uten Geolog-skill vises mineraler som «Ukjent mineral» og elementer oppdages ikke automatisk. Effektiv utvinning gir nå +1 ekstra element per smelting
+- **Metallurg-skillz styrket (#81):** Rask smelting gir nå også +15% sjanse for ekstra utbytte. Legeringsmester gir 20% sjanse for dobbel legering-output. Mestersmie økt til +30% stats og gir spesialegenskaper (våpen: +10% krit, rustning: +1 torneskade)
+
+### Tekniske endringer
+- Fontstørrelser justert i alle 11 scene-filer
+- TouchControls utvidet med zoom/fullskjerm-knapper og Fullscreen API-integrasjon
+- InputHandler støtter nå touch_zoom_in/touch_zoom_out registry-flagg
+- Nye hero-egenskaper: mineralIdentifyLevel, smeltBonusElement, smeltExtraYieldChance, doubleAlloyChance
+- SmeltingSystem.smelt() støtter bonuselement og ekstra utbytte-mekanikk
+- SmeltingSystem.forgeEquipment() legger til spesialegenskaper ved Mestersmie
+
+---
+
 ## v0.32 – 2026-04-08
 
 ### Nye funksjoner

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,8 +11,14 @@
 - **Geolog-skillz styrket (#81):** Malmøye gir nå også mineral-identifisering – uten Geolog-skill vises mineraler som «Ukjent mineral» og elementer oppdages ikke automatisk. Effektiv utvinning gir nå +1 ekstra element per smelting
 - **Metallurg-skillz styrket (#81):** Rask smelting gir nå også +15% sjanse for ekstra utbytte. Legeringsmester gir 20% sjanse for dobbel legering-output. Mestersmie økt til +30% stats og gir spesialegenskaper (våpen: +10% krit, rustning: +1 torneskade)
 
+### Forbedringer
+- **SkillScene utvidet (#79):** Panelet fyller nå hele skjermen (1260×780 i stedet for 940×520). Skill-kort økt til 220×108px med mer plass til tekst og beskrivelser
+- **CharacterCreatorScene fullstendig redesignet (#80):** Ny tre-kolonne layout som fyller hele 1280×800-lerret. Venstre: 2×2 rase-rutenett + egenskaper. Senter: Stort forhåndsvisningsfelt (280px) + heltenavn. Høyre: Utseende-tilpasning. Bunnfelt: Startbonus + startknapp. Visuelt sammenhengende med seksjonspaneler
+
 ### Tekniske endringer
 - Fontstørrelser justert i alle 11 scene-filer
+- SkillScene: panelW/panelH bruker nå W-20/H-20, cardW opptil 220px, cardH 108px, tierH 140px
+- CharacterCreatorScene: Fullstendig omskrevet med tre-kolonne panelstruktur og seksjonspaneler
 - TouchControls utvidet med zoom/fullskjerm-knapper og Fullscreen API-integrasjon
 - InputHandler støtter nå touch_zoom_in/touch_zoom_out registry-flagg
 - Nye hero-egenskaper: mineralIdentifyLevel, smeltBonusElement, smeltExtraYieldChance, doubleAlloyChance

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,6 +1,6 @@
 # Labyrint Hero – Game Design Document
-**Versjon:** 0.32
-**Sist oppdatert:** 2026-04-08
+**Versjon:** 0.9
+**Sist oppdatert:** 2026-04-09
 
 ---
 
@@ -291,8 +291,8 @@ Livspotte, Stor livspotte, Styrkebrygg (midlertidig +2 ATK i 60 sek), Forsvarsbr
 | T3 | precision | +3 ATK, +3 kjæl.-ATK, +3 kjæl.-HP, +2 hjerter nå | ×1 |
 
 ### Håndverksstier (låses opp)
-- **Geolog** (lås: finn mineral) – mineralsynsradius, utbytte, garantert sjeldent mineral
-- **Metallurg** (lås: smelt mineral) – smeltetid, legeringsstats, mestersmie
+- **Geolog** (lås: finn mineral) – mineralidentifisering, mineralsynsradius, utbytte, bonuselementer, garantert sjeldent mineral
+- **Metallurg** (lås: smelt mineral) – smeltetid/energi, ekstra utbytte, legeringsstats, dobbellegering, mestersmie med spesialegenskaper
 - **Kjemiker** (lås: lag kjemikalie) – potion-varighet, bombeskade, eksplosjonsradius
 
 ### Synergier
@@ -370,7 +370,8 @@ Aktiveres automatisk når helten har evner fra begge stier i et par:
 | Skilltre (5 stier + synergier) | ✅ Ferdig | Kriger / Villmarksjeger + Geolog / Metallurg / Kjemiker + 9 synergier. T-tast for visning |
 | Unike gjenstandsikoner | ✅ Ferdig | 20+ distinkte prosedyregrafikker |
 | Bevegelsesanimasjon (glide) | ✅ Ferdig | 90ms hero, 126ms monster |
-| Zoom (kamera) | ✅ Ferdig | Muskjul og +/− |
+| Zoom (kamera) | ✅ Ferdig | Mushjul, +/−, touch-knapper |
+| Fullskjerm (touch) | ✅ Ferdig | Fullscreen API via touch-knapp |
 | HUD + UIScene | ✅ Ferdig | |
 | Minimap (M-tast) | ✅ Ferdig | Fog-bevisst, hjørne-kart |
 | Statuseffekter (4 typer) | ✅ Ferdig | Gift, Brann, Frostbitt, Lammet |
@@ -457,12 +458,14 @@ Elements-modifikasjonen fletter det periodiske system, geologi, metallurgi og kj
 Periodisk system-overlay med 18×9 rutenett. Oppdagede grunnstoffer vises med symbol og kategori-farge. Gruppeprestasjoner (f.eks. Jernmetaller → +2 HP) vises nederst.
 
 ### Geolog-skillsti (#6)
-Låses opp ved første mineral-funn. 3 tiers:
+Låses opp ved første mineral-funn. Kreves for mineral-identifisering. 3 tiers:
 | Tier | Skill | Effekt |
 |------|-------|--------|
-| T1 | Malmøye | +1 mineral-synsradius per stack (maks 3) |
-| T2 | Effektiv utvinning | +25% mineralutbytte per stack (maks 3) |
+| T1 | Malmøye | +1 mineral-synsradius, mineral-identifisering per stack (maks 3) |
+| T2 | Effektiv utvinning | +25% mineralutbytte, +1 ekstra element ved smelting per stack (maks 3) |
 | T3 | Mesterprospektør | Garantert T4+ mineral per etasje (maks 1) |
+
+**Mineral-identifisering:** Uten Geolog-skill vises mineraler som «Ukjent mineral» og grunnstoffer oppdages ikke automatisk ved oppsamling. Malmøye-skillen gir mineralidentifisering.
 
 Synergi: **Jordens kraft** (Geolog + Vokter) → +1 forsvar, +1 mineralsynsradius.
 
@@ -481,9 +484,9 @@ Smelting, legeringer og smiing av utstyr.
 **Metallurg-skillsti (#8):**
 | Tier | Skill | Effekt |
 |------|-------|--------|
-| T1 | Rask smelting | -25% energi og smeltetid per stack (maks 3) |
-| T2 | Legeringsmester | +15% legering-stats per stack (maks 2) |
-| T3 | Mestersmie | +25% stats på smidd utstyr (maks 1) |
+| T1 | Rask smelting | -25% energi/smeltetid, +15% sjanse ekstra utbytte per stack (maks 3) |
+| T2 | Legeringsmester | +15% legering-stats, 20% sjanse for dobbel legering per stack (maks 2) |
+| T3 | Mestersmie | +30% stats på smidd utstyr, spesialegenskaper (våpen: +10% krit, rustning: +1 torneskade) (maks 1) |
 
 ### Fase 3: Kjemi (v0.25)
 

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -114,7 +114,7 @@ Kun ekstra passasje-vegger kan være SECRET/CRACKED/DOOR – DFS-stien er alltid
 - **Forsvar:** Reduserer innkommende skade
 - **Synsfelt:** Tåkeradius (påvirkes av `keen_eye`-evnen)
 - **XP-kurve:** `XP_BASE = 100`, vokser med `XP_GROWTH = 1.55` per nivå → merkbart slakere progresjon
-- **Nivå opp:** Åpner SkillScene (velg én av tre tilfeldige evner). **Ingen automatisk stats-boost** – all styrke kommer fra evner og utstyr.
+- **Nivå opp:** Åpner SkillScene (fullskjerm-panel med 5 kolonner × 3 tier, kort 220×108px). **Ingen automatisk stats-boost** – all styrke kommer fra evner og utstyr.
 - **Facing-retning:** Siste bevegelsesretning brukes av SPACE/F og pilskyting
 
 ### Kjæledyr-følgesvenn
@@ -353,7 +353,7 @@ Aktiveres automatisk når helten har evner fra begge stier i et par:
 | Tile-typer (6 typer inkl. TRAP) | ✅ Ferdig | SECRET, CRACKED_WALL, DOOR, TRAP |
 | Fog of War | ✅ Ferdig | 3 nivåer |
 | Visuelle verdenstemaer | ✅ Ferdig | 5 temaer med detaljerte per-tile dekorasjoner, murverk, vegg-skygger |
-| Karakterskaper (4 raser) | ✅ Ferdig | Alv, Dverg, Menneske, Hobbit; kjønnsvalg |
+| Karakterskaper (4 raser) | ✅ Ferdig | Tre-kolonne layout: 2×2 rase-rutenett + stats | preview + navn | utseende. Fyller hele skjermen |
 | Prosedyrekaraktergrafikk | ✅ Ferdig | 2 kjønn, 10 frisyrer, 4 klesstiler, øynefarge, skjegg, tilbehør per rase |
 | Vanskelighetsgrad (MenuScene) | ✅ Ferdig | LETT/NORMAL/VANSKELIG – prominent i startmenyen |
 | Startbonus-valg | ✅ Ferdig | +Hjerte / +Angrep / +Syn |

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -122,18 +122,24 @@ const SKILL_TREE_PATHS = [
             {
                 id:       'mineral_eye',
                 name:     'Malmøye',
-                desc:     '+1 mineral-\nsynsradius',
+                desc:     '+1 mineral-syn\nIdentifiser mineraler',
                 category: 'GEO',
                 maxStack: 3,
-                apply(hero) { hero.mineralVisionRadius = (hero.mineralVisionRadius || 0) + 1; }
+                apply(hero) {
+                    hero.mineralVisionRadius = (hero.mineralVisionRadius || 0) + 1;
+                    hero.mineralIdentifyLevel = (hero.mineralIdentifyLevel || 0) + 1;
+                }
             },
             {
                 id:       'efficient_mining',
                 name:     'Effektiv utvinning',
-                desc:     '+25% mineral-\nutbytte',
+                desc:     '+25% mineral-utbytte\n+1 ekstra element\nved smelting',
                 category: 'GEO',
                 maxStack: 3,
-                apply(hero) { hero.miningYieldBonus = (hero.miningYieldBonus || 0) + 0.25; }
+                apply(hero) {
+                    hero.miningYieldBonus = (hero.miningYieldBonus || 0) + 0.25;
+                    hero.smeltBonusElement = (hero.smeltBonusElement || 0) + 1;
+                }
             },
             {
                 id:       'master_prospector',
@@ -157,29 +163,33 @@ const SKILL_TREE_PATHS = [
             {
                 id:       'fast_smelting',
                 name:     'Rask smelting',
-                desc:     '-25% smeltetid\nog energikost',
+                desc:     '-25% smeltetid/energi\n+15% sjanse for\nekstra utbytte',
                 category: 'UTIL',
                 maxStack: 3,
                 apply(hero) {
                     hero.smeltingSpeedMul = (hero.smeltingSpeedMul || 1.0) * 0.75;
                     hero.smeltingEfficiency = (hero.smeltingEfficiency || 1.0) * 0.75;
+                    hero.smeltExtraYieldChance = (hero.smeltExtraYieldChance || 0) + 0.15;
                 }
             },
             {
                 id:       'alloy_mastery',
                 name:     'Legeringsmester',
-                desc:     '+15% legering-\nstats per stack',
+                desc:     '+15% legering-stats\n20% sjanse for\ndobbel legering',
                 category: 'UTIL',
                 maxStack: 2,
-                apply(hero) { hero.alloyMasteryBonus = (hero.alloyMasteryBonus || 0) + 0.15; }
+                apply(hero) {
+                    hero.alloyMasteryBonus = (hero.alloyMasteryBonus || 0) + 0.15;
+                    hero.doubleAlloyChance = (hero.doubleAlloyChance || 0) + 0.20;
+                }
             },
             {
                 id:       'master_smith',
                 name:     'Mestersmie',
-                desc:     '+25% stats på\nsmidd utstyr',
+                desc:     '+30% stats på smidd\nutstyr, utstyr får\nspesialegenskaper',
                 category: 'ATK',
                 maxStack: 1,
-                apply(hero) { hero.alloyStatBonus = (hero.alloyStatBonus || 0) + 0.25; }
+                apply(hero) { hero.alloyStatBonus = (hero.alloyStatBonus || 0) + 0.30; }
             },
         ]
     },

--- a/src/entities/HeroCrafting.js
+++ b/src/entities/HeroCrafting.js
@@ -10,16 +10,20 @@ const HeroCrafting = {
         hero.elementTracker = new ElementTracker();
         hero.geologistUnlocked = false;
         hero.mineralVisionRadius = 0;
+        hero.mineralIdentifyLevel = 0;
         hero.miningYieldBonus = 0;
+        hero.smeltBonusElement = 0;
         hero.guaranteedRareMineral = false;
 
         // Metallurgy mod (Phase 2)
         hero.metallurgistUnlocked = false;
         hero.smeltingSpeedMul = 1.0;
         hero.smeltingEfficiency = 1.0;
+        hero.smeltExtraYieldChance = 0;
         hero.alloyMasteryBonus = 0;
         hero.alloyStatBonus = 0;
         hero.oreEfficiencyChance = 0;
+        hero.doubleAlloyChance = 0;
         hero.alloyInventory = {};
 
         // Chemistry mod (Phase 3)
@@ -44,14 +48,18 @@ const HeroCrafting = {
             elementTracker:       hero.elementTracker.serialize(),
             geologistUnlocked:    hero.geologistUnlocked,
             mineralVisionRadius:  hero.mineralVisionRadius,
+            mineralIdentifyLevel: hero.mineralIdentifyLevel,
             miningYieldBonus:     hero.miningYieldBonus,
+            smeltBonusElement:    hero.smeltBonusElement,
             guaranteedRareMineral: hero.guaranteedRareMineral,
             metallurgistUnlocked: hero.metallurgistUnlocked,
             smeltingSpeedMul:     hero.smeltingSpeedMul,
             smeltingEfficiency:   hero.smeltingEfficiency,
+            smeltExtraYieldChance: hero.smeltExtraYieldChance,
             alloyMasteryBonus:    hero.alloyMasteryBonus,
             alloyStatBonus:       hero.alloyStatBonus,
             oreEfficiencyChance:  hero.oreEfficiencyChance,
+            doubleAlloyChance:    hero.doubleAlloyChance,
             alloyInventory:       { ...hero.alloyInventory },
             campStash:            hero.campStash.map(e => ({ ...e })),
             chemistUnlocked:      hero.chemistUnlocked,
@@ -70,14 +78,18 @@ const HeroCrafting = {
         hero.elementTracker       = ElementTracker.deserialize(stats.elementTracker || null);
         hero.geologistUnlocked    = stats.geologistUnlocked    || false;
         hero.mineralVisionRadius  = stats.mineralVisionRadius  || 0;
+        hero.mineralIdentifyLevel = stats.mineralIdentifyLevel || 0;
         hero.miningYieldBonus     = stats.miningYieldBonus     || 0;
+        hero.smeltBonusElement    = stats.smeltBonusElement    || 0;
         hero.guaranteedRareMineral = stats.guaranteedRareMineral || false;
         hero.metallurgistUnlocked = stats.metallurgistUnlocked || false;
         hero.smeltingSpeedMul     = stats.smeltingSpeedMul     || 1.0;
         hero.smeltingEfficiency   = stats.smeltingEfficiency   || 1.0;
+        hero.smeltExtraYieldChance = stats.smeltExtraYieldChance || 0;
         hero.alloyMasteryBonus    = stats.alloyMasteryBonus    || 0;
         hero.alloyStatBonus       = stats.alloyStatBonus       || 0;
         hero.oreEfficiencyChance  = stats.oreEfficiencyChance  || 0;
+        hero.doubleAlloyChance    = stats.doubleAlloyChance    || 0;
         hero.alloyInventory       = stats.alloyInventory       ? { ...stats.alloyInventory } : {};
         hero.campStash            = (stats.campStash || []).map(e => ({ ...e }));
         hero.chemistUnlocked      = stats.chemistUnlocked      || false;

--- a/src/scenes/CharacterCreatorScene.js
+++ b/src/scenes/CharacterCreatorScene.js
@@ -1,4 +1,5 @@
 // ─── Labyrint Hero – CharacterCreatorScene ────────────────────────────────────
+// Full-page three-column layout: Race+Stats | Preview+Name | Appearance
 
 const RACE_DEFS = {
     human:  { name: 'Menneske', hearts: 5, attack: 2, defense: 0, visionRadius: 5, xpMultiplier: 1.25, special: 'XP-bonus +25%',       desc: 'Allsidig og tilpasningsdyktig. Lærer raskere enn andre.' },
@@ -23,7 +24,6 @@ class CharacterCreatorScene extends Phaser.Scene {
 
     create() {
         const { width: W, height: H } = this.cameras.main;
-        const cx = W / 2;
 
         this.selectedRace       = 'human';
         this.selectedDifficulty = this._initDifficulty;
@@ -32,59 +32,91 @@ class CharacterCreatorScene extends Phaser.Scene {
         this.appearance         = defaultAppearance('human');
         this._customOverrides   = {};
 
-        // ── Background ────────────────────────────────────────────────────────
-        this.add.rectangle(cx, H / 2, W, H, 0x0a0814);
+        // ── Full background ──────────────────────────────────────────────────
+        this.add.rectangle(W / 2, H / 2, W, H, 0x080612);
 
-        // ── Title ─────────────────────────────────────────────────────────────
-        this.add.text(cx, 22, 'VELG DIN HELT', {
-            fontSize: '28px', color: '#f5e642', fontFamily: 'monospace',
-            fontStyle: 'bold', stroke: '#7a6a00', strokeThickness: 3
-        }).setOrigin(0.5, 0);
+        // ── Layout constants ─────────────────────────────────────────────────
+        const pad = 15;
+        const mainY = 58, mainBot = H - 145;
+        const mainH = mainBot - mainY;
 
-        // ── Difficulty display ────────────────────────────────────────────────
-        this._buildDifficultyRow(cx, W);
+        const leftX = pad, leftW = 370;
+        const centerX = leftX + leftW + pad, centerW = 400;
+        const rightX = centerX + centerW + pad, rightW = W - rightX - pad;
 
-        // ── Race tabs ─────────────────────────────────────────────────────────
-        this._buildRacePanel(W, H);
+        this._leftPanel   = { x: leftX, y: mainY, w: leftW, h: mainH };
+        this._centerPanel = { x: centerX, y: mainY, w: centerW, h: mainH };
+        this._rightPanel  = { x: rightX, y: mainY, w: rightW, h: mainH };
 
-        // ── Appearance / Preview (right panel) ────────────────────────────────
-        this._buildAppearancePanel(W, H);
+        // ── Top bar ──────────────────────────────────────────────────────────
+        this._buildTopBar(W);
 
-        // ── Starting bonus (left panel, below stats) ──────────────────────────
-        this._buildBonusPanel(W, H);
+        // ── Section panels (backgrounds) ─────────────────────────────────────
+        this._drawSectionPanel(leftX, mainY, leftW, mainH);
+        this._drawSectionPanel(centerX, mainY, centerW, mainH);
+        this._drawSectionPanel(rightX, mainY, rightW, mainH);
 
-        // ── Name + start ──────────────────────────────────────────────────────
-        this._buildNameAndStart(cx, W, H);
+        // ── Left panel: Race grid + Stats ────────────────────────────────────
+        this._statsObjs = [];
+        this._buildRaceGrid();
 
+        // ── Center panel: Preview + Name ─────────────────────────────────────
+        this._previewGfx = this.add.graphics();
+        this._descObjs   = [];
+        this._buildNameInput();
+
+        // ── Right panel: Appearance ──────────────────────────────────────────
+        this._appearObjs = [];
+
+        // ── Bottom bar: Bonus + Start ────────────────────────────────────────
+        this._buildBottomBar(W, H, mainBot + pad);
+
+        // ── Apply defaults ───────────────────────────────────────────────────
         this._selectRace('human');
+        this._selectDifficulty(this.selectedDifficulty);
+        this._selectBonus('heart');
         this.input.keyboard.on('keydown', this._onKey, this);
     }
 
-    // ── Difficulty row ────────────────────────────────────────────────────────
+    _drawSectionPanel(x, y, w, h) {
+        const g = this.add.graphics();
+        g.fillStyle(0x0c0a1a, 0.85);
+        g.fillRoundedRect(x, y, w, h, 6);
+        g.lineStyle(1, 0x2a2060, 0.5);
+        g.strokeRoundedRect(x, y, w, h, 6);
+    }
 
-    _buildDifficultyRow(cx, W) {
-        this.add.rectangle(cx, 52, W - 40, 1, 0x1a1535);
-        this.add.text(30, 64, 'VANSKELIGHETSGRAD:', {
-            fontSize: '13px', color: '#445566', fontFamily: 'monospace'
+    // ── Top bar: Title + Difficulty ──────────────────────────────────────────
+
+    _buildTopBar(W) {
+        const cx = W / 2;
+        this.add.text(cx, 8, 'VELG DIN HELT', {
+            fontSize: '26px', color: '#f5e642', fontFamily: 'monospace',
+            fontStyle: 'bold', stroke: '#7a6a00', strokeThickness: 3
+        }).setOrigin(0.5, 0);
+
+        this.add.text(W - 390, 18, 'VANSKELIGHETSGRAD:', {
+            fontSize: '12px', color: '#445566', fontFamily: 'monospace'
         });
 
         const DIFFS = [
-            { id: 'easy',   label: 'LETT',     col: 0x44bb44 },
-            { id: 'normal', label: 'NORMAL',   col: 0x4488ff },
-            { id: 'hard',   label: 'VANSK.',   col: 0xff4444 },
+            { id: 'easy',   label: 'LETT',   col: 0x44bb44 },
+            { id: 'normal', label: 'NORMAL', col: 0x4488ff },
+            { id: 'hard',   label: 'VANSK.', col: 0xff4444 },
         ];
         this._diffBtns = {};
         DIFFS.forEach(({ id, label, col }, i) => {
-            const bx  = 220 + i * 120;
-            const bg  = this.add.rectangle(bx, 66, 105, 24, 0x111122)
+            const bx = W - 230 + i * 80;
+            const bg = this.add.rectangle(bx, 17, 70, 22, 0x111122)
                 .setStrokeStyle(1, 0x334466).setInteractive({ useHandCursor: true });
-            const txt = this.add.text(bx, 66, label, {
-                fontSize: '14px', color: '#889aaa', fontFamily: 'monospace'
+            const txt = this.add.text(bx, 17, label, {
+                fontSize: '12px', color: '#889aaa', fontFamily: 'monospace'
             }).setOrigin(0.5);
             bg.on('pointerdown', () => this._selectDifficulty(id));
             this._diffBtns[id] = { bg, txt, col };
         });
-        this._selectDifficulty(this.selectedDifficulty);
+
+        this.add.rectangle(cx, 46, W - 24, 1, 0x1a1535);
     }
 
     _selectDifficulty(id) {
@@ -97,44 +129,77 @@ class CharacterCreatorScene extends Phaser.Scene {
         }
     }
 
-    // ── Left panel: race selection + stats ────────────────────────────────────
+    // ── Left panel: Race grid (2x2) + Stats ──────────────────────────────────
 
-    _buildRacePanel(W, H) {
-        const panelX = 30;
-        const races  = Object.keys(RACE_DEFS);
-        const btnW   = 120, btnH = 38;
+    _buildRaceGrid() {
+        const { x: px, y: py, w: pw } = this._leftPanel;
+        const innerPad = 15;
+
+        this.add.text(px + pw / 2, py + 10, 'RASE', {
+            fontSize: '13px', color: '#556677', fontFamily: 'monospace', fontStyle: 'bold'
+        }).setOrigin(0.5, 0);
+
+        const races = Object.keys(RACE_DEFS);
+        const cardW = (pw - innerPad * 2 - 10) / 2;
+        const cardH = 80;
+        const gap = 8;
+        const gridX = px + innerPad;
+        const gridY = py + 30;
 
         this._raceBtns = {};
-        this.add.rectangle(panelX + races.length * (btnW + 8) / 2, 90, W / 2, 1, 0x1a1535);
         races.forEach((id, i) => {
-            const bx  = panelX + i * (btnW + 8) + btnW / 2;
-            const btn = this._raceTab(bx, 108, btnW, btnH, RACE_DEFS[id].name, id);
-            this._raceBtns[id] = btn;
+            const col = i % 2;
+            const row = Math.floor(i / 2);
+            const cx = gridX + col * (cardW + gap) + cardW / 2;
+            const cy = gridY + row * (cardH + gap) + cardH / 2;
+
+            const def = RACE_DEFS[id];
+            const bg = this.add.graphics();
+            bg.fillStyle(0x111128, 0.9);
+            bg.fillRoundedRect(cx - cardW / 2, cy - cardH / 2, cardW, cardH, 5);
+            bg.lineStyle(1, 0x334466);
+            bg.strokeRoundedRect(cx - cardW / 2, cy - cardH / 2, cardW, cardH, 5);
+
+            const hitZone = this.add.rectangle(cx, cy, cardW, cardH)
+                .setInteractive({ useHandCursor: true }).setAlpha(0.001);
+
+            const name = this.add.text(cx, cy - 20, def.name, {
+                fontSize: '15px', color: '#cccccc', fontFamily: 'monospace', fontStyle: 'bold'
+            }).setOrigin(0.5);
+            const spec = this.add.text(cx, cy + 2, def.special, {
+                fontSize: '11px', color: '#667788', fontFamily: 'monospace'
+            }).setOrigin(0.5);
+            const statLine = `\u2665${def.hearts} \u2694${def.attack} \u25C6${def.defense} \u25CE${def.visionRadius}`;
+            const stats = this.add.text(cx, cy + 20, statLine, {
+                fontSize: '10px', color: '#556677', fontFamily: 'monospace'
+            }).setOrigin(0.5);
+
+            hitZone.on('pointerdown', () => this._selectRace(id));
+            hitZone.on('pointerover', () => { if (this.selectedRace !== id) bg.setAlpha(0.8); });
+            hitZone.on('pointerout',  () => bg.setAlpha(1));
+
+            this._raceBtns[id] = { bg, name, spec, stats, hitZone, cardW, cardH, cx, cy };
         });
 
-        this._statsY    = 140;
-        this._statsObjs = [];
-        this._rebuildStats();
-    }
-
-    _raceTab(x, y, w, h, label, raceId) {
-        const bg  = this.add.rectangle(x, y, w, h, 0x1a1535).setStrokeStyle(1, 0x4444aa).setInteractive({ useHandCursor: true });
-        const txt = this.add.text(x, y, label, { fontSize: '15px', color: '#cccccc', fontFamily: 'monospace' }).setOrigin(0.5);
-        bg.on('pointerdown', () => this._selectRace(raceId));
-        bg.on('pointerover', () => bg.setAlpha(0.8));
-        bg.on('pointerout',  () => bg.setAlpha(1));
-        return { bg, txt };
+        // Stats area starts below the grid
+        this._statsAreaY = gridY + 2 * (cardH + gap) + 12;
     }
 
     _selectRace(id) {
         this.selectedRace = id;
-        this.appearance   = { ...defaultAppearance(id), ...this._customOverrides };
-        for (const [rid, { bg, txt }] of Object.entries(this._raceBtns)) {
+        this.appearance = { ...defaultAppearance(id), ...this._customOverrides };
+
+        for (const [rid, btn] of Object.entries(this._raceBtns)) {
             const sel = rid === id;
-            bg.setFillStyle(sel ? 0x2a2060 : 0x1a1535);
-            bg.setStrokeStyle(sel ? 2 : 1, sel ? 0xf5e642 : 0x4444aa);
-            txt.setColor(sel ? '#f5e642' : '#cccccc');
+            btn.bg.clear();
+            btn.bg.fillStyle(sel ? 0x1a1540 : 0x111128, 0.9);
+            btn.bg.fillRoundedRect(btn.cx - btn.cardW / 2, btn.cy - btn.cardH / 2, btn.cardW, btn.cardH, 5);
+            btn.bg.lineStyle(sel ? 2 : 1, sel ? 0xf5e642 : 0x334466);
+            btn.bg.strokeRoundedRect(btn.cx - btn.cardW / 2, btn.cy - btn.cardH / 2, btn.cardW, btn.cardH, 5);
+            btn.name.setColor(sel ? '#f5e642' : '#cccccc');
+            btn.spec.setColor(sel ? '#aabb88' : '#667788');
         }
+
         this._rebuildStats();
         this._rebuildPreview();
         this._rebuildAppearancePickers();
@@ -144,63 +209,152 @@ class CharacterCreatorScene extends Phaser.Scene {
         this._statsObjs.forEach(o => o.destroy());
         this._statsObjs = [];
 
+        const { x: px, w: pw } = this._leftPanel;
+        const innerPad = 15;
+        const lx = px + innerPad;
+        const sy = this._statsAreaY;
         const def = RACE_DEFS[this.selectedRace];
         const add = o => { this._statsObjs.push(o); return o; };
-        const y0  = this._statsY;
-        const lx  = 34;
 
-        add(this.add.text(lx, y0, def.desc, { fontSize: '13px', color: '#8899bb', fontFamily: 'monospace', wordWrap: { width: 480 } }));
-        add(this.add.text(lx, y0 + 20, `Spesial: ${def.special}`, { fontSize: '13px', color: '#f5e642', fontFamily: 'monospace' }));
+        // Race description
+        add(this.add.text(lx, sy, def.desc, {
+            fontSize: '12px', color: '#8899bb', fontFamily: 'monospace',
+            wordWrap: { width: pw - innerPad * 2 }
+        }));
+        add(this.add.text(lx, sy + 28, `\u2605 ${def.special}`, {
+            fontSize: '12px', color: '#f5e642', fontFamily: 'monospace'
+        }));
+
+        // Separator
+        const sepG = add(this.add.graphics());
+        sepG.lineStyle(1, 0x1a1535);
+        sepG.lineBetween(px + 10, sy + 50, px + pw - 10, sy + 50);
+
+        // Section header
+        add(this.add.text(px + pw / 2, sy + 58, 'EGENSKAPER', {
+            fontSize: '12px', color: '#556677', fontFamily: 'monospace', fontStyle: 'bold'
+        }).setOrigin(0.5, 0));
 
         const stats = [
-            { label: 'Hjerter',  val: def.hearts,       max: 8,  col: 0xff2244 },
-            { label: 'Angrep',   val: def.attack,        max: 6,  col: 0xff8800 },
-            { label: 'Forsvar',  val: def.defense,       max: 4,  col: 0x4488ff },
-            { label: 'Syn',      val: def.visionRadius,  max: 8,  col: 0xffee00 },
-            { label: 'XP-mult',  val: def.xpMultiplier,  max: 2,  col: 0xaa44ff }
+            { label: 'Hjerter', val: def.hearts,      max: 8, col: 0xff2244 },
+            { label: 'Angrep',  val: def.attack,       max: 6, col: 0xff8800 },
+            { label: 'Forsvar', val: def.defense,      max: 4, col: 0x4488ff },
+            { label: 'Syn',     val: def.visionRadius, max: 8, col: 0xffee00 },
+            { label: 'XP-mult', val: def.xpMultiplier, max: 2, col: 0xaa44ff }
         ];
-        const barX = lx, bw = 220, bh = 12, gap = 24;
+
+        const bw = pw - innerPad * 2 - 100;
+        const bh = 12;
+        const gap = 26;
+
         stats.forEach(({ label, val, max, col }, i) => {
-            const y = y0 + 46 + i * gap;
-            add(this.add.text(barX, y, label, { fontSize: '13px', color: '#556677', fontFamily: 'monospace' }));
-            const bg = add(this.add.graphics());
-            bg.fillStyle(0x1a1535);
-            bg.fillRect(barX + 80, y + 2, bw, bh);
+            const y = sy + 80 + i * gap;
+            add(this.add.text(lx, y, label, {
+                fontSize: '12px', color: '#556677', fontFamily: 'monospace'
+            }));
+            const bgBar = add(this.add.graphics());
+            bgBar.fillStyle(0x1a1535);
+            bgBar.fillRect(lx + 72, y + 2, bw, bh);
             const fill = add(this.add.graphics());
             fill.fillStyle(col);
-            fill.fillRect(barX + 80, y + 2, Math.floor(bw * (val / max)), bh);
-            const valStr = label === 'XP-mult' ? `×${val.toFixed(2)}` : String(val);
-            add(this.add.text(barX + 80 + bw + 8, y, valStr, { fontSize: '13px', color: '#aabbcc', fontFamily: 'monospace' }));
+            fill.fillRect(lx + 72, y + 2, Math.floor(bw * (val / max)), bh);
+            const valStr = label === 'XP-mult' ? `\u00d7${val.toFixed(2)}` : String(val);
+            add(this.add.text(lx + 72 + bw + 6, y, valStr, {
+                fontSize: '12px', color: '#aabbcc', fontFamily: 'monospace'
+            }));
         });
     }
 
-    // ── Right panel: sprite preview + appearance pickers ──────────────────────
+    // ── Center panel: Preview + Description + Name ───────────────────────────
 
-    _buildAppearancePanel(W, H) {
-        this._previewGfx  = this.add.graphics();
-        this._appearObjs  = [];
-        this._rebuildAppearancePickers();
+    _rebuildPreview() {
+        this._descObjs.forEach(o => o.destroy());
+        this._descObjs = [];
+
+        const { x: px, y: py, w: pw, h: ph } = this._centerPanel;
+        const g = this._previewGfx;
+        g.clear();
+
+        const previewSize = Math.min(280, pw - 40);
+        const prevCX = px + pw / 2;
+        const prevY = py + 20;
+
+        // Preview box background
+        g.fillStyle(0x0d0b1e, 0.95);
+        g.fillRoundedRect(prevCX - previewSize / 2 - 8, prevY, previewSize + 16, previewSize + 16, 6);
+        g.lineStyle(2, 0x3a3070, 0.6);
+        g.strokeRoundedRect(prevCX - previewSize / 2 - 8, prevY, previewSize + 16, previewSize + 16, 6);
+
+        // Floor hint
+        g.fillStyle(0x1e1a30);
+        g.fillRect(prevCX - previewSize / 2 - 3, prevY + previewSize - 12, previewSize + 6, 23);
+
+        // Character sprite
+        if (typeof drawDetailedCharacterSprite === 'function') {
+            drawDetailedCharacterSprite(g, prevCX - previewSize / 2, prevY + 8, previewSize, this.appearance, this.selectedRace);
+        } else {
+            drawCharacterSprite(g, prevCX - previewSize / 2, prevY + 8, previewSize, this.appearance, this.selectedRace);
+        }
+
+        // Race name below preview
+        const add = o => { this._descObjs.push(o); return o; };
+        const def = RACE_DEFS[this.selectedRace];
+        add(this.add.text(prevCX, prevY + previewSize + 28, def.name.toUpperCase(), {
+            fontSize: '18px', color: '#f5e642', fontFamily: 'monospace', fontStyle: 'bold'
+        }).setOrigin(0.5, 0));
     }
+
+    _buildNameInput() {
+        const { x: px, y: py, w: pw, h: ph } = this._centerPanel;
+        const cx = px + pw / 2;
+        const y = py + ph - 55;
+
+        this.add.text(cx - 110, y, 'Heltenavn:', {
+            fontSize: '13px', color: '#667788', fontFamily: 'monospace'
+        }).setOrigin(0, 0.5);
+
+        this._nameBg  = this.add.rectangle(cx + 30, y, 200, 28, 0x1a1830)
+            .setStrokeStyle(1, 0x4444aa);
+        this._nameTxt = this.add.text(cx + 30, y, '|', {
+            fontSize: '16px', color: '#ffffff', fontFamily: 'monospace'
+        }).setOrigin(0.5);
+
+        this._nameBg.setInteractive({ useHandCursor: true });
+        this._nameBg.on('pointerdown', () => this._openMobileNameInput());
+
+        this._cursor = true;
+        this.time.addEvent({ delay: 500, loop: true, callback: () => {
+            this._cursor = !this._cursor;
+            this._nameTxt.setText((this.heroName || '') + (this._cursor ? '|' : ' '));
+        }});
+    }
+
+    // ── Right panel: Appearance ──────────────────────────────────────────────
 
     _rebuildAppearancePickers() {
         this._appearObjs.forEach(o => o.destroy());
         this._appearObjs = [];
 
-        const { width: W } = this.cameras.main;
-        const px = W - 420, py = 140;
+        const { x: px, y: py, w: pw } = this._rightPanel;
+        const innerPad = 15;
+        const lx = px + innerPad;
         const add = o => { this._appearObjs.push(o); return o; };
 
-        add(this.add.text(px, py, 'UTSEENDE', { fontSize: '13px', color: '#445566', fontFamily: 'monospace' }));
+        add(this.add.text(px + pw / 2, py + 10, 'UTSEENDE', {
+            fontSize: '13px', color: '#556677', fontFamily: 'monospace', fontStyle: 'bold'
+        }).setOrigin(0.5, 0));
 
-        // ── Gender row ────────────────────────────────────────────────────────
-        let rowY = py + 24;
-        add(this.add.text(px, rowY, 'Kjønn:', { fontSize: '13px', color: '#667788', fontFamily: 'monospace' }));
+        let rowY = py + 36;
+        const rowGap = 36;
+
+        // ── Gender ───────────────────────────────────────────────────────────
+        add(this.add.text(lx, rowY, 'Kj\u00f8nn:', { fontSize: '12px', color: '#667788', fontFamily: 'monospace' }));
         GENDERS.forEach((gid, i) => {
-            const bx  = px + 70 + i * 80;
+            const bx = lx + 70 + i * 80;
             const sel = this.appearance.gender === gid;
-            const bg  = this.add.rectangle(bx + 28, rowY + 8, 70, 22, sel ? 0x2a2060 : 0x111122)
+            const bg = this.add.rectangle(bx + 28, rowY + 6, 68, 22, sel ? 0x2a2060 : 0x111122)
                 .setStrokeStyle(1, sel ? 0xf5e642 : 0x334455).setInteractive({ useHandCursor: true });
-            const txt = this.add.text(bx + 28, rowY + 8, GENDER_LABELS[gid], {
+            const txt = this.add.text(bx + 28, rowY + 6, GENDER_LABELS[gid], {
                 fontSize: '12px', color: sel ? '#f5e642' : '#778899', fontFamily: 'monospace'
             }).setOrigin(0.5);
             bg.on('pointerdown', () => {
@@ -213,55 +367,54 @@ class CharacterCreatorScene extends Phaser.Scene {
                 this._rebuildPreview();
                 this._rebuildAppearancePickers();
             });
-            add(bg);
-            add(txt);
+            add(bg); add(txt);
         });
 
-        // ── Skin tone row ─────────────────────────────────────────────────────
-        rowY += 32;
-        add(this.add.text(px, rowY, 'Hud:', { fontSize: '13px', color: '#667788', fontFamily: 'monospace' }));
+        // ── Skin tone ────────────────────────────────────────────────────────
+        rowY += rowGap;
+        add(this.add.text(lx, rowY, 'Hud:', { fontSize: '12px', color: '#667788', fontFamily: 'monospace' }));
         SKIN_TONES.forEach((col, i) => {
-            const btn = this._colorDot(px + 52 + i * 30, rowY + 7, col, this.appearance.skinColor === col);
+            const btn = this._colorDot(lx + 52 + i * 30, rowY + 7, col, this.appearance.skinColor === col);
             btn.on('pointerdown', () => { this._customOverrides.skinColor = col; this.appearance.skinColor = col; this._rebuildPreview(); this._rebuildAppearancePickers(); });
             add(btn);
         });
 
-        // ── Hair color row ────────────────────────────────────────────────────
-        rowY += 32;
-        add(this.add.text(px, rowY, 'Hår:', { fontSize: '13px', color: '#667788', fontFamily: 'monospace' }));
+        // ── Hair color ───────────────────────────────────────────────────────
+        rowY += rowGap;
+        add(this.add.text(lx, rowY, 'H\u00e5r:', { fontSize: '12px', color: '#667788', fontFamily: 'monospace' }));
         HAIR_COLORS.forEach((col, i) => {
-            const btn = this._colorDot(px + 52 + i * 28, rowY + 7, col, this.appearance.hairColor === col);
+            const btn = this._colorDot(lx + 52 + i * 28, rowY + 7, col, this.appearance.hairColor === col);
             btn.on('pointerdown', () => { this._customOverrides.hairColor = col; this.appearance.hairColor = col; this._rebuildPreview(); this._rebuildAppearancePickers(); });
             add(btn);
         });
 
-        // ── Eye color row ─────────────────────────────────────────────────────
-        rowY += 32;
-        add(this.add.text(px, rowY, 'Øyne:', { fontSize: '13px', color: '#667788', fontFamily: 'monospace' }));
+        // ── Eye color ────────────────────────────────────────────────────────
+        rowY += rowGap;
+        add(this.add.text(lx, rowY, '\u00d8yne:', { fontSize: '12px', color: '#667788', fontFamily: 'monospace' }));
         EYE_COLORS.forEach((col, i) => {
-            const btn = this._colorDot(px + 60 + i * 30, rowY + 7, col, this.appearance.eyeColor === col);
+            const btn = this._colorDot(lx + 60 + i * 30, rowY + 7, col, this.appearance.eyeColor === col);
             btn.on('pointerdown', () => { this._customOverrides.eyeColor = col; this.appearance.eyeColor = col; this._rebuildPreview(); this._rebuildAppearancePickers(); });
             add(btn);
         });
 
-        // ── Cloth color row ───────────────────────────────────────────────────
-        rowY += 32;
-        add(this.add.text(px, rowY, 'Farge:', { fontSize: '13px', color: '#667788', fontFamily: 'monospace' }));
+        // ── Cloth color ──────────────────────────────────────────────────────
+        rowY += rowGap;
+        add(this.add.text(lx, rowY, 'Farge:', { fontSize: '12px', color: '#667788', fontFamily: 'monospace' }));
         CLOTH_COLORS.forEach((col, i) => {
-            const btn = this._colorDot(px + 60 + i * 26, rowY + 7, col, this.appearance.clothColor === col);
+            const btn = this._colorDot(lx + 60 + i * 26, rowY + 7, col, this.appearance.clothColor === col);
             btn.on('pointerdown', () => { this._customOverrides.clothColor = col; this.appearance.clothColor = col; this._rebuildPreview(); this._rebuildAppearancePickers(); });
             add(btn);
         });
 
-        // ── Clothing style row ────────────────────────────────────────────────
-        rowY += 32;
-        add(this.add.text(px, rowY, 'Drakt:', { fontSize: '13px', color: '#667788', fontFamily: 'monospace' }));
+        // ── Clothing style ───────────────────────────────────────────────────
+        rowY += rowGap;
+        add(this.add.text(lx, rowY, 'Drakt:', { fontSize: '12px', color: '#667788', fontFamily: 'monospace' }));
         CLOTH_STYLES.forEach((style, i) => {
-            const bx  = px + 60 + i * 68;
+            const bx = lx + 60 + i * 68;
             const sel = this.appearance.clothStyle === style;
-            const bg  = this.add.rectangle(bx + 26, rowY + 8, 60, 22, sel ? 0x2a2060 : 0x111122)
+            const bg = this.add.rectangle(bx + 26, rowY + 6, 60, 22, sel ? 0x2a2060 : 0x111122)
                 .setStrokeStyle(1, sel ? 0xf5e642 : 0x334455).setInteractive({ useHandCursor: true });
-            const txt = this.add.text(bx + 26, rowY + 8, CLOTH_STYLE_LABELS[style], {
+            const txt = this.add.text(bx + 26, rowY + 6, CLOTH_STYLE_LABELS[style], {
                 fontSize: '11px', color: sel ? '#f5e642' : '#778899', fontFamily: 'monospace'
             }).setOrigin(0.5);
             bg.on('pointerdown', () => {
@@ -270,22 +423,21 @@ class CharacterCreatorScene extends Phaser.Scene {
                 this._rebuildPreview();
                 this._rebuildAppearancePickers();
             });
-            add(bg);
-            add(txt);
+            add(bg); add(txt);
         });
 
-        // ── Hair style row (not for dwarf) ────────────────────────────────────
+        // ── Hair style (not for dwarf) ───────────────────────────────────────
         if (this.selectedRace !== 'dwarf') {
-            rowY += 32;
-            add(this.add.text(px, rowY, 'Frisyre:', { fontSize: '13px', color: '#667788', fontFamily: 'monospace' }));
+            rowY += rowGap;
+            add(this.add.text(lx, rowY, 'Frisyre:', { fontSize: '12px', color: '#667788', fontFamily: 'monospace' }));
             const stylesPerRow = 5;
             HAIR_STYLES.forEach((style, i) => {
                 const row = Math.floor(i / stylesPerRow);
                 const col = i % stylesPerRow;
-                const bx  = px + 70 + col * 62;
-                const by  = rowY + 8 + row * 28;
+                const bx = lx + 70 + col * 62;
+                const by = rowY + 6 + row * 28;
                 const sel = this.appearance.hairStyle === style;
-                const bg  = this.add.rectangle(bx + 24, by, 56, 22, sel ? 0x2a2060 : 0x111122)
+                const bg = this.add.rectangle(bx + 24, by, 56, 22, sel ? 0x2a2060 : 0x111122)
                     .setStrokeStyle(1, sel ? 0xf5e642 : 0x334455).setInteractive({ useHandCursor: true });
                 const txt = this.add.text(bx + 24, by, HAIR_STYLE_LABELS[style], {
                     fontSize: '11px', color: sel ? '#f5e642' : '#778899', fontFamily: 'monospace'
@@ -296,24 +448,23 @@ class CharacterCreatorScene extends Phaser.Scene {
                     this._rebuildPreview();
                     this._rebuildAppearancePickers();
                 });
-                add(bg);
-                add(txt);
+                add(bg); add(txt);
             });
             rowY += Math.ceil(HAIR_STYLES.length / stylesPerRow) * 28;
         }
 
-        // ── Beard style row (male human / dwarf only) ─────────────────────────
+        // ── Beard style (male human / dwarf only) ────────────────────────────
         const showBeard = (this.selectedRace === 'human' || this.selectedRace === 'dwarf') &&
                           this.appearance.gender !== 'female';
         if (showBeard) {
             rowY += 6;
-            add(this.add.text(px, rowY, 'Skjegg:', { fontSize: '13px', color: '#667788', fontFamily: 'monospace' }));
+            add(this.add.text(lx, rowY, 'Skjegg:', { fontSize: '12px', color: '#667788', fontFamily: 'monospace' }));
             BEARD_STYLES.forEach((style, i) => {
-                const bx  = px + 70 + i * 70;
+                const bx = lx + 70 + i * 70;
                 const sel = this.appearance.beardStyle === style;
-                const bg  = this.add.rectangle(bx + 24, rowY + 8, 62, 22, sel ? 0x2a2060 : 0x111122)
+                const bg = this.add.rectangle(bx + 24, rowY + 6, 62, 22, sel ? 0x2a2060 : 0x111122)
                     .setStrokeStyle(1, sel ? 0xf5e642 : 0x334455).setInteractive({ useHandCursor: true });
-                const txt = this.add.text(bx + 24, rowY + 8, BEARD_STYLE_LABELS[style], {
+                const txt = this.add.text(bx + 24, rowY + 6, BEARD_STYLE_LABELS[style], {
                     fontSize: '11px', color: sel ? '#f5e642' : '#778899', fontFamily: 'monospace'
                 }).setOrigin(0.5);
                 bg.on('pointerdown', () => {
@@ -322,12 +473,9 @@ class CharacterCreatorScene extends Phaser.Scene {
                     this._rebuildPreview();
                     this._rebuildAppearancePickers();
                 });
-                add(bg);
-                add(txt);
+                add(bg); add(txt);
             });
         }
-
-        this._rebuildPreview();
     }
 
     _colorDot(x, y, color, selected) {
@@ -343,63 +491,47 @@ class CharacterCreatorScene extends Phaser.Scene {
         return g;
     }
 
-    _rebuildPreview() {
-        const { width: W, height: H } = this.cameras.main;
-        const g = this._previewGfx;
-        g.clear();
+    // ── Bottom bar: Bonus + Start ────────────────────────────────────────────
 
-        const previewSize = 256;
-        const px = W - 160;
-        const py = H - 380;
+    _buildBottomBar(W, H, botY) {
+        const barH = H - botY - 8;
+        const barG = this.add.graphics();
+        barG.fillStyle(0x0c0a1a, 0.9);
+        barG.fillRoundedRect(15, botY, W - 30, barH, 6);
+        barG.lineStyle(1, 0x2a2060, 0.5);
+        barG.strokeRoundedRect(15, botY, W - 30, barH, 6);
 
-        // Preview box background
-        g.fillStyle(0x0d0b1e, 0.95);
-        g.fillRoundedRect(px - previewSize / 2 - 8, py - 8, previewSize + 16, previewSize + 16, 6);
-        g.lineStyle(2, 0x4444aa, 0.6);
-        g.strokeRoundedRect(px - previewSize / 2 - 8, py - 8, previewSize + 16, previewSize + 16, 6);
-        g.lineStyle(1, 0x2a2050, 0.4);
-        g.strokeRoundedRect(px - previewSize / 2 - 4, py - 4, previewSize + 8, previewSize + 8, 4);
-
-        // Floor tile hint
-        g.fillStyle(0x1e1a30);
-        g.fillRect(px - previewSize / 2 - 3, py + previewSize - 20, previewSize + 6, 23);
-
-        // Draw the detailed character sprite
-        if (typeof drawDetailedCharacterSprite === 'function') {
-            drawDetailedCharacterSprite(g, px - previewSize / 2, py, previewSize, this.appearance, this.selectedRace);
-        } else {
-            drawCharacterSprite(g, px - previewSize / 2, py, previewSize, this.appearance, this.selectedRace);
-        }
-    }
-
-    // ── Starting bonus panel ──────────────────────────────────────────────────
-
-    _buildBonusPanel(W, H) {
-        const lx = 34, by = this._statsY + 180;
-
-        this.add.rectangle(W / 4, by - 8, W / 2 - 20, 1, 0x1a1535);
-        this.add.text(lx, by, 'STARTBONUS  (velg én)', {
-            fontSize: '13px', color: '#445566', fontFamily: 'monospace'
+        // Starting bonus label
+        this.add.text(35, botY + 14, 'STARTBONUS', {
+            fontSize: '13px', color: '#556677', fontFamily: 'monospace', fontStyle: 'bold'
         });
 
         this._bonusBtns = {};
         START_BONUSES.forEach(({ id, label, desc, col }, i) => {
-            const bx  = lx + i * 170 + 72;
-            const bg  = this.add.rectangle(bx, by + 32, 155, 40, 0x111122)
+            const bx = 130 + i * 185;
+            const by = botY + 48;
+            const bg = this.add.rectangle(bx, by, 168, 42, 0x111122)
                 .setStrokeStyle(1, 0x334466).setInteractive({ useHandCursor: true });
-            const lbl = this.add.text(bx, by + 25, label, {
+            const lbl = this.add.text(bx, by - 8, label, {
                 fontSize: '14px', color: '#aabbcc', fontFamily: 'monospace', fontStyle: 'bold'
             }).setOrigin(0.5);
-            const dsc = this.add.text(bx, by + 40, desc, {
+            const dsc = this.add.text(bx, by + 10, desc, {
                 fontSize: '11px', color: '#556677', fontFamily: 'monospace'
             }).setOrigin(0.5);
             bg.on('pointerdown', () => this._selectBonus(id));
-            bg.on('pointerover',  () => { if (this.selectedBonus !== id) bg.setFillStyle(0x1a1a33); });
-            bg.on('pointerout',   () => { if (this.selectedBonus !== id) bg.setFillStyle(0x111122); });
+            bg.on('pointerover', () => { if (this.selectedBonus !== id) bg.setFillStyle(0x1a1a33); });
+            bg.on('pointerout',  () => { if (this.selectedBonus !== id) bg.setFillStyle(0x111122); });
             this._bonusBtns[id] = { bg, lbl, dsc, col };
         });
 
-        this._selectBonus('heart');
+        // Start button
+        const startBtn = this.add.text(W - 210, botY + barH / 2, '[ START EVENTYR ]', {
+            fontSize: '24px', color: '#00e87a', fontFamily: 'monospace', fontStyle: 'bold'
+        }).setOrigin(0.5).setInteractive({ useHandCursor: true });
+        startBtn.on('pointerover', () => startBtn.setAlpha(0.7));
+        startBtn.on('pointerout',  () => startBtn.setAlpha(1));
+        startBtn.on('pointerdown', () => this._startGame());
+        this.tweens.add({ targets: startBtn, alpha: 0.5, duration: 700, yoyo: true, repeat: -1 });
     }
 
     _selectBonus(id) {
@@ -412,33 +544,7 @@ class CharacterCreatorScene extends Phaser.Scene {
         }
     }
 
-    // ── Name input ────────────────────────────────────────────────────────────
-
-    _buildNameAndStart(cx, W, H) {
-        const nameY = H - 100;
-        this.add.rectangle(cx, nameY, W - 40, 1, 0x1a1535);
-        this.add.text(34, nameY + 18, 'Navn:', { fontSize: '15px', color: '#667788', fontFamily: 'monospace' }).setOrigin(0, 0.5);
-
-        this._nameBg  = this.add.rectangle(cx + 40, nameY + 18, 280, 34, 0x1a1830).setStrokeStyle(1, 0x4444aa);
-        this._nameTxt = this.add.text(cx + 40, nameY + 18, '|', { fontSize: '18px', color: '#ffffff', fontFamily: 'monospace' }).setOrigin(0.5);
-
-        this._nameBg.setInteractive({ useHandCursor: true });
-        this._nameBg.on('pointerdown', () => this._openMobileNameInput());
-
-        this._cursor = true;
-        this.time.addEvent({ delay: 500, loop: true, callback: () => {
-            this._cursor = !this._cursor;
-            this._nameTxt.setText((this.heroName || '') + (this._cursor ? '|' : ' '));
-        }});
-
-        const startBtn = this.add.text(cx, H - 40, '[ START EVENTYR ]', {
-            fontSize: '26px', color: '#00e87a', fontFamily: 'monospace'
-        }).setOrigin(0.5).setInteractive({ useHandCursor: true });
-        startBtn.on('pointerover', () => startBtn.setAlpha(0.7));
-        startBtn.on('pointerout',  () => startBtn.setAlpha(1));
-        startBtn.on('pointerdown', () => this._startGame());
-        this.tweens.add({ targets: startBtn, alpha: 0.5, duration: 700, yoyo: true, repeat: -1 });
-    }
+    // ── Keyboard + Mobile name input ─────────────────────────────────────────
 
     _onKey(event) {
         if (event.key === 'Backspace') {
@@ -480,6 +586,8 @@ class CharacterCreatorScene extends Phaser.Scene {
         inp.value = this.heroName;
         inp.focus();
     }
+
+    // ── Start game ───────────────────────────────────────────────────────────
 
     _startGame() {
         const inp = document.getElementById('_heroNameInput');

--- a/src/scenes/CharacterCreatorScene.js
+++ b/src/scenes/CharacterCreatorScene.js
@@ -36,8 +36,8 @@ class CharacterCreatorScene extends Phaser.Scene {
         this.add.rectangle(cx, H / 2, W, H, 0x0a0814);
 
         // ── Title ─────────────────────────────────────────────────────────────
-        this.add.text(cx, 18, 'VELG DIN HELT', {
-            fontSize: '24px', color: '#f5e642', fontFamily: 'monospace',
+        this.add.text(cx, 22, 'VELG DIN HELT', {
+            fontSize: '28px', color: '#f5e642', fontFamily: 'monospace',
             fontStyle: 'bold', stroke: '#7a6a00', strokeThickness: 3
         }).setOrigin(0.5, 0);
 
@@ -63,9 +63,9 @@ class CharacterCreatorScene extends Phaser.Scene {
     // ── Difficulty row ────────────────────────────────────────────────────────
 
     _buildDifficultyRow(cx, W) {
-        this.add.rectangle(cx, 45, W - 20, 1, 0x1a1535);
-        this.add.text(18, 52, 'VANSKELIGHETSGRAD:', {
-            fontSize: '10px', color: '#445566', fontFamily: 'monospace'
+        this.add.rectangle(cx, 52, W - 40, 1, 0x1a1535);
+        this.add.text(30, 64, 'VANSKELIGHETSGRAD:', {
+            fontSize: '13px', color: '#445566', fontFamily: 'monospace'
         });
 
         const DIFFS = [
@@ -75,11 +75,11 @@ class CharacterCreatorScene extends Phaser.Scene {
         ];
         this._diffBtns = {};
         DIFFS.forEach(({ id, label, col }, i) => {
-            const bx  = 170 + i * 100;
-            const bg  = this.add.rectangle(bx, 57, 88, 18, 0x111122)
+            const bx  = 220 + i * 120;
+            const bg  = this.add.rectangle(bx, 66, 105, 24, 0x111122)
                 .setStrokeStyle(1, 0x334466).setInteractive({ useHandCursor: true });
-            const txt = this.add.text(bx, 57, label, {
-                fontSize: '11px', color: '#889aaa', fontFamily: 'monospace'
+            const txt = this.add.text(bx, 66, label, {
+                fontSize: '14px', color: '#889aaa', fontFamily: 'monospace'
             }).setOrigin(0.5);
             bg.on('pointerdown', () => this._selectDifficulty(id));
             this._diffBtns[id] = { bg, txt, col };
@@ -100,26 +100,26 @@ class CharacterCreatorScene extends Phaser.Scene {
     // ── Left panel: race selection + stats ────────────────────────────────────
 
     _buildRacePanel(W, H) {
-        const panelX = 18;
+        const panelX = 30;
         const races  = Object.keys(RACE_DEFS);
-        const btnW   = 100, btnH = 32;
+        const btnW   = 120, btnH = 38;
 
         this._raceBtns = {};
-        this.add.rectangle(panelX + races.length * (btnW + 6) / 2, 75, W / 2, 1, 0x1a1535);
+        this.add.rectangle(panelX + races.length * (btnW + 8) / 2, 90, W / 2, 1, 0x1a1535);
         races.forEach((id, i) => {
-            const bx  = panelX + i * (btnW + 6) + btnW / 2;
-            const btn = this._raceTab(bx, 88, btnW, btnH, RACE_DEFS[id].name, id);
+            const bx  = panelX + i * (btnW + 8) + btnW / 2;
+            const btn = this._raceTab(bx, 108, btnW, btnH, RACE_DEFS[id].name, id);
             this._raceBtns[id] = btn;
         });
 
-        this._statsY    = 116;
+        this._statsY    = 140;
         this._statsObjs = [];
         this._rebuildStats();
     }
 
     _raceTab(x, y, w, h, label, raceId) {
         const bg  = this.add.rectangle(x, y, w, h, 0x1a1535).setStrokeStyle(1, 0x4444aa).setInteractive({ useHandCursor: true });
-        const txt = this.add.text(x, y, label, { fontSize: '13px', color: '#cccccc', fontFamily: 'monospace' }).setOrigin(0.5);
+        const txt = this.add.text(x, y, label, { fontSize: '15px', color: '#cccccc', fontFamily: 'monospace' }).setOrigin(0.5);
         bg.on('pointerdown', () => this._selectRace(raceId));
         bg.on('pointerover', () => bg.setAlpha(0.8));
         bg.on('pointerout',  () => bg.setAlpha(1));
@@ -147,10 +147,10 @@ class CharacterCreatorScene extends Phaser.Scene {
         const def = RACE_DEFS[this.selectedRace];
         const add = o => { this._statsObjs.push(o); return o; };
         const y0  = this._statsY;
-        const lx  = 22;
+        const lx  = 34;
 
-        add(this.add.text(lx, y0, def.desc, { fontSize: '10px', color: '#8899bb', fontFamily: 'monospace', wordWrap: { width: 420 } }));
-        add(this.add.text(lx, y0 + 14, `Spesial: ${def.special}`, { fontSize: '10px', color: '#f5e642', fontFamily: 'monospace' }));
+        add(this.add.text(lx, y0, def.desc, { fontSize: '13px', color: '#8899bb', fontFamily: 'monospace', wordWrap: { width: 480 } }));
+        add(this.add.text(lx, y0 + 20, `Spesial: ${def.special}`, { fontSize: '13px', color: '#f5e642', fontFamily: 'monospace' }));
 
         const stats = [
             { label: 'Hjerter',  val: def.hearts,       max: 8,  col: 0xff2244 },
@@ -159,18 +159,18 @@ class CharacterCreatorScene extends Phaser.Scene {
             { label: 'Syn',      val: def.visionRadius,  max: 8,  col: 0xffee00 },
             { label: 'XP-mult',  val: def.xpMultiplier,  max: 2,  col: 0xaa44ff }
         ];
-        const barX = lx, bw = 190, bh = 8, gap = 17;
+        const barX = lx, bw = 220, bh = 12, gap = 24;
         stats.forEach(({ label, val, max, col }, i) => {
-            const y = y0 + 30 + i * gap;
-            add(this.add.text(barX, y, label, { fontSize: '10px', color: '#556677', fontFamily: 'monospace' }));
+            const y = y0 + 46 + i * gap;
+            add(this.add.text(barX, y, label, { fontSize: '13px', color: '#556677', fontFamily: 'monospace' }));
             const bg = add(this.add.graphics());
             bg.fillStyle(0x1a1535);
-            bg.fillRect(barX + 62, y, bw, bh);
+            bg.fillRect(barX + 80, y + 2, bw, bh);
             const fill = add(this.add.graphics());
             fill.fillStyle(col);
-            fill.fillRect(barX + 62, y, Math.floor(bw * (val / max)), bh);
+            fill.fillRect(barX + 80, y + 2, Math.floor(bw * (val / max)), bh);
             const valStr = label === 'XP-mult' ? `×${val.toFixed(2)}` : String(val);
-            add(this.add.text(barX + 62 + bw + 5, y, valStr, { fontSize: '10px', color: '#aabbcc', fontFamily: 'monospace' }));
+            add(this.add.text(barX + 80 + bw + 8, y, valStr, { fontSize: '13px', color: '#aabbcc', fontFamily: 'monospace' }));
         });
     }
 
@@ -187,26 +187,25 @@ class CharacterCreatorScene extends Phaser.Scene {
         this._appearObjs = [];
 
         const { width: W } = this.cameras.main;
-        const px = W - 380, py = 112;
+        const px = W - 420, py = 140;
         const add = o => { this._appearObjs.push(o); return o; };
 
-        add(this.add.text(px, py, 'UTSEENDE', { fontSize: '10px', color: '#445566', fontFamily: 'monospace' }));
+        add(this.add.text(px, py, 'UTSEENDE', { fontSize: '13px', color: '#445566', fontFamily: 'monospace' }));
 
         // ── Gender row ────────────────────────────────────────────────────────
-        let rowY = py + 18;
-        add(this.add.text(px, rowY, 'Kjønn:', { fontSize: '10px', color: '#667788', fontFamily: 'monospace' }));
+        let rowY = py + 24;
+        add(this.add.text(px, rowY, 'Kjønn:', { fontSize: '13px', color: '#667788', fontFamily: 'monospace' }));
         GENDERS.forEach((gid, i) => {
-            const bx  = px + 56 + i * 70;
+            const bx  = px + 70 + i * 80;
             const sel = this.appearance.gender === gid;
-            const bg  = this.add.rectangle(bx + 24, rowY + 7, 60, 18, sel ? 0x2a2060 : 0x111122)
+            const bg  = this.add.rectangle(bx + 28, rowY + 8, 70, 22, sel ? 0x2a2060 : 0x111122)
                 .setStrokeStyle(1, sel ? 0xf5e642 : 0x334455).setInteractive({ useHandCursor: true });
-            const txt = this.add.text(bx + 24, rowY + 7, GENDER_LABELS[gid], {
-                fontSize: '9px', color: sel ? '#f5e642' : '#778899', fontFamily: 'monospace'
+            const txt = this.add.text(bx + 28, rowY + 8, GENDER_LABELS[gid], {
+                fontSize: '12px', color: sel ? '#f5e642' : '#778899', fontFamily: 'monospace'
             }).setOrigin(0.5);
             bg.on('pointerdown', () => {
                 this._customOverrides.gender = gid;
                 this.appearance.gender = gid;
-                // Reset beard for female
                 if (gid === 'female' && this.appearance.beardStyle !== 'none') {
                     this._customOverrides.beardStyle = 'none';
                     this.appearance.beardStyle = 'none';
@@ -219,51 +218,51 @@ class CharacterCreatorScene extends Phaser.Scene {
         });
 
         // ── Skin tone row ─────────────────────────────────────────────────────
-        rowY += 24;
-        add(this.add.text(px, rowY, 'Hud:', { fontSize: '10px', color: '#667788', fontFamily: 'monospace' }));
+        rowY += 32;
+        add(this.add.text(px, rowY, 'Hud:', { fontSize: '13px', color: '#667788', fontFamily: 'monospace' }));
         SKIN_TONES.forEach((col, i) => {
-            const btn = this._colorDot(px + 44 + i * 26, rowY + 5, col, this.appearance.skinColor === col);
+            const btn = this._colorDot(px + 52 + i * 30, rowY + 7, col, this.appearance.skinColor === col);
             btn.on('pointerdown', () => { this._customOverrides.skinColor = col; this.appearance.skinColor = col; this._rebuildPreview(); this._rebuildAppearancePickers(); });
             add(btn);
         });
 
         // ── Hair color row ────────────────────────────────────────────────────
-        rowY += 24;
-        add(this.add.text(px, rowY, 'Hår:', { fontSize: '10px', color: '#667788', fontFamily: 'monospace' }));
+        rowY += 32;
+        add(this.add.text(px, rowY, 'Hår:', { fontSize: '13px', color: '#667788', fontFamily: 'monospace' }));
         HAIR_COLORS.forEach((col, i) => {
-            const btn = this._colorDot(px + 44 + i * 24, rowY + 5, col, this.appearance.hairColor === col);
+            const btn = this._colorDot(px + 52 + i * 28, rowY + 7, col, this.appearance.hairColor === col);
             btn.on('pointerdown', () => { this._customOverrides.hairColor = col; this.appearance.hairColor = col; this._rebuildPreview(); this._rebuildAppearancePickers(); });
             add(btn);
         });
 
         // ── Eye color row ─────────────────────────────────────────────────────
-        rowY += 24;
-        add(this.add.text(px, rowY, 'Øyne:', { fontSize: '10px', color: '#667788', fontFamily: 'monospace' }));
+        rowY += 32;
+        add(this.add.text(px, rowY, 'Øyne:', { fontSize: '13px', color: '#667788', fontFamily: 'monospace' }));
         EYE_COLORS.forEach((col, i) => {
-            const btn = this._colorDot(px + 52 + i * 26, rowY + 5, col, this.appearance.eyeColor === col);
+            const btn = this._colorDot(px + 60 + i * 30, rowY + 7, col, this.appearance.eyeColor === col);
             btn.on('pointerdown', () => { this._customOverrides.eyeColor = col; this.appearance.eyeColor = col; this._rebuildPreview(); this._rebuildAppearancePickers(); });
             add(btn);
         });
 
         // ── Cloth color row ───────────────────────────────────────────────────
-        rowY += 24;
-        add(this.add.text(px, rowY, 'Farge:', { fontSize: '10px', color: '#667788', fontFamily: 'monospace' }));
+        rowY += 32;
+        add(this.add.text(px, rowY, 'Farge:', { fontSize: '13px', color: '#667788', fontFamily: 'monospace' }));
         CLOTH_COLORS.forEach((col, i) => {
-            const btn = this._colorDot(px + 52 + i * 22, rowY + 5, col, this.appearance.clothColor === col);
+            const btn = this._colorDot(px + 60 + i * 26, rowY + 7, col, this.appearance.clothColor === col);
             btn.on('pointerdown', () => { this._customOverrides.clothColor = col; this.appearance.clothColor = col; this._rebuildPreview(); this._rebuildAppearancePickers(); });
             add(btn);
         });
 
         // ── Clothing style row ────────────────────────────────────────────────
-        rowY += 24;
-        add(this.add.text(px, rowY, 'Drakt:', { fontSize: '10px', color: '#667788', fontFamily: 'monospace' }));
+        rowY += 32;
+        add(this.add.text(px, rowY, 'Drakt:', { fontSize: '13px', color: '#667788', fontFamily: 'monospace' }));
         CLOTH_STYLES.forEach((style, i) => {
-            const bx  = px + 52 + i * 58;
+            const bx  = px + 60 + i * 68;
             const sel = this.appearance.clothStyle === style;
-            const bg  = this.add.rectangle(bx + 22, rowY + 7, 52, 18, sel ? 0x2a2060 : 0x111122)
+            const bg  = this.add.rectangle(bx + 26, rowY + 8, 60, 22, sel ? 0x2a2060 : 0x111122)
                 .setStrokeStyle(1, sel ? 0xf5e642 : 0x334455).setInteractive({ useHandCursor: true });
-            const txt = this.add.text(bx + 22, rowY + 7, CLOTH_STYLE_LABELS[style], {
-                fontSize: '9px', color: sel ? '#f5e642' : '#778899', fontFamily: 'monospace'
+            const txt = this.add.text(bx + 26, rowY + 8, CLOTH_STYLE_LABELS[style], {
+                fontSize: '11px', color: sel ? '#f5e642' : '#778899', fontFamily: 'monospace'
             }).setOrigin(0.5);
             bg.on('pointerdown', () => {
                 this._customOverrides.clothStyle = style;
@@ -277,20 +276,19 @@ class CharacterCreatorScene extends Phaser.Scene {
 
         // ── Hair style row (not for dwarf) ────────────────────────────────────
         if (this.selectedRace !== 'dwarf') {
-            rowY += 26;
-            add(this.add.text(px, rowY, 'Frisyre:', { fontSize: '10px', color: '#667788', fontFamily: 'monospace' }));
-            // Show 5 styles per row to fit
+            rowY += 32;
+            add(this.add.text(px, rowY, 'Frisyre:', { fontSize: '13px', color: '#667788', fontFamily: 'monospace' }));
             const stylesPerRow = 5;
             HAIR_STYLES.forEach((style, i) => {
                 const row = Math.floor(i / stylesPerRow);
                 const col = i % stylesPerRow;
-                const bx  = px + 60 + col * 56;
-                const by  = rowY + 7 + row * 22;
+                const bx  = px + 70 + col * 62;
+                const by  = rowY + 8 + row * 28;
                 const sel = this.appearance.hairStyle === style;
-                const bg  = this.add.rectangle(bx + 22, by, 50, 18, sel ? 0x2a2060 : 0x111122)
+                const bg  = this.add.rectangle(bx + 24, by, 56, 22, sel ? 0x2a2060 : 0x111122)
                     .setStrokeStyle(1, sel ? 0xf5e642 : 0x334455).setInteractive({ useHandCursor: true });
-                const txt = this.add.text(bx + 22, by, HAIR_STYLE_LABELS[style], {
-                    fontSize: '8px', color: sel ? '#f5e642' : '#778899', fontFamily: 'monospace'
+                const txt = this.add.text(bx + 24, by, HAIR_STYLE_LABELS[style], {
+                    fontSize: '11px', color: sel ? '#f5e642' : '#778899', fontFamily: 'monospace'
                 }).setOrigin(0.5);
                 bg.on('pointerdown', () => {
                     this._customOverrides.hairStyle = style;
@@ -301,22 +299,22 @@ class CharacterCreatorScene extends Phaser.Scene {
                 add(bg);
                 add(txt);
             });
-            rowY += Math.ceil(HAIR_STYLES.length / stylesPerRow) * 22;
+            rowY += Math.ceil(HAIR_STYLES.length / stylesPerRow) * 28;
         }
 
         // ── Beard style row (male human / dwarf only) ─────────────────────────
         const showBeard = (this.selectedRace === 'human' || this.selectedRace === 'dwarf') &&
                           this.appearance.gender !== 'female';
         if (showBeard) {
-            rowY += 4;
-            add(this.add.text(px, rowY, 'Skjegg:', { fontSize: '10px', color: '#667788', fontFamily: 'monospace' }));
+            rowY += 6;
+            add(this.add.text(px, rowY, 'Skjegg:', { fontSize: '13px', color: '#667788', fontFamily: 'monospace' }));
             BEARD_STYLES.forEach((style, i) => {
-                const bx  = px + 56 + i * 60;
+                const bx  = px + 70 + i * 70;
                 const sel = this.appearance.beardStyle === style;
-                const bg  = this.add.rectangle(bx + 20, rowY + 7, 54, 18, sel ? 0x2a2060 : 0x111122)
+                const bg  = this.add.rectangle(bx + 24, rowY + 8, 62, 22, sel ? 0x2a2060 : 0x111122)
                     .setStrokeStyle(1, sel ? 0xf5e642 : 0x334455).setInteractive({ useHandCursor: true });
-                const txt = this.add.text(bx + 20, rowY + 7, BEARD_STYLE_LABELS[style], {
-                    fontSize: '9px', color: sel ? '#f5e642' : '#778899', fontFamily: 'monospace'
+                const txt = this.add.text(bx + 24, rowY + 8, BEARD_STYLE_LABELS[style], {
+                    fontSize: '11px', color: sel ? '#f5e642' : '#778899', fontFamily: 'monospace'
                 }).setOrigin(0.5);
                 bg.on('pointerdown', () => {
                     this._customOverrides.beardStyle = style;
@@ -333,7 +331,7 @@ class CharacterCreatorScene extends Phaser.Scene {
     }
 
     _colorDot(x, y, color, selected) {
-        const r = 9;
+        const r = 10;
         const g = this.add.graphics();
         g.fillStyle(color);
         g.fillCircle(x, y, r);
@@ -352,12 +350,11 @@ class CharacterCreatorScene extends Phaser.Scene {
 
         const previewSize = 256;
         const px = W - 160;
-        const py = H - 420;
+        const py = H - 380;
 
         // Preview box background
         g.fillStyle(0x0d0b1e, 0.95);
         g.fillRoundedRect(px - previewSize / 2 - 8, py - 8, previewSize + 16, previewSize + 16, 6);
-        // Double border
         g.lineStyle(2, 0x4444aa, 0.6);
         g.strokeRoundedRect(px - previewSize / 2 - 8, py - 8, previewSize + 16, previewSize + 16, 6);
         g.lineStyle(1, 0x2a2050, 0.4);
@@ -373,33 +370,28 @@ class CharacterCreatorScene extends Phaser.Scene {
         } else {
             drawCharacterSprite(g, px - previewSize / 2, py, previewSize, this.appearance, this.selectedRace);
         }
-
-        // Label below preview
-        g.fillStyle(0x000000, 0);
-        const raceName = RACE_DEFS[this.selectedRace]?.name || '';
-        // Race label is handled by text objects in stats panel
     }
 
     // ── Starting bonus panel ──────────────────────────────────────────────────
 
     _buildBonusPanel(W, H) {
-        const lx = 22, by = this._statsY + 120;
+        const lx = 34, by = this._statsY + 180;
 
-        this.add.rectangle(W / 4, by - 6, W / 2 - 10, 1, 0x1a1535);
+        this.add.rectangle(W / 4, by - 8, W / 2 - 20, 1, 0x1a1535);
         this.add.text(lx, by, 'STARTBONUS  (velg én)', {
-            fontSize: '10px', color: '#445566', fontFamily: 'monospace'
+            fontSize: '13px', color: '#445566', fontFamily: 'monospace'
         });
 
         this._bonusBtns = {};
         START_BONUSES.forEach(({ id, label, desc, col }, i) => {
-            const bx  = lx + i * 150 + 60;
-            const bg  = this.add.rectangle(bx, by + 26, 138, 32, 0x111122)
+            const bx  = lx + i * 170 + 72;
+            const bg  = this.add.rectangle(bx, by + 32, 155, 40, 0x111122)
                 .setStrokeStyle(1, 0x334466).setInteractive({ useHandCursor: true });
-            const lbl = this.add.text(bx, by + 20, label, {
-                fontSize: '12px', color: '#aabbcc', fontFamily: 'monospace', fontStyle: 'bold'
+            const lbl = this.add.text(bx, by + 25, label, {
+                fontSize: '14px', color: '#aabbcc', fontFamily: 'monospace', fontStyle: 'bold'
             }).setOrigin(0.5);
-            const dsc = this.add.text(bx, by + 32, desc, {
-                fontSize: '9px', color: '#556677', fontFamily: 'monospace'
+            const dsc = this.add.text(bx, by + 40, desc, {
+                fontSize: '11px', color: '#556677', fontFamily: 'monospace'
             }).setOrigin(0.5);
             bg.on('pointerdown', () => this._selectBonus(id));
             bg.on('pointerover',  () => { if (this.selectedBonus !== id) bg.setFillStyle(0x1a1a33); });
@@ -423,12 +415,12 @@ class CharacterCreatorScene extends Phaser.Scene {
     // ── Name input ────────────────────────────────────────────────────────────
 
     _buildNameAndStart(cx, W, H) {
-        const nameY = H - 80;
-        this.add.rectangle(cx, nameY, W - 20, 1, 0x1a1535);
-        this.add.text(22, nameY + 12, 'Navn:', { fontSize: '12px', color: '#667788', fontFamily: 'monospace' }).setOrigin(0, 0.5);
+        const nameY = H - 100;
+        this.add.rectangle(cx, nameY, W - 40, 1, 0x1a1535);
+        this.add.text(34, nameY + 18, 'Navn:', { fontSize: '15px', color: '#667788', fontFamily: 'monospace' }).setOrigin(0, 0.5);
 
-        this._nameBg  = this.add.rectangle(cx + 40, nameY + 12, 240, 28, 0x1a1830).setStrokeStyle(1, 0x4444aa);
-        this._nameTxt = this.add.text(cx + 40, nameY + 12, '|', { fontSize: '15px', color: '#ffffff', fontFamily: 'monospace' }).setOrigin(0.5);
+        this._nameBg  = this.add.rectangle(cx + 40, nameY + 18, 280, 34, 0x1a1830).setStrokeStyle(1, 0x4444aa);
+        this._nameTxt = this.add.text(cx + 40, nameY + 18, '|', { fontSize: '18px', color: '#ffffff', fontFamily: 'monospace' }).setOrigin(0.5);
 
         this._nameBg.setInteractive({ useHandCursor: true });
         this._nameBg.on('pointerdown', () => this._openMobileNameInput());
@@ -439,8 +431,8 @@ class CharacterCreatorScene extends Phaser.Scene {
             this._nameTxt.setText((this.heroName || '') + (this._cursor ? '|' : ' '));
         }});
 
-        const startBtn = this.add.text(cx, H - 36, '[ START EVENTYR ]', {
-            fontSize: '22px', color: '#00e87a', fontFamily: 'monospace'
+        const startBtn = this.add.text(cx, H - 40, '[ START EVENTYR ]', {
+            fontSize: '26px', color: '#00e87a', fontFamily: 'monospace'
         }).setOrigin(0.5).setInteractive({ useHandCursor: true });
         startBtn.on('pointerover', () => startBtn.setAlpha(0.7));
         startBtn.on('pointerout',  () => startBtn.setAlpha(1));
@@ -468,7 +460,7 @@ class CharacterCreatorScene extends Phaser.Scene {
             inp.maxLength = 14;
             inp.autocomplete = 'off';
             inp.style.cssText = 'position:fixed;top:40%;left:50%;transform:translate(-50%,-50%);' +
-                'font-size:18px;font-family:monospace;padding:8px 12px;width:240px;' +
+                'font-size:20px;font-family:monospace;padding:10px 16px;width:280px;' +
                 'background:#1a1830;color:#ffffff;border:2px solid #4444aa;border-radius:6px;' +
                 'text-align:center;z-index:9999;outline:none;';
             document.body.appendChild(inp);

--- a/src/scenes/ChemLabScene.js
+++ b/src/scenes/ChemLabScene.js
@@ -69,7 +69,7 @@ class ChemLabScene extends Phaser.Scene {
         // Fuel indicator
         const fuel = this.smelter.calculateFuelEnergy(this.heroRef);
         this._fuelText = this.add.text(this.px + this.panelW - 20, this.py + 18, `Energi: ${fuel}`, {
-            fontSize: '10px', color: '#448844', fontFamily: 'monospace'
+            fontSize: '12px', color: '#448844', fontFamily: 'monospace'
         }).setOrigin(1, 0.5);
 
         this.add.rectangle(cx, this.py + 34, this.panelW - 20, 1, 0x113322);
@@ -88,7 +88,7 @@ class ChemLabScene extends Phaser.Scene {
             const fx = this.px + 30 + i * 100 + 45;
             const active = this._filter === f.id;
             const btn = this.add.text(fx, filterY, f.label, {
-                fontSize: '10px', color: active ? '#33dd88' : '#335533',
+                fontSize: '12px', color: active ? '#33dd88' : '#335533',
                 fontFamily: 'monospace', fontStyle: active ? 'bold' : 'normal'
             }).setOrigin(0.5).setInteractive({ useHandCursor: true });
             btn.on('pointerdown', () => { this._filter = f.id; this._refresh(); });
@@ -153,7 +153,7 @@ class ChemLabScene extends Phaser.Scene {
 
         if (allMols.length === 0) {
             this._d(this.add.text(cx, y + 40, 'Ingen oppskrifter tilgjengelig.', {
-                fontSize: '11px', color: '#334433', fontFamily: 'monospace'
+                fontSize: '13px', color: '#334433', fontFamily: 'monospace'
             }).setOrigin(0.5));
         }
 
@@ -178,10 +178,10 @@ class ChemLabScene extends Phaser.Scene {
 
             // Name + formula
             this._d(this.add.text(leftX + 24, my + 5, `${m.name}`, {
-                fontSize: '11px', color: hexCol, fontFamily: 'monospace', fontStyle: 'bold'
+                fontSize: '13px', color: hexCol, fontFamily: 'monospace', fontStyle: 'bold'
             }));
             this._d(this.add.text(leftX + 24, my + 19, `${m.formula}  [T${m.tier}]`, {
-                fontSize: '8px', color: '#556655', fontFamily: 'monospace'
+                fontSize: '12px', color: '#556655', fontFamily: 'monospace'
             }));
 
             // Recipe elements
@@ -191,17 +191,17 @@ class ChemLabScene extends Phaser.Scene {
                 return `${r.symbol}:${have}/${r.amount}${ok ? '' : '!'}`;
             }).join('  ');
             this._d(this.add.text(leftX + 6, my + 33, recipeStr, {
-                fontSize: '8px', color: '#556655', fontFamily: 'monospace'
+                fontSize: '12px', color: '#556655', fontFamily: 'monospace'
             }));
 
             // Effect preview
             this._d(this.add.text(leftX + colW - 8, my + 36, m.desc.length > 35 ? m.desc.slice(0, 33) + '…' : m.desc, {
-                fontSize: '7px', color: '#445544', fontFamily: 'monospace'
+                fontSize: '12px', color: '#445544', fontFamily: 'monospace'
             }).setOrigin(1, 0));
 
             if (can) {
                 const btn = this._d(this.add.text(leftX + colW - 50, my + 10, '[ Lag ]', {
-                    fontSize: '11px', color: '#33dd88', fontFamily: 'monospace', fontStyle: 'bold'
+                    fontSize: '13px', color: '#33dd88', fontFamily: 'monospace', fontStyle: 'bold'
                 }).setInteractive({ useHandCursor: true }));
                 btn.on('pointerover', () => btn.setColor('#66ffaa'));
                 btn.on('pointerout', () => btn.setColor('#33dd88'));
@@ -243,14 +243,14 @@ class ChemLabScene extends Phaser.Scene {
 
     _drawElementCounts(x, y, w) {
         this._d(this.add.text(x, y, 'GRUNNSTOFFER:', {
-            fontSize: '9px', color: '#556655', fontFamily: 'monospace', fontStyle: 'bold'
+            fontSize: '13px', color: '#556655', fontFamily: 'monospace', fontStyle: 'bold'
         }));
 
         const collected = this.heroRef.elementTracker.collected;
         const entries = Object.entries(collected).filter(([, v]) => v > 0);
         if (entries.length === 0) {
             this._d(this.add.text(x, y + 14, 'Ingen lagret.', {
-                fontSize: '9px', color: '#334433', fontFamily: 'monospace'
+                fontSize: '13px', color: '#334433', fontFamily: 'monospace'
             }));
             return;
         }
@@ -261,7 +261,7 @@ class ChemLabScene extends Phaser.Scene {
             const col = elem ? elem.color : 0xaaaaaa;
             const hexCol = '#' + col.toString(16).padStart(6, '0');
             const badge = this._d(this.add.text(bx, by, `${symbol}:${count}`, {
-                fontSize: '9px', color: hexCol, fontFamily: 'monospace',
+                fontSize: '13px', color: hexCol, fontFamily: 'monospace',
                 backgroundColor: '#081808', padding: { x: 3, y: 1 }
             }));
             bx += badge.width + 6;

--- a/src/scenes/ElementBookScene.js
+++ b/src/scenes/ElementBookScene.js
@@ -39,7 +39,7 @@ class ElementBookScene extends Phaser.Scene {
         }).setOrigin(0.5);
 
         this.add.text(cx, py + 36, `Oppdaget: ${discovered}/${total} grunnstoffer`, {
-            fontSize: '11px', color: '#887766', fontFamily: 'monospace'
+            fontSize: '13px', color: '#887766', fontFamily: 'monospace'
         }).setOrigin(0.5);
 
         this.add.rectangle(cx, py + 48, panelW - 30, 1, 0x2a2060);
@@ -54,7 +54,7 @@ class ElementBookScene extends Phaser.Scene {
 
         // Tooltip text (shown on hover)
         this.tooltipText = this.add.text(cx, py + panelH - 40, '', {
-            fontSize: '11px', color: '#bbaa99', fontFamily: 'monospace',
+            fontSize: '13px', color: '#bbaa99', fontFamily: 'monospace',
             align: 'center', wordWrap: { width: panelW - 40 }
         }).setOrigin(0.5);
 
@@ -98,7 +98,7 @@ class ElementBookScene extends Phaser.Scene {
                 // Atomic number
                 const numHex = '#' + (catCol).toString(16).padStart(6, '0');
                 this.add.text(cellX + 3, cellY + 2, `${elem.atomicNumber}`, {
-                    fontSize: '7px', color: numHex, fontFamily: 'monospace'
+                    fontSize: '13px', color: numHex, fontFamily: 'monospace'
                 });
 
                 // Symbol
@@ -152,7 +152,7 @@ class ElementBookScene extends Phaser.Scene {
             const startBX = cx - bonusW / 2 + 60;
 
             this.add.text(cx, bonusY - 4, 'GRUPPEPRESTASJONER', {
-                fontSize: '9px', color: '#555544', fontFamily: 'monospace'
+                fontSize: '13px', color: '#555544', fontFamily: 'monospace'
             }).setOrigin(0.5);
 
             ELEMENT_BONUSES.forEach((bonus, i) => {
@@ -161,10 +161,10 @@ class ElementBookScene extends Phaser.Scene {
                 const col = completed ? '#ffcc44' : '#333344';
                 const icon = completed ? '★' : '○';
                 this.add.text(bx, bonusY + 10, `${icon} ${bonus.name}`, {
-                    fontSize: '8px', color: col, fontFamily: 'monospace'
+                    fontSize: '10px', color: col, fontFamily: 'monospace'
                 }).setOrigin(0.5);
                 this.add.text(bx, bonusY + 22, bonus.desc, {
-                    fontSize: '7px', color: completed ? '#887766' : '#222233', fontFamily: 'monospace'
+                    fontSize: '13px', color: completed ? '#887766' : '#222233', fontFamily: 'monospace'
                 }).setOrigin(0.5);
             });
         }

--- a/src/scenes/InventoryScene.js
+++ b/src/scenes/InventoryScene.js
@@ -31,22 +31,22 @@ class InventoryScene extends Phaser.Scene {
         // Title shifted right to make room for portrait
         const contentCX = cx + 100;
         this.add.text(contentCX, panelY - panelH / 2 + 18, 'INVENTAR', {
-            fontSize: '20px', color: '#ccddff', fontFamily: 'monospace', fontStyle: 'bold'
+            fontSize: '22px', color: '#ccddff', fontFamily: 'monospace', fontStyle: 'bold'
         }).setOrigin(0.5);
 
         this.add.rectangle(contentCX, panelY - panelH / 2 + 54, panelW - 250, 1, 0x223344);
 
         // Stats line – dynamic so it refreshes
         this._statsText = this.add.text(contentCX, panelY - panelH / 2 + 40, '', {
-            fontSize: '11px', color: '#667788', fontFamily: 'monospace'
+            fontSize: '13px', color: '#667788', fontFamily: 'monospace'
         }).setOrigin(0.5);
 
         // Section labels (static) - shifted right
         this.add.text(contentCX - 220, panelY - panelH / 2 + 62, 'UTSTYR', {
-            fontSize: '11px', color: '#445566', fontFamily: 'monospace'
+            fontSize: '13px', color: '#445566', fontFamily: 'monospace'
         });
         this.add.text(contentCX, panelY - panelH / 2 + 168, 'EVNER', {
-            fontSize: '11px', color: '#445566', fontFamily: 'monospace'
+            fontSize: '13px', color: '#445566', fontFamily: 'monospace'
         }).setOrigin(0.5);
         // RYGGSEKK label is drawn dynamically in _refresh() to show slot count
 
@@ -54,12 +54,12 @@ class InventoryScene extends Phaser.Scene {
             ? '[Trykk] Bruk/utstyr  ·  [Hold] → Kjæledyr/Slipp  ·  [E/ESC] Lukk'
             : '[Trykk] Bruk/utstyr  ·  [Hold] Slipp  ·  [E/ESC] Lukk';
         this.add.text(cx, panelY + panelH / 2 - 14, helpText, {
-            fontSize: '11px', color: '#334455', fontFamily: 'monospace'
+            fontSize: '13px', color: '#334455', fontFamily: 'monospace'
         }).setOrigin(0.5);
 
         // Element Book button
         const ebBtn = this.add.text(cx - panelW / 2 + 20, cy - panelH / 2 + 18, 'Elementbok [B]', {
-            fontSize: '10px', color: '#997755', fontFamily: 'monospace'
+            fontSize: '12px', color: '#997755', fontFamily: 'monospace'
         }).setOrigin(0, 0.5).setInteractive({ useHandCursor: true });
         ebBtn.on('pointerover', () => ebBtn.setColor('#ccaa77'));
         ebBtn.on('pointerout',  () => ebBtn.setColor('#997755'));
@@ -134,7 +134,7 @@ class InventoryScene extends Phaser.Scene {
         // Pet portrait is drawn inline with pet inventory section (see _drawPetInventory)
         // Hero name under portrait
         this._d(this.add.text(portraitX + portraitSize / 2, portraitY + portraitSize + 10, h.heroName || 'Helten', {
-            fontSize: '11px', color: '#8899bb', fontFamily: 'monospace'
+            fontSize: '13px', color: '#8899bb', fontFamily: 'monospace'
         }).setOrigin(0.5));
 
         // Equipment slots (shifted right to leave room for portrait)
@@ -149,7 +149,7 @@ class InventoryScene extends Phaser.Scene {
         // Backpack label with count
         this._d(this.add.text(contentCX + 80, panelY - panelH / 2 + 220,
             `(${this.inv.itemCount}/10)`, {
-            fontSize: '11px', color: '#334455', fontFamily: 'monospace'
+            fontSize: '13px', color: '#334455', fontFamily: 'monospace'
         }));
 
         // Backpack slots (dynamic size – base 10 + skill expansions)
@@ -161,7 +161,7 @@ class InventoryScene extends Phaser.Scene {
 
         const bpLabel = `RYGGSEKK (${this.inv.itemCount}/${bpCount})`;
         this._d(this.add.text(contentCX - 220, bpY - 22, bpLabel, {
-            fontSize: '11px', color: '#445566', fontFamily: 'monospace'
+            fontSize: '13px', color: '#445566', fontFamily: 'monospace'
         }));
 
         for (let i = 0; i < bpCount; i++) {
@@ -208,13 +208,13 @@ class InventoryScene extends Phaser.Scene {
         ));
 
         this._d(this.add.text(x, y + size / 2 + 10, label, {
-            fontSize: '10px', color: '#445566', fontFamily: 'monospace'
+            fontSize: '12px', color: '#445566', fontFamily: 'monospace'
         }).setOrigin(0.5));
 
         if (item) {
             this._drawItemIcon(x, y, item, size - 12);
             this._d(this.add.text(x, y - size / 2 - 10, item.name, {
-                fontSize: '10px', color: this._rarityTextColor(item), fontFamily: 'monospace'
+                fontSize: '12px', color: this._rarityTextColor(item), fontFamily: 'monospace'
             }).setOrigin(0.5));
 
             bg.setInteractive({ useHandCursor: true });
@@ -248,7 +248,7 @@ class InventoryScene extends Phaser.Scene {
             });
         } else {
             this._d(this.add.text(x, y, 'Tom', {
-                fontSize: '11px', color: '#223344', fontFamily: 'monospace'
+                fontSize: '13px', color: '#223344', fontFamily: 'monospace'
             }).setOrigin(0.5));
         }
     }
@@ -270,14 +270,14 @@ class InventoryScene extends Phaser.Scene {
         ));
 
         this._d(this.add.text(x, y + size / 2 + 10, 'Hurtig (Q)', {
-            fontSize: '10px', color: '#33aa88', fontFamily: 'monospace'
+            fontSize: '12px', color: '#33aa88', fontFamily: 'monospace'
         }).setOrigin(0.5));
 
         if (itemDef) {
             this._drawItemIcon(x, y, itemDef, size - 12);
             const label = qu.count > 1 ? `${itemDef.name} ×${qu.count}` : itemDef.name;
             this._d(this.add.text(x, y - size / 2 - 10, label, {
-                fontSize: '10px', color: '#ccddff', fontFamily: 'monospace'
+                fontSize: '12px', color: '#ccddff', fontFamily: 'monospace'
             }).setOrigin(0.5));
 
             bg.setInteractive({ useHandCursor: true });
@@ -311,7 +311,7 @@ class InventoryScene extends Phaser.Scene {
             });
         } else {
             this._d(this.add.text(x, y, 'Tom', {
-                fontSize: '11px', color: '#223344', fontFamily: 'monospace'
+                fontSize: '13px', color: '#223344', fontFamily: 'monospace'
             }).setOrigin(0.5));
         }
     }
@@ -343,13 +343,13 @@ class InventoryScene extends Phaser.Scene {
                 ? '#' + (MINERAL_TIER_COLORS[itemDef.tier] || 0x997755).toString(16).padStart(6, '0')
                 : this._rarityTextColor(itemDef);
             this._d(this.add.text(x, y + size / 2 - 2, this._shortName(itemDef.name), {
-                fontSize: '8px', color: nameCol, fontFamily: 'monospace'
+                fontSize: '12px', color: nameCol, fontFamily: 'monospace'
             }).setOrigin(0.5, 1));
 
             // Stack count badge
             if (count > 1) {
                 this._d(this.add.text(x + size / 2 - 4, y - size / 2 + 2, `${count}`, {
-                    fontSize: '10px', color: '#ffee88', fontFamily: 'monospace', fontStyle: 'bold'
+                    fontSize: '12px', color: '#ffee88', fontFamily: 'monospace', fontStyle: 'bold'
                 }).setOrigin(1, 0));
             }
 
@@ -425,11 +425,11 @@ class InventoryScene extends Phaser.Scene {
         const labelX = petPortX + petPortSize + 12;
         const hpText = `${pet.petName}  HP: ${pet.hp}/${pet.effectiveMaxHp}  ATK: ${pet.effectiveAttack}`;
         this._d(this.add.text(labelX, baseY, `KJÆLEDYR  ·  ${hpText}`, {
-            fontSize: '11px', color: '#ffaadd', fontFamily: 'monospace'
+            fontSize: '13px', color: '#ffaadd', fontFamily: 'monospace'
         }));
         this._d(this.add.text(cx + panelW / 2 - 20, baseY,
             `(${pet.backpackCount}/4)`, {
-            fontSize: '11px', color: '#334455', fontFamily: 'monospace'
+            fontSize: '13px', color: '#334455', fontFamily: 'monospace'
         }).setOrigin(1, 0));
 
         // Pet backpack slots (4 slots in a row, to the right of portrait)
@@ -468,12 +468,12 @@ class InventoryScene extends Phaser.Scene {
             this._drawItemIcon(x, y, itemDef, size - 10);
             const nameCol = this._rarityTextColor(itemDef);
             this._d(this.add.text(x, y + size / 2 - 2, this._shortName(itemDef.name), {
-                fontSize: '8px', color: nameCol, fontFamily: 'monospace'
+                fontSize: '12px', color: nameCol, fontFamily: 'monospace'
             }).setOrigin(0.5, 1));
 
             if (count > 1) {
                 this._d(this.add.text(x + size / 2 - 4, y - size / 2 + 2, `${count}`, {
-                    fontSize: '10px', color: '#ffee88', fontFamily: 'monospace', fontStyle: 'bold'
+                    fontSize: '12px', color: '#ffee88', fontFamily: 'monospace', fontStyle: 'bold'
                 }).setOrigin(1, 0));
             }
 
@@ -532,7 +532,7 @@ class InventoryScene extends Phaser.Scene {
         const entries = Object.entries(counts);
         if (entries.length === 0) {
             this._d(this.add.text(cx, y, 'Ingen evner ennå', {
-                fontSize: '11px', color: '#334455', fontFamily: 'monospace'
+                fontSize: '13px', color: '#334455', fontFamily: 'monospace'
             }).setOrigin(0.5));
             return;
         }
@@ -547,7 +547,7 @@ class InventoryScene extends Phaser.Scene {
                 cx - totalW / 2 + 44 + (i % 5) * 90,
                 y + Math.floor(i / 5) * 16,
                 lbl,
-                { fontSize: '10px', fontFamily: 'monospace', color: col }
+                { fontSize: '12px', fontFamily: 'monospace', color: col }
             ));
         });
     }
@@ -676,7 +676,7 @@ class InventoryScene extends Phaser.Scene {
         const lines = [rarTag + item.name, item.desc || ''];
         const txtCol = this._rarityTextColor(item);
         this._tooltip = this.add.text(x, y, lines.join('\n'), {
-            fontSize: '10px', color: txtCol, fontFamily: 'monospace',
+            fontSize: '12px', color: txtCol, fontFamily: 'monospace',
             backgroundColor: '#0a0918', padding: { x: 6, y: 4 },
             stroke: '#334466', strokeThickness: 1
         }).setOrigin(0.5, 1).setDepth(30);

--- a/src/scenes/LeaderboardScene.js
+++ b/src/scenes/LeaderboardScene.js
@@ -65,13 +65,13 @@ class LeaderboardScene extends Phaser.Scene {
             { id: 'hard', label: 'Vanskelig' },
         ];
 
-        const ts = { fontSize: '10px', color: '#556677', fontFamily: 'monospace' };
+        const ts = { fontSize: '12px', color: '#556677', fontFamily: 'monospace' };
         this.add.text(cx - 200, y, 'Rase:', ts);
 
         let rx = cx - 165;
         for (const r of RACES) {
             const btn = this.add.text(rx, y, `[${r.label}]`, {
-                fontSize: '10px', color: this._filterRace === r.id ? '#f5e642' : '#667788',
+                fontSize: '12px', color: this._filterRace === r.id ? '#f5e642' : '#667788',
                 fontFamily: 'monospace'
             }).setInteractive({ useHandCursor: true });
             btn.on('pointerdown', () => {
@@ -85,7 +85,7 @@ class LeaderboardScene extends Phaser.Scene {
         let dx = cx + 75;
         for (const d of DIFFS) {
             const btn = this.add.text(dx, y, `[${d.label}]`, {
-                fontSize: '10px', color: this._filterDiff === d.id ? '#f5e642' : '#667788',
+                fontSize: '12px', color: this._filterDiff === d.id ? '#f5e642' : '#667788',
                 fontFamily: 'monospace'
             }).setInteractive({ useHandCursor: true });
             btn.on('pointerdown', () => {
@@ -113,7 +113,7 @@ class LeaderboardScene extends Phaser.Scene {
         }
 
         // Header
-        const hdrStyle = { fontSize: '10px', color: '#556677', fontFamily: 'monospace' };
+        const hdrStyle = { fontSize: '12px', color: '#556677', fontFamily: 'monospace' };
         const cols = [cx - 215, cx - 150, cx - 85, cx - 30, cx + 15, cx + 60, cx + 110, cx + 160];
         ['#', 'Navn', 'Rase', 'Verden', 'Niv\u00e5', 'Drap', 'Gull', 'Tid'].forEach((h, i) => {
             this._dyn.push(this.add.text(cols[i], y0, h, hdrStyle));
@@ -133,12 +133,12 @@ class LeaderboardScene extends Phaser.Scene {
             if (ry < y0 + 10 || ry > H - 50) continue; // clip rows outside visible area
             const isTop3 = i < 3;
             const col = isTop3 ? ['#f5e642', '#cccccc', '#cc8844'][i] : '#667788';
-            const style = { fontSize: '11px', color: col, fontFamily: 'monospace' };
+            const style = { fontSize: '13px', color: col, fontFamily: 'monospace' };
 
             const medal = i === 0 ? '1.' : i === 1 ? '2.' : i === 2 ? '3.' : `${i + 1}.`;
             this._dyn.push(this.add.text(cols[0], ry, medal, style));
             this._dyn.push(this.add.text(cols[1], ry, s.heroName || 'Helt', style));
-            this._dyn.push(this.add.text(cols[2], ry, RACE_NAMES[s.race] || s.race, { ...style, fontSize: '9px' }));
+            this._dyn.push(this.add.text(cols[2], ry, RACE_NAMES[s.race] || s.race, { ...style, fontSize: '13px' }));
             this._dyn.push(this.add.text(cols[3], ry, `${s.worldsCleared}`, style));
             this._dyn.push(this.add.text(cols[4], ry, `${s.level}`, style));
             this._dyn.push(this.add.text(cols[5], ry, `${s.monstersKilled}`, style));

--- a/src/scenes/MenuScene.js
+++ b/src/scenes/MenuScene.js
@@ -51,7 +51,7 @@ class MenuScene extends Phaser.Scene {
             const race = (saved.heroStats?.race)    || 'human';
             const lvl  = saved.heroStats?.level || 1;
             this.add.text(cx, cy + 28, `${name}  ·  Verden ${saved.worldNum}  ·  Nivå ${lvl}`, {
-                fontSize: '13px', color: '#667788', fontFamily: 'monospace'
+                fontSize: '15px', color: '#667788', fontFamily: 'monospace'
             }).setOrigin(0.5);
 
             const cont = this._btn(cx, cy + 58, '[ FORTSETT ]', '#00e87a', 22);
@@ -82,12 +82,12 @@ class MenuScene extends Phaser.Scene {
         lbBtn.on('pointerdown', () => this.scene.start('LeaderboardScene'));
 
         // ── Footer tips ───────────────────────────────────────────────────────
-        const ts = { fontSize: '11px', color: '#445566', fontFamily: 'monospace' };
+        const ts = { fontSize: '13px', color: '#445566', fontFamily: 'monospace' };
         this.add.text(cx, H - 50, 'WASD/Piltaster: Beveg  ·  SPACE/F: Angrep  ·  R: Pil  ·  E: Inventar  ·  M: Kart', ts).setOrigin(0.5);
         this.add.text(cx, H - 30, 'Beseir bossen for å gå videre til neste verden', ts).setOrigin(0.5);
 
         // Version
-        this.add.text(8, H - 16, 'v0.8', { fontSize: '10px', color: '#222244', fontFamily: 'monospace' });
+        this.add.text(8, H - 16, 'v0.9', { fontSize: '12px', color: '#222244', fontFamily: 'monospace' });
     }
 
     // ── Difficulty panel ──────────────────────────────────────────────────────
@@ -95,7 +95,7 @@ class MenuScene extends Phaser.Scene {
     _buildDifficultyPanel(cx, cy) {
         // Label
         this.add.text(cx, cy - 54, 'VANSKELIGHETSGRAD', {
-            fontSize: '11px', color: '#445566', fontFamily: 'monospace'
+            fontSize: '13px', color: '#445566', fontFamily: 'monospace'
         }).setOrigin(0.5);
 
         const DIFFS = [
@@ -127,7 +127,7 @@ class MenuScene extends Phaser.Scene {
         });
 
         this._diffHintText = this.add.text(cx, cy - 5, '', {
-            fontSize: '10px', color: '#556677', fontFamily: 'monospace'
+            fontSize: '12px', color: '#556677', fontFamily: 'monospace'
         }).setOrigin(0.5);
 
         this._selectDifficulty('normal');

--- a/src/scenes/MerchantScene.js
+++ b/src/scenes/MerchantScene.js
@@ -30,17 +30,17 @@ class MerchantScene extends Phaser.Scene {
 
         // Gold display
         this._goldText = this.add.text(cx, cy - panelH / 2 + 50, '', {
-            fontSize: '13px', color: '#ffcc00', fontFamily: 'monospace'
+            fontSize: '15px', color: '#ffcc00', fontFamily: 'monospace'
         }).setOrigin(0.5);
 
         // Message area
         this._msgText = this.add.text(cx, cy + panelH / 2 - 40, '', {
-            fontSize: '11px', color: '#88bbff', fontFamily: 'monospace'
+            fontSize: '13px', color: '#88bbff', fontFamily: 'monospace'
         }).setOrigin(0.5);
 
         // Close hint
         this.add.text(cx, cy + panelH / 2 - 14, '[ESC/E] Lukk', {
-            fontSize: '11px', color: '#334455', fontFamily: 'monospace'
+            fontSize: '13px', color: '#334455', fontFamily: 'monospace'
         }).setOrigin(0.5);
 
         // Close button
@@ -118,7 +118,7 @@ class MerchantScene extends Phaser.Scene {
 
         // Description
         this._d(this.add.text(cx - w / 2 + 50, y + 22, item.desc || '', {
-            fontSize: '9px', color: '#667788', fontFamily: 'monospace'
+            fontSize: '13px', color: '#667788', fontFamily: 'monospace'
         }));
 
         // Price

--- a/src/scenes/SettingsScene.js
+++ b/src/scenes/SettingsScene.js
@@ -23,7 +23,7 @@ class SettingsScene extends Phaser.Scene {
         panel.lineStyle(2, 0x334466, 1);
         panel.strokeRoundedRect(PX, PY, PW, PH, 8);
 
-        const ts = (sz, col = '#aabbdd') => ({ fontSize: sz + 'px', color: col, fontFamily: 'monospace' });
+        const ts = (sz, col = '#aabbdd') => ({ fontSize: Math.max(sz, 12) + 'px', color: col, fontFamily: 'monospace' });
 
         this.add.text(PX + PW / 2, PY + 18, '⚙  Innstillinger', ts(15, '#88bbff')).setOrigin(0.5, 0);
 
@@ -73,7 +73,7 @@ class SettingsScene extends Phaser.Scene {
         let state = initial;
 
         const btn = this.add.graphics();
-        const label = this.add.text(x + 44, y, '', { fontSize: '11px', color: '#aabbdd', fontFamily: 'monospace' })
+        const label = this.add.text(x + 44, y, '', { fontSize: '13px', color: '#aabbdd', fontFamily: 'monospace' })
             .setOrigin(0, 0.5);
 
         const draw = () => {
@@ -103,7 +103,7 @@ class SettingsScene extends Phaser.Scene {
 
         const track = this.add.graphics();
         const knob  = this.add.graphics();
-        const vText = this.add.text(x + width + 8, y + 6, '', { fontSize: '10px', color: '#667799', fontFamily: 'monospace' })
+        const vText = this.add.text(x + width + 8, y + 6, '', { fontSize: '12px', color: '#667799', fontFamily: 'monospace' })
             .setOrigin(0, 0.5);
 
         const draw = () => {

--- a/src/scenes/SkillScene.js
+++ b/src/scenes/SkillScene.js
@@ -19,8 +19,8 @@ class SkillScene extends Phaser.Scene {
         this.add.rectangle(cx, cy, W, H, 0x000000, 0.78);
 
         // ── Panel ─────────────────────────────────────────────────────────────
-        const panelW = Math.min(W - 10, 940);
-        const panelH = Math.min(H - 10, 520);
+        const panelW = W - 20;
+        const panelH = H - 20;
         const px = cx - panelW / 2;
         const py = cy - panelH / 2;
 
@@ -96,7 +96,7 @@ class SkillScene extends Phaser.Scene {
         const hero    = this.heroRef;
         const colColor = path.color;
         const hexCol  = '#' + colColor.toString(16).padStart(6, '0');
-        const hdrW = Math.min(160, this._colW - 8);
+        const hdrW = Math.min(220, this._colW - 12);
 
         // Check if entire path is locked
         const pathLocked = (path.unlockCondition === 'mineral_pickup' && !hero.geologistUnlocked)
@@ -134,8 +134,8 @@ class SkillScene extends Phaser.Scene {
             return;
         }
 
-        const tierH    = 100;
-        const cardW    = Math.min(160, this._colW - 12), cardH = 84;
+        const tierH    = 140;
+        const cardW    = Math.min(220, this._colW - 16), cardH = 108;
         const tierGapY = areaTop + 28;
 
         path.tiers.forEach((skill, tierIndex) => {
@@ -208,7 +208,7 @@ class SkillScene extends Phaser.Scene {
         }
 
         // Skill name
-        this.add.text(cx, y + 18, skill.name, {
+        this.add.text(cx, y + 20, skill.name, {
             fontSize: '14px',
             color: maxed ? '#445566' : (locked ? '#333355' : '#e8e8ff'),
             fontFamily: 'monospace', fontStyle: 'bold',
@@ -218,7 +218,7 @@ class SkillScene extends Phaser.Scene {
         // Category badge + description combined
         const catHex = locked ? '#222233' : '#' + colColor.toString(16).padStart(6, '0');
         const descLine = skill.desc.replace(/\n/g, ', ');
-        this.add.text(cx, y + 36, `[${skill.category}] ${descLine}`, {
+        this.add.text(cx, y + 42, `[${skill.category}] ${descLine}`, {
             fontSize: '12px',
             color: locked ? '#1e1e30' : (maxed ? '#334455' : '#8899bb'),
             fontFamily: 'monospace', align: 'center',

--- a/src/scenes/SkillScene.js
+++ b/src/scenes/SkillScene.js
@@ -37,7 +37,7 @@ class SkillScene extends Phaser.Scene {
         const titleColor = this.viewOnly ? '#88aacc' : '#f5e642';
         const titleStroke = this.viewOnly ? '#334466' : '#7a6a00';
         this.add.text(cx, py + 18, titleText, {
-            fontSize: '15px', color: titleColor, fontFamily: 'monospace',
+            fontSize: '17px', color: titleColor, fontFamily: 'monospace',
             fontStyle: 'bold', stroke: titleStroke, strokeThickness: 2
         }).setOrigin(0.5);
 
@@ -75,7 +75,7 @@ class SkillScene extends Phaser.Scene {
             }
             // Hero name below portrait
             this.add.text(portraitX + portraitSize / 2, portraitY + portraitSize + 8, this.heroRef.heroName || '', {
-                fontSize: '9px', color: '#667788', fontFamily: 'monospace'
+                fontSize: '11px', color: '#667788', fontFamily: 'monospace'
             }).setOrigin(0.5);
         }
 
@@ -88,7 +88,7 @@ class SkillScene extends Phaser.Scene {
             ? 'Grønne rammer = tilgjengelig ved neste nivå opp · Grå = låst'
             : 'Grønne rammer = tilgjengelig · Grå = låst · Klikk for å velge';
         this.add.text(cx, py + panelH - 14, footerText, {
-            fontSize: '10px', color: '#33335a', fontFamily: 'monospace'
+            fontSize: '12px', color: '#33335a', fontFamily: 'monospace'
         }).setOrigin(0.5);
     }
 
@@ -111,13 +111,13 @@ class SkillScene extends Phaser.Scene {
         hdrBg.strokeRoundedRect(colCX - hdrW / 2, areaTop, hdrW, 26, 4);
 
         this.add.text(colCX, areaTop + 6, `── ${path.name.toUpperCase()} ──`, {
-            fontSize: '11px', color: pathLocked ? '#333344' : hexCol, fontFamily: 'monospace', fontStyle: 'bold'
+            fontSize: '13px', color: pathLocked ? '#333344' : hexCol, fontFamily: 'monospace', fontStyle: 'bold'
         }).setOrigin(0.5);
         const lockHint = path.unlockCondition === 'first_smelt' ? 'Smelt et mineral!'
             : path.unlockCondition === 'first_synthesis' ? 'Lag en kjemikalie!'
             : 'Finn et mineral!';
         this.add.text(colCX, areaTop + 18, pathLocked ? lockHint : path.desc, {
-            fontSize: '8px', color: pathLocked ? '#333344' : '#445566', fontFamily: 'monospace'
+            fontSize: '10px', color: pathLocked ? '#333344' : '#445566', fontFamily: 'monospace'
         }).setOrigin(0.5);
 
         // If entire path is locked, show a lock overlay and skip drawing skill cards
@@ -129,7 +129,7 @@ class SkillScene extends Phaser.Scene {
                 ? 'Lag en kjemikalie\ni laboratoriet\nfor å låse opp'
                 : 'Plukk opp et\nmineral for å\nlåse opp';
             this.add.text(colCX, areaTop + 110, lockMsg, {
-                fontSize: '9px', color: '#333344', fontFamily: 'monospace', align: 'center'
+                fontSize: '11px', color: '#333344', fontFamily: 'monospace', align: 'center'
             }).setOrigin(0.5);
             return;
         }
@@ -194,7 +194,7 @@ class SkillScene extends Phaser.Scene {
         tierG.fillStyle(locked ? 0x1a1535 : colColor, locked ? 0.3 : 0.25);
         tierG.fillRoundedRect(cx + w / 2 - 24, y + 2, 22, 14, 3);
         this.add.text(cx + w / 2 - 13, y + 9, tierLabel, {
-            fontSize: '8px', color: locked ? '#333355' : hexCol, fontFamily: 'monospace'
+            fontSize: '10px', color: locked ? '#333355' : hexCol, fontFamily: 'monospace'
         }).setOrigin(0.5);
 
         // Lock icon or stack indicator
@@ -203,13 +203,13 @@ class SkillScene extends Phaser.Scene {
         } else if (taken > 0 && skill.maxStack > 1) {
             const stackStr = `${taken}/${skill.maxStack}`;
             this.add.text(cx - w / 2 + 6, y + 9, stackStr, {
-                fontSize: '8px', color: hexCol, fontFamily: 'monospace'
+                fontSize: '10px', color: hexCol, fontFamily: 'monospace'
             }).setOrigin(0, 0.5);
         }
 
         // Skill name
         this.add.text(cx, y + 18, skill.name, {
-            fontSize: '12px',
+            fontSize: '14px',
             color: maxed ? '#445566' : (locked ? '#333355' : '#e8e8ff'),
             fontFamily: 'monospace', fontStyle: 'bold',
             align: 'center', wordWrap: { width: w - 12 }
@@ -219,7 +219,7 @@ class SkillScene extends Phaser.Scene {
         const catHex = locked ? '#222233' : '#' + colColor.toString(16).padStart(6, '0');
         const descLine = skill.desc.replace(/\n/g, ', ');
         this.add.text(cx, y + 36, `[${skill.category}] ${descLine}`, {
-            fontSize: '10px',
+            fontSize: '12px',
             color: locked ? '#1e1e30' : (maxed ? '#334455' : '#8899bb'),
             fontFamily: 'monospace', align: 'center',
             wordWrap: { width: w - 10 }
@@ -228,7 +228,7 @@ class SkillScene extends Phaser.Scene {
         // Maxed label
         if (maxed) {
             this.add.text(cx, y + h / 2, 'MAKS', {
-                fontSize: '12px', color: '#2a2a44', fontFamily: 'monospace', fontStyle: 'bold'
+                fontSize: '14px', color: '#2a2a44', fontFamily: 'monospace', fontStyle: 'bold'
             }).setOrigin(0.5);
         }
 
@@ -261,7 +261,7 @@ class SkillScene extends Phaser.Scene {
         if (SKILL_SYNERGIES.length === 0) return;
 
         this.add.text(cx, y - 10, 'SYNERGIER', {
-            fontSize: '9px', color: '#445566', fontFamily: 'monospace'
+            fontSize: '11px', color: '#445566', fontFamily: 'monospace'
         }).setOrigin(0.5);
 
         const totalW = SKILL_SYNERGIES.length * 170;
@@ -280,10 +280,10 @@ class SkillScene extends Phaser.Scene {
             }).join('+')} ${syn.name}`;
 
             this.add.text(sx, y + 2, isActive ? '✦ ' + label : '○ ' + label, {
-                fontSize: '9px', color: nameCol, fontFamily: 'monospace'
+                fontSize: '11px', color: nameCol, fontFamily: 'monospace'
             }).setOrigin(0.5);
             this.add.text(sx, y + 14, syn.desc, {
-                fontSize: '8px', color: descCol, fontFamily: 'monospace'
+                fontSize: '10px', color: descCol, fontFamily: 'monospace'
             }).setOrigin(0.5);
         });
     }

--- a/src/scenes/SmelteryScene.js
+++ b/src/scenes/SmelteryScene.js
@@ -69,14 +69,14 @@ class SmelteryScene extends Phaser.Scene {
         // Fuel indicator
         const fuel = this.smelter.calculateFuelEnergy(this.heroRef);
         this._fuelText = this.add.text(this.px + this.panelW - 20, this.py + 18, `Brensel: ${fuel} energi`, {
-            fontSize: '10px', color: '#886633', fontFamily: 'monospace'
+            fontSize: '12px', color: '#886633', fontFamily: 'monospace'
         }).setOrigin(1, 0.5);
 
         // Element counts summary
         const tracker = this.heroRef.elementTracker;
         const elemCount = Object.keys(tracker.collected).length;
         this._elemText = this.add.text(this.px + 20, this.py + 18, `Grunnstoffer: ${elemCount}`, {
-            fontSize: '10px', color: '#887766', fontFamily: 'monospace'
+            fontSize: '12px', color: '#887766', fontFamily: 'monospace'
         }).setOrigin(0, 0.5);
 
         this.add.rectangle(cx, this.py + 34, this.panelW - 20, 1, 0x332200);
@@ -95,7 +95,7 @@ class SmelteryScene extends Phaser.Scene {
             const tx = this.px + 30 + i * (tabW + 10) + tabW / 2;
             const active = this._tab === tab.id;
             const btn = this.add.text(tx, tabY, tab.label, {
-                fontSize: '11px', color: active ? '#ff7722' : '#554433',
+                fontSize: '13px', color: active ? '#ff7722' : '#554433',
                 fontFamily: 'monospace', fontStyle: active ? 'bold' : 'normal'
             }).setOrigin(0.5).setInteractive({ useHandCursor: true });
             btn.on('pointerdown', () => { this._tab = tab.id; this._refresh(); });
@@ -159,7 +159,7 @@ class SmelteryScene extends Phaser.Scene {
 
         // ── Left side: Backpack (deposit from) ──────────────────────────────
         this._d(this.add.text(leftX, y, 'RYGGSEKK → Lager', {
-            fontSize: '10px', color: '#887766', fontFamily: 'monospace', fontStyle: 'bold'
+            fontSize: '12px', color: '#887766', fontFamily: 'monospace', fontStyle: 'bold'
         }));
         y += 16;
 
@@ -179,7 +179,7 @@ class SmelteryScene extends Phaser.Scene {
             const hexCol = '#' + col.toString(16).padStart(6, '0');
 
             this._d(this.add.text(leftX + 4, bpY, `${def.name} ×${entry.count}`, {
-                fontSize: '10px', color: hexCol, fontFamily: 'monospace'
+                fontSize: '12px', color: hexCol, fontFamily: 'monospace'
             }));
 
             const btn = this._d(this.add.text(leftX + colW - 10, bpY, '→', {
@@ -193,20 +193,20 @@ class SmelteryScene extends Phaser.Scene {
         }
         if (!hasDepositable) {
             this._d(this.add.text(leftX + 4, bpY, 'Ingen mineraler/brensel', {
-                fontSize: '9px', color: '#444433', fontFamily: 'monospace'
+                fontSize: '13px', color: '#444433', fontFamily: 'monospace'
             }));
         }
 
         // ── Right side: Stash (withdraw from) ──────────────────────────────
         let sY = this.contentY;
         this._d(this.add.text(rightX, sY, 'LAGER → Ryggsekk', {
-            fontSize: '10px', color: '#887766', fontFamily: 'monospace', fontStyle: 'bold'
+            fontSize: '12px', color: '#887766', fontFamily: 'monospace', fontStyle: 'bold'
         }));
         sY += 16;
 
         if (hero.campStash.length === 0) {
             this._d(this.add.text(rightX + 4, sY, 'Lageret er tomt.', {
-                fontSize: '9px', color: '#444433', fontFamily: 'monospace'
+                fontSize: '13px', color: '#444433', fontFamily: 'monospace'
             }));
         } else {
             for (let si = 0; si < hero.campStash.length; si++) {
@@ -220,7 +220,7 @@ class SmelteryScene extends Phaser.Scene {
                 const hexCol = '#' + col.toString(16).padStart(6, '0');
 
                 this._d(this.add.text(rightX + 4, sY, `${name} ×${stashEntry.count}`, {
-                    fontSize: '10px', color: hexCol, fontFamily: 'monospace'
+                    fontSize: '12px', color: hexCol, fontFamily: 'monospace'
                 }));
 
                 const btn = this._d(this.add.text(rightX + colW - 10, sY, '←', {
@@ -237,7 +237,7 @@ class SmelteryScene extends Phaser.Scene {
         // Stash capacity label
         const totalStashed = hero.campStash.reduce((s, e) => s + (e.count || 0), 0);
         this._d(this.add.text(cx, this.py + this.panelH - 30, `Lagret: ${totalStashed} gjenstander  |  Klikk → for å lagre, ← for å hente`, {
-            fontSize: '9px', color: '#665544', fontFamily: 'monospace'
+            fontSize: '13px', color: '#665544', fontFamily: 'monospace'
         }).setOrigin(0.5));
     }
 
@@ -299,7 +299,7 @@ class SmelteryScene extends Phaser.Scene {
         let y = this.contentY;
 
         this._d(this.add.text(cx, y, 'Velg et mineral å smelte (ryggsekk + lager):', {
-            fontSize: '10px', color: '#887766', fontFamily: 'monospace'
+            fontSize: '12px', color: '#887766', fontFamily: 'monospace'
         }).setOrigin(0.5));
         y += 18;
 
@@ -326,7 +326,7 @@ class SmelteryScene extends Phaser.Scene {
 
         if (minerals.length === 0) {
             this._d(this.add.text(cx, y + 30, 'Ingen mineraler i ryggsekk eller lager.', {
-                fontSize: '11px', color: '#444433', fontFamily: 'monospace'
+                fontSize: '13px', color: '#444433', fontFamily: 'monospace'
             }).setOrigin(0.5));
             return;
         }
@@ -354,19 +354,19 @@ class SmelteryScene extends Phaser.Scene {
 
             // Mineral name + count
             this._d(this.add.text(startX + 8, my + 6, `${m.def.name} (×${m.count})${srcLabel}`, {
-                fontSize: '11px', color: hexCol, fontFamily: 'monospace', fontStyle: 'bold'
+                fontSize: '13px', color: hexCol, fontFamily: 'monospace', fontStyle: 'bold'
             }));
 
             // Yield preview
             const yieldStr = m.def.yields.map(y => `${y.symbol}×${y.amount}`).join(', ');
             this._d(this.add.text(startX + 8, my + 22, `→ ${yieldStr}  |  Energi: ${check.energyCost}`, {
-                fontSize: '9px', color: '#776655', fontFamily: 'monospace'
+                fontSize: '13px', color: '#776655', fontFamily: 'monospace'
             }));
 
             // Smelt button
             if (check.canSmelt) {
                 const btn = this._d(this.add.text(startX + colW - 60, my + 12, '[ Smelt ]', {
-                    fontSize: '11px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
+                    fontSize: '13px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
                 }).setInteractive({ useHandCursor: true }));
                 btn.on('pointerover', () => btn.setColor('#ffaa44'));
                 btn.on('pointerout', () => btn.setColor('#ff7722'));
@@ -377,7 +377,7 @@ class SmelteryScene extends Phaser.Scene {
                 }
             } else {
                 this._d(this.add.text(startX + colW - 70, my + 12, 'Lite brensel', {
-                    fontSize: '9px', color: '#443322', fontFamily: 'monospace'
+                    fontSize: '13px', color: '#443322', fontFamily: 'monospace'
                 }));
             }
         });
@@ -438,7 +438,7 @@ class SmelteryScene extends Phaser.Scene {
         let y = this.contentY;
 
         this._d(this.add.text(cx, y, 'Kombiner grunnstoffer til legeringer:', {
-            fontSize: '10px', color: '#887766', fontFamily: 'monospace'
+            fontSize: '12px', color: '#887766', fontFamily: 'monospace'
         }).setOrigin(0.5));
         y += 18;
 
@@ -449,7 +449,7 @@ class SmelteryScene extends Phaser.Scene {
 
         if (alloys.length === 0) {
             this._d(this.add.text(cx, y + 30, 'Ingen legeringer tilgjengelig.', {
-                fontSize: '11px', color: '#444433', fontFamily: 'monospace'
+                fontSize: '13px', color: '#444433', fontFamily: 'monospace'
             }).setOrigin(0.5));
             return;
         }
@@ -469,7 +469,7 @@ class SmelteryScene extends Phaser.Scene {
 
             // Alloy name + formula
             this._d(this.add.text(startX + 8, ay + 6, `${a.name} (${a.formula})`, {
-                fontSize: '11px', color: hexCol, fontFamily: 'monospace', fontStyle: 'bold'
+                fontSize: '13px', color: hexCol, fontFamily: 'monospace', fontStyle: 'bold'
             }));
 
             // Recipe
@@ -479,19 +479,19 @@ class SmelteryScene extends Phaser.Scene {
                 return `${r.symbol}: ${have}/${r.amount}${ok ? '' : '!'}`;
             }).join('  ');
             this._d(this.add.text(startX + 8, ay + 22, recipeStr, {
-                fontSize: '9px', color: '#776655', fontFamily: 'monospace'
+                fontSize: '13px', color: '#776655', fontFamily: 'monospace'
             }));
 
             // Stats preview
             const stats = a.statBonuses;
             const statStr = Object.entries(stats).map(([k, v]) => `+${v} ${k}`).join(', ');
             this._d(this.add.text(startX + 8, ay + 34, `Stats: ${statStr}  |  Energi: ${entry.energyCost}`, {
-                fontSize: '8px', color: '#665544', fontFamily: 'monospace'
+                fontSize: '12px', color: '#665544', fontFamily: 'monospace'
             }));
 
             if (entry.canCraft) {
                 const btn = this._d(this.add.text(startX + colW - 50, ay + 14, '[ Lag ]', {
-                    fontSize: '11px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
+                    fontSize: '13px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
                 }).setInteractive({ useHandCursor: true }));
                 btn.on('pointerover', () => btn.setColor('#ffaa44'));
                 btn.on('pointerout', () => btn.setColor('#ff7722'));
@@ -529,7 +529,7 @@ class SmelteryScene extends Phaser.Scene {
         let y = this.contentY;
 
         this._d(this.add.text(cx, y, 'Smi utstyr fra legeringer:', {
-            fontSize: '10px', color: '#887766', fontFamily: 'monospace'
+            fontSize: '12px', color: '#887766', fontFamily: 'monospace'
         }).setOrigin(0.5));
         y += 18;
 
@@ -541,7 +541,7 @@ class SmelteryScene extends Phaser.Scene {
 
         if (available.length === 0) {
             this._d(this.add.text(cx, y + 30, 'Ingen legeringer å smi med.\nLag legeringer i "Lag legering"-fanen først.', {
-                fontSize: '10px', color: '#444433', fontFamily: 'monospace', align: 'center'
+                fontSize: '12px', color: '#444433', fontFamily: 'monospace', align: 'center'
             }).setOrigin(0.5));
             return;
         }
@@ -552,7 +552,7 @@ class SmelteryScene extends Phaser.Scene {
             if (!alloy) continue;
 
             this._d(this.add.text(startX, rowY, `${alloy.name} (×${count}):`, {
-                fontSize: '11px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
+                fontSize: '13px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
             }));
             rowY += 18;
 
@@ -566,14 +566,14 @@ class SmelteryScene extends Phaser.Scene {
                 bg.fillRoundedRect(startX + 10, rowY, colW - 20, 36, 3);
 
                 this._d(this.add.text(startX + 18, rowY + 6, `${equip.name} (${equip.type === 'weapon' ? 'Våpen' : 'Rustning'})`, {
-                    fontSize: '10px', color: hexCol, fontFamily: 'monospace'
+                    fontSize: '12px', color: hexCol, fontFamily: 'monospace'
                 }));
                 this._d(this.add.text(startX + 18, rowY + 20, equip.desc, {
-                    fontSize: '8px', color: '#776655', fontFamily: 'monospace'
+                    fontSize: '12px', color: '#776655', fontFamily: 'monospace'
                 }));
 
                 const btn = this._d(this.add.text(startX + colW - 60, rowY + 10, '[ Smi ]', {
-                    fontSize: '10px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
+                    fontSize: '12px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
                 }).setInteractive({ useHandCursor: true }));
                 btn.on('pointerover', () => btn.setColor('#ffaa44'));
                 btn.on('pointerout', () => btn.setColor('#ff7722'));
@@ -614,7 +614,7 @@ class SmelteryScene extends Phaser.Scene {
         if (entries.length === 0) return;
 
         this._d(this.add.text(startX, y, 'Lagrede grunnstoffer:', {
-            fontSize: '9px', color: '#665544', fontFamily: 'monospace'
+            fontSize: '13px', color: '#665544', fontFamily: 'monospace'
         }));
         y += 14;
 
@@ -626,7 +626,7 @@ class SmelteryScene extends Phaser.Scene {
             const hexCol = '#' + col.toString(16).padStart(6, '0');
 
             const badge = this._d(this.add.text(bx, by, `${symbol}:${count}`, {
-                fontSize: '9px', color: hexCol, fontFamily: 'monospace',
+                fontSize: '13px', color: hexCol, fontFamily: 'monospace',
                 backgroundColor: '#0a0818', padding: { x: 3, y: 1 }
             }));
             bx += badge.width + 6;

--- a/src/scenes/UIScene.js
+++ b/src/scenes/UIScene.js
@@ -24,30 +24,30 @@ class UIScene extends Phaser.Scene {
         this.xpFill    = this.add.graphics();
         this.eqGfx     = this.add.graphics();
 
-        const ts = { fontSize: '11px', color: '#8899bb', fontFamily: 'monospace' };
+        const ts = { fontSize: '13px', color: '#8899bb', fontFamily: 'monospace' };
         const DIFF_COL  = { easy: '#44bb44', normal: '#4488ff', hard: '#ff5555' };
         const DIFF_LBL  = { easy: 'LETT', normal: 'NORMAL', hard: 'VANSKELIG' };
         const diff      = this.gameScene.difficulty || 'normal';
         this.add.text(W - 14, 8, DIFF_LBL[diff] || 'NORMAL', {
-            fontSize: '9px', color: DIFF_COL[diff] || '#4488ff', fontFamily: 'monospace'
+            fontSize: '11px', color: DIFF_COL[diff] || '#4488ff', fontFamily: 'monospace'
         }).setOrigin(1, 0);
 
         this.worldText  = this.add.text(W - 50, 8,  '', { ...ts, color: '#aaaacc' }).setOrigin(1, 0);
         this.levelText  = this.add.text(W - 50, 22, '', ts).setOrigin(1, 0);
         this.atkText    = this.add.text(W - 50, 36, '', ts).setOrigin(1, 0);
-        this.goldText   = this.add.text(10, 30, '', { fontSize: '11px', color: '#ffcc00', fontFamily: 'monospace' });
-        this.eqText     = this.add.text(10, 56, '', { fontSize: '10px', color: '#556677', fontFamily: 'monospace' });
-        this.eHint      = this.add.text(W - 50, 56, '[SPACE/F] Angrep  [R] Pil  [Q] Bruk  [E] Inventar  [+/-] Zoom', { fontSize: '10px', color: '#334455', fontFamily: 'monospace' }).setOrigin(1, 0);
+        this.goldText   = this.add.text(10, 30, '', { fontSize: '13px', color: '#ffcc00', fontFamily: 'monospace' });
+        this.eqText     = this.add.text(10, 56, '', { fontSize: '12px', color: '#556677', fontFamily: 'monospace' });
+        this.eHint      = this.add.text(W - 50, 56, '[SPACE/F] Angrep  [R] Pil  [Q] Bruk  [E] Inventar  [+/-] Zoom', { fontSize: '12px', color: '#334455', fontFamily: 'monospace' }).setOrigin(1, 0);
 
         // Status effect indicators
         this.statusText = this.add.text(10, 70, '', {
-            fontSize: '11px', color: '#ffffff', fontFamily: 'monospace', fontStyle: 'bold'
+            fontSize: '13px', color: '#ffffff', fontFamily: 'monospace', fontStyle: 'bold'
         });
         this.statusText.setVisible(false);
 
         // Pet info
         this.petText = this.add.text(W / 2 - 60, 30, '', {
-            fontSize: '10px', color: '#ffaadd', fontFamily: 'monospace'
+            fontSize: '12px', color: '#ffaadd', fontFamily: 'monospace'
         });
         this.petHpGfx = this.add.graphics();
 
@@ -95,7 +95,7 @@ class UIScene extends Phaser.Scene {
     _makeBossBar(W) {
         const c = this.add.container(W / 2, 68);
         c.setVisible(false);
-        const label = this.add.text(0, 0, '', { fontSize: '11px', color: '#ff4488', fontFamily: 'monospace' }).setOrigin(0.5, 0);
+        const label = this.add.text(0, 0, '', { fontSize: '13px', color: '#ff4488', fontFamily: 'monospace' }).setOrigin(0.5, 0);
         const bg    = this.add.graphics();
         bg.fillStyle(0x330011);
         bg.fillRect(-90, 14, 180, 10);

--- a/src/systems/InputHandler.js
+++ b/src/systems/InputHandler.js
@@ -130,10 +130,16 @@ class InputHandler {
 
     handleZoom() {
         const scene = this.scene;
+        const reg   = scene.game.registry;
         const plus  = Phaser.Input.Keyboard.JustDown(scene.zoomInKey)  ||
-                      Phaser.Input.Keyboard.JustDown(scene.zoomInAlt);
+                      Phaser.Input.Keyboard.JustDown(scene.zoomInAlt) ||
+                      reg.get('touch_zoom_in');
         const minus = Phaser.Input.Keyboard.JustDown(scene.zoomOutKey) ||
-                      Phaser.Input.Keyboard.JustDown(scene.zoomOutAlt);
+                      Phaser.Input.Keyboard.JustDown(scene.zoomOutAlt) ||
+                      reg.get('touch_zoom_out');
+        // Clear touch zoom flags
+        if (reg.get('touch_zoom_in'))  reg.set('touch_zoom_in', false);
+        if (reg.get('touch_zoom_out')) reg.set('touch_zoom_out', false);
         const z = scene.cameras.main.zoom;
         if (plus)  scene.cameras.main.setZoom(Math.min(ZOOM_MAX, +(z + ZOOM_STEP).toFixed(2)));
         if (minus) scene.cameras.main.setZoom(Math.max(ZOOM_MIN, +(z - ZOOM_STEP).toFixed(2)));

--- a/src/systems/ItemSpawner.js
+++ b/src/systems/ItemSpawner.js
@@ -459,15 +459,21 @@ class ItemSpawner {
                             scene.hero.geologistUnlocked = true;
                             scene._floatingText(hx, hy - 1, 'Geolog-stien er ulåst!', '#997755');
                         }
-                        for (const y of obj.item.yields) {
-                            const isNew = scene.hero.elementTracker.discover(y.symbol);
-                            if (isNew && typeof ELEMENTS !== 'undefined') {
-                                const elem = ELEMENTS[y.symbol];
-                                if (elem) {
-                                    const hexCol = '#' + elem.color.toString(16).padStart(6, '0');
-                                    scene._floatingText(hx, hy, `${elem.symbol} (${elem.name}) oppdaget!`, hexCol);
+                        // Only discover/identify elements if hero has Geologist skill
+                        const canIdentify = (scene.hero.mineralIdentifyLevel || 0) > 0;
+                        if (canIdentify) {
+                            for (const y of obj.item.yields) {
+                                const isNew = scene.hero.elementTracker.discover(y.symbol);
+                                if (isNew && typeof ELEMENTS !== 'undefined') {
+                                    const elem = ELEMENTS[y.symbol];
+                                    if (elem) {
+                                        const hexCol = '#' + elem.color.toString(16).padStart(6, '0');
+                                        scene._floatingText(hx, hy, `${elem.symbol} (${elem.name}) oppdaget!`, hexCol);
+                                    }
                                 }
                             }
+                        } else {
+                            scene._floatingText(hx, hy, 'Ukjent mineral – lær Geolog!', '#776655');
                         }
                         // Check for completion bonuses
                         const newBonuses = scene.hero.elementTracker.checkCompletions();

--- a/src/systems/SmeltingSystem.js
+++ b/src/systems/SmeltingSystem.js
@@ -44,6 +44,12 @@ class SmeltingSystem {
                 if (oreEfficiency > 0 && Math.random() < oreEfficiency) {
                     amount += 1;
                 }
+                // Geologist smeltBonusElement: extra element per smelt
+                amount += (hero.smeltBonusElement || 0);
+                // Metallurgist smeltExtraYieldChance: chance for double yield
+                if ((hero.smeltExtraYieldChance || 0) > 0 && Math.random() < hero.smeltExtraYieldChance) {
+                    amount = Math.ceil(amount * 1.5);
+                }
                 elements.push({ symbol: y.symbol, amount });
 
                 // Add to tracker
@@ -104,7 +110,10 @@ class SmeltingSystem {
         }
 
         const energyCost = this._adjustedEnergyCost(alloy.energyCost, hero);
-        return { success: true, alloy, energyCost };
+        // Double alloy chance from Metallurgist Legeringsmester
+        const doubleChance = hero.doubleAlloyChance || 0;
+        const doubled = doubleChance > 0 && Math.random() < doubleChance;
+        return { success: true, alloy, energyCost, doubled };
     }
 
     /**
@@ -158,7 +167,14 @@ class SmeltingSystem {
             if (item.atk) item.atk = Math.round(item.atk * (1 + bonus));
             if (item.def) item.def = Math.round(item.def * (1 + bonus));
             if (item.hearts) item.hearts = Math.round(item.hearts * (1 + bonus));
-            item.desc = item.desc + ' [Mestersmie]';
+            // Master Smith special properties
+            if (item.type === 'weapon') {
+                item.critBonus = 0.10;
+                item.desc = item.desc + ' [Mestersmie: +10% krit]';
+            } else if (item.type === 'armor') {
+                item.thornsDmg = 1;
+                item.desc = item.desc + ' [Mestersmie: +1 torneskade]';
+            }
         }
 
         // Alloy mastery bonus from skills

--- a/src/systems/TouchControls.js
+++ b/src/systems/TouchControls.js
@@ -109,6 +109,81 @@ class TouchControls {
             const y = baseY + btn.oy;
             this._makeActionButton(x, y, sz, btn.label, btn.key, btn.color);
         }
+
+        // ── Zoom & fullscreen buttons (top-right corner) ─────────────────────
+        this._createZoomButtons();
+    }
+
+    // ── Zoom & fullscreen (top-right) ────────────────────────────────────────
+
+    _createZoomButtons() {
+        const scene = this.scene;
+        const reg   = this.game.registry;
+        const sz    = 44;
+        const gap   = 8;
+        const W     = scene.cameras.main.width;
+        const startX = W - 20 - sz / 2;
+        const startY = 64 + sz / 2;
+
+        // Zoom in (+)
+        this._makeSimpleButton(startX, startY, sz, '+', 0x336699, () => {
+            reg.set('touch_zoom_in', true);
+        });
+
+        // Zoom out (-)
+        this._makeSimpleButton(startX - (sz + gap), startY, sz, '−', 0x336699, () => {
+            reg.set('touch_zoom_out', true);
+        });
+
+        // Fullscreen toggle
+        this._makeSimpleButton(startX - (sz + gap) * 2, startY, sz, '⛶', 0x446688, () => {
+            this._toggleFullscreen();
+        });
+    }
+
+    _makeSimpleButton(x, y, sz, label, color, callback) {
+        const scene = this.scene;
+        const alpha = 0.4;
+        const pressAlpha = 0.75;
+
+        const bg = scene.add.graphics();
+        this._drawRoundedBtn(bg, x, y, sz, color, alpha);
+        bg.setDepth(100);
+
+        const txt = scene.add.text(x, y, label, {
+            fontSize: '22px', color: '#eeeeff', fontFamily: 'monospace', fontStyle: 'bold'
+        }).setOrigin(0.5).setDepth(101).setAlpha(0.7);
+
+        const zone = scene.add.zone(x, y, sz, sz).setInteractive().setDepth(102);
+
+        zone.on('pointerdown', () => {
+            callback();
+            this._drawRoundedBtn(bg, x, y, sz, color, pressAlpha);
+            txt.setAlpha(1);
+        });
+
+        const release = () => {
+            this._drawRoundedBtn(bg, x, y, sz, color, alpha);
+            txt.setAlpha(0.7);
+        };
+
+        zone.on('pointerup', release);
+        zone.on('pointerout', release);
+
+        this.widgets.push(bg, txt, zone);
+    }
+
+    _toggleFullscreen() {
+        if (document.fullscreenElement) {
+            document.exitFullscreen().catch(() => {});
+        } else {
+            const el = this.game.canvas.parentElement || this.game.canvas;
+            if (el.requestFullscreen) {
+                el.requestFullscreen().catch(() => {});
+            } else if (el.webkitRequestFullscreen) {
+                el.webkitRequestFullscreen();
+            }
+        }
     }
 
     _makeActionButton(x, y, sz, label, regKey, color) {


### PR DESCRIPTION
## Summary

This PR addresses four open issues with UI readability, layout design, touch support, and skill balance.

### Font sizes across all scenes (#79)
- All font sizes increased by 2-3px in 11 scene files
- Minimum font size raised from 7px to 10px
- Affected scenes: UIScene, MenuScene, SettingsScene, InventoryScene, SmelteryScene, ChemLabScene, ElementBookScene, MerchantScene, LeaderboardScene, GameOverScene, SkillScene

### CharacterCreatorScene complete redesign (#80)
Previous layout was a loose two-column arrangement that didn't use the full canvas. New design is a structured **three-column layout** filling the entire 1280×800 canvas:
- **Left panel (370px):** 2×2 race card grid showing name, special ability, and mini-stats per race. Stat bars with labels below (hearts, attack, defense, vision, XP multiplier)
- **Center panel (400px):** Large 280px character preview as the visual focal point, race name display, and hero name input
- **Right panel (450px):** All appearance customization options (gender, skin tone, hair color/style, eye color, cloth color/style, beard)
- **Bottom bar:** Starting bonus selection (3 options) on the left, pulsing start button on the right
- All sections wrapped in cohesive dark panels with consistent rounded borders and color scheme

### SkillScene layout fix (#79)
After font size increases, text was overflowing skill cards. Fixed by:
- Panel expanded from fixed 940×520 to full screen (`W-20 × H-20`)
- Skill cards enlarged from 160×84px to 220×108px
- Tier spacing increased from 100px to 140px
- Text positions adjusted (name at y+20, description at y+42) for better vertical distribution
- Header width increased from 160px to 220px

### Touch zoom and fullscreen controls (#78)
- Three new buttons in top-right corner for touch devices: Zoom in (+), Zoom out (−), Fullscreen (⛶)
- 44×44px touch targets following mobile accessibility guidelines
- Fullscreen uses Fullscreen API with webkit fallback
- Zoom buttons communicate via `game.registry` flags consumed by InputHandler

### Geologist and Metallurgist skill rebalancing (#81)

**Geologist path:**
- T1 Malmøye: Now also sets `mineralIdentifyLevel` — without this skill, minerals show as "Ukjent mineral" and elements are not auto-discovered on pickup
- T2 Effektiv utvinning: Now grants `smeltBonusElement` (+1 extra element per smelt operation)

**Metallurgist path:**
- T1 Rask smelting: Now also grants `smeltExtraYieldChance` (15% chance for 1.5× yield)
- T2 Legeringsmester: Now grants `doubleAlloyChance` (20% chance for double alloy output)
- T3 Mestersmie: Increased from +20% to +30% stat bonus. Adds special properties: weapons get +10% crit chance, armor gets +1 thorns damage

**New hero properties:** `mineralIdentifyLevel`, `smeltBonusElement`, `smeltExtraYieldChance`, `doubleAlloyChance` — all serialized/deserialized in HeroCrafting.js.

## Files changed
- `src/scenes/CharacterCreatorScene.js` — Complete rewrite (three-column layout)
- `src/scenes/SkillScene.js` — Panel/card dimension expansion
- `src/scenes/UIScene.js`, `MenuScene.js`, `SettingsScene.js`, `InventoryScene.js`, `SmelteryScene.js`, `ChemLabScene.js`, `ElementBookScene.js`, `MerchantScene.js`, `LeaderboardScene.js`, `GameOverScene.js` — Font size bumps
- `src/systems/TouchControls.js` — Zoom/fullscreen buttons
- `src/systems/InputHandler.js` — Touch zoom registry flag support
- `src/data/skills.js` — Enhanced Geologist/Metallurgist skill effects
- `src/entities/HeroCrafting.js` — New crafting properties (init, serialize, applyStats)
- `src/systems/SmeltingSystem.js` — Bonus element, extra yield, and special forge properties
- `src/systems/ItemSpawner.js` — Mineral identification gating
- `docs/CHANGELOG.md` — v0.9 section added
- `docs/GDD.md` — Updated skill descriptions and feature status

## Test plan
- [ ] Start new game: verify CharacterCreatorScene layout fills page, all panels functional (race selection, stats, preview, appearance, bonus, name, start)
- [ ] Level up: verify SkillScene text fits within expanded cards, no overflow
- [ ] Touch device: verify zoom +/− and fullscreen buttons appear and function
- [ ] Take Geologist T1: pick up mineral, verify it shows as identified (not "Ukjent mineral")
- [ ] Take Metallurgist T1+T2: smelt minerals, verify extra yield and double alloy mechanics
- [ ] Save and reload: verify all new hero properties persist correctly

Closes #78 #79 #80 #81

https://claude.ai/code/session_01CX5mzXd9m5nNgMfzGNZuPy