### PR TITLE
Add crafting skill requirements and HUD quick-access buttons

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ---
 
+## v0.34 – 2026-04-10
+
+### Nye funksjoner
+- **Mineraler krever Geolog-skill:** Mineraler er nå usynlige på kartet uten Malmøye-skillen (Geolog T1). Helten kan fortsatt plukke opp mineraler blindt ved å gå over dem
+- **Smelting krever Metallurg-skill:** Smelt-, Legering- og Smi-fanene i smelteovnen er låst bak Metallurg-skill. Lager-fanen er alltid tilgjengelig
+- **Kjemi krever Kjemiker-skill:** Syntese i kjemisk lab er låst bak Kjemiker-skill
+- **HUD-knapper:** Elementbok (📖), Skilltre (⚔) og Inventar (🎒) tilgjengelig som knapper øverst til høyre i HUD-baren
+- **Nye opplåsingsbetingelser:** Metallurg-stien låses opp ved besøk i leirplass (ikke lenger ved første smelting). Kjemiker-stien låses opp ved besøk i kjemisk lab (ikke lenger ved første syntese)
+
+### Tekniske endringer
+- MapRenderer toggler mineral-grafikk synlighet basert på Geolog-skill i updateFog()
+- SmelteryScene og ChemLabScene sjekker hero.skills[] for aktive skill-krav
+- UIScene utvidet med 3 interaktive snarveiknapper
+- Skill unlock conditions endret: metallurg='camp_room_found', kjemiker='chem_lab_found'
+- Fjernet auto-unlock av metallurgist/chemist fra SmelteryScene og ChemistrySystem
+
+---
+
 ## v0.33 – 2026-04-10
 
 ### Nye funksjoner

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,5 +1,5 @@
 # Labyrint Hero – Game Design Document
-**Versjon:** 0.33
+**Versjon:** 0.34
 **Sist oppdatert:** 2026-04-10
 
 ---
@@ -23,7 +23,7 @@ Et top-down 2D labyrint-RPG i nettleser. Spilleren navigerer en prosedyre-genere
 - **Rendering:** Phaser Graphics API – prosedyretegnet, ingen bildefiler
 - **Lyd:** Web Audio API – prosedyremusikk og SFX, ingen lydfiler
 - **Lagring:** localStorage via SaveManager
-- **Multi-scene pattern:** GameScene + UIScene parallelt; SkillScene, InventoryScene og SettingsScene som overlays
+- **Multi-scene pattern:** GameScene + UIScene parallelt; SkillScene, InventoryScene og SettingsScene som overlays. UIScene har HUD-knapper for Elementbok, Skilltre og Inventar øverst til høyre
 
 ### Filstruktur
 ```
@@ -292,9 +292,9 @@ Livspotte, Stor livspotte, Styrkebrygg (midlertidig +2 ATK i 60 sek), Forsvarsbr
 | T3 | precision | +3 ATK, +3 kjæl.-ATK, +3 kjæl.-HP, +2 hjerter nå | ×1 |
 
 ### Håndverksstier (låses opp)
-- **Geolog** (lås: finn mineral) – mineralidentifisering, mineralsynsradius, utbytte, bonuselementer, garantert sjeldent mineral
-- **Metallurg** (lås: smelt mineral) – smeltetid/energi, ekstra utbytte, legeringsstats, dobbellegering, mestersmie med spesialegenskaper
-- **Kjemiker** (lås: lag kjemikalie) – potion-varighet, bombeskade, eksplosjonsradius
+- **Geolog** (lås: finn mineral) – mineralidentifisering, mineralsynsradius, utbytte, bonuselementer, garantert sjeldent mineral. **Kreves for å se mineraler på kartet.**
+- **Metallurg** (lås: finn leirplass) – smeltetid/energi, ekstra utbytte, legeringsstats, dobbellegering, mestersmie med spesialegenskaper. **Kreves for smelting, legering og smiing.**
+- **Kjemiker** (lås: finn kjemisk lab) – potion-varighet, bombeskade, eksplosjonsradius. **Kreves for å lage kjemikalier.**
 
 ### Synergier
 Aktiveres automatisk når helten har evner fra begge stier i et par:
@@ -459,14 +459,14 @@ Elements-modifikasjonen fletter det periodiske system, geologi, metallurgi og kj
 Periodisk system-overlay med 18×9 rutenett. Oppdagede grunnstoffer vises med symbol og kategori-farge. Gruppeprestasjoner (f.eks. Jernmetaller → +2 HP) vises nederst.
 
 ### Geolog-skillsti (#6)
-Låses opp ved første mineral-funn. Kreves for mineral-identifisering. 3 tiers:
+Låses opp ved første mineral-funn. Kreves for å se mineraler på kartet og for mineral-identifisering. 3 tiers:
 | Tier | Skill | Effekt |
 |------|-------|--------|
 | T1 | Malmøye | +1 mineral-synsradius, mineral-identifisering per stack (maks 3) |
 | T2 | Effektiv utvinning | +25% mineralutbytte, +1 ekstra element ved smelting per stack (maks 3) |
 | T3 | Mesterprospektør | Garantert T4+ mineral per etasje (maks 1) |
 
-**Mineral-identifisering:** Uten Geolog-skill vises mineraler som «Ukjent mineral» og grunnstoffer oppdages ikke automatisk ved oppsamling. Malmøye-skillen gir mineralidentifisering.
+**Mineral-synlighet:** Uten Geolog-skill er mineraler usynlige på kartet. Helten kan fortsatt plukke opp mineraler ved å gå over dem (blindt opptak). Malmøye-skillen gjør mineraler synlige og gir mineral-identifisering. Uten identifisering vises mineraler som «Ukjent mineral» og grunnstoffer oppdages ikke automatisk.
 
 Synergi: **Jordens kraft** (Geolog + Vokter) → +1 forsvar, +1 mineralsynsradius.
 
@@ -483,6 +483,7 @@ Smelting, legeringer og smiing av utstyr.
 **Smiing:** 12 nye våpen/rustninger fra legeringer. Stats overgår vanlig utstyr.
 
 **Metallurg-skillsti (#8):**
+Låses opp ved første besøk i leirplass. **Minst én Metallurg-skill kreves for å bruke smelting, legering og smiing.** Lager-fanen er alltid tilgjengelig.
 | Tier | Skill | Effekt |
 |------|-------|--------|
 | T1 | Rask smelting | -25% energi/smeltetid, +15% sjanse ekstra utbytte per stack (maks 3) |
@@ -498,6 +499,7 @@ Kjemisk syntese av potions, bomber, medisiner og syrer fra rene grunnstoffer.
 **Produkter:** 15 kjemiske produkter i 5 kategorier. Kraftigere enn vanlige consumables – kjemisk livselixir healer 4 HP (vs 2), krutt gjør 8 skade i radius 3 (vs 6 for vanlig bombe), dynamitt 15 skade.
 
 **Kjemiker-skillsti (#9):**
+Låses opp ved første besøk i kjemisk laboratorium. **Minst én Kjemiker-skill kreves for å lage kjemikalier.**
 | Tier | Skill | Effekt |
 |------|-------|--------|
 | T1 | Potente potions | +50% potion-varighet per stack (maks 3) |

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -158,7 +158,7 @@ const SKILL_TREE_PATHS = [
         desc:  'Smelting og legeringer',
         color: 0xff7722,
         icon:  'M',
-        unlockCondition: 'first_smelt',
+        unlockCondition: 'camp_room_found',
         tiers: [
             {
                 id:       'fast_smelting',
@@ -200,7 +200,7 @@ const SKILL_TREE_PATHS = [
         desc:  'Potions, bomber og medisin',
         color: 0x33dd88,
         icon:  'C',
-        unlockCondition: 'first_synthesis',
+        unlockCondition: 'chem_lab_found',
         tiers: [
             {
                 id:       'potent_potions',
@@ -255,8 +255,8 @@ function isSkillUnlocked(hero, pathIndex, tierIndex) {
 
     // Check path-level unlock condition
     if (path.unlockCondition === 'mineral_pickup' && !hero.geologistUnlocked) return false;
-    if (path.unlockCondition === 'first_smelt' && !hero.metallurgistUnlocked) return false;
-    if (path.unlockCondition === 'first_synthesis' && !hero.chemistUnlocked) return false;
+    if (path.unlockCondition === 'camp_room_found' && !hero.metallurgistUnlocked) return false;
+    if (path.unlockCondition === 'chem_lab_found' && !hero.chemistUnlocked) return false;
 
     // Already at max stack → not available
     if (_countSkill(hero, skill.id) >= skill.maxStack) return false;

--- a/src/scenes/ChemLabScene.js
+++ b/src/scenes/ChemLabScene.js
@@ -130,7 +130,29 @@ class ChemLabScene extends Phaser.Scene {
         const fuel = this.smelter.calculateFuelEnergy(this.heroRef);
         this._fuelText.setText(`Energi: ${fuel}`);
 
-        this._drawRecipes(fuel);
+        if (this._hasKjemikerSkill()) {
+            this._drawRecipes(fuel);
+        } else {
+            this._drawLockedMessage();
+        }
+    }
+
+    _hasKjemikerSkill() {
+        return (this.heroRef.skills || []).some(s =>
+            s === 'potent_potions' || s === 'acid_mastery' || s === 'explosive_genius'
+        );
+    }
+
+    _drawLockedMessage() {
+        const cx = this.px + this.panelW / 2;
+        const cy = this.contentY + (this.panelH - (this.contentY - this.py)) / 2 - 40;
+        this._d(this.add.text(cx, cy, '🔒', { fontSize: '32px' }).setOrigin(0.5));
+        this._d(this.add.text(cx, cy + 30, 'Krever Kjemiker-skill!', {
+            fontSize: '14px', color: '#33dd88', fontFamily: 'monospace', fontStyle: 'bold'
+        }).setOrigin(0.5));
+        this._d(this.add.text(cx, cy + 50, 'Lær Potente potions i skilltreet\nfor å bruke laboratoriet.', {
+            fontSize: '12px', color: '#445544', fontFamily: 'monospace', align: 'center'
+        }).setOrigin(0.5));
     }
 
     _d(obj) { this._dyn.push(obj); return obj; }
@@ -228,11 +250,6 @@ class ChemLabScene extends Phaser.Scene {
         const added = hero.inventory.addItem(result.item);
         if (!added) {
             EventBus.emit('spawnItem', { gx: hero.gridX, gy: hero.gridY, item: result.item });
-        }
-
-        // Unlock chemist path
-        if (!hero.chemistUnlocked) {
-            EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY - 1, msg: 'Kjemiker-stien er ulåst!', color: '#33dd88' });
         }
 
         EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `Laget: ${result.item.name}!`, color: '#33dd88' });

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -224,6 +224,11 @@ class GameScene extends Phaser.Scene {
         if (!this._campRoomShown && this._isInCampRoom()) {
             this._campRoomShown = true;
             this._showMessage('Leirplass! Trykk V for å smelte og smi.', '#ff7722');
+            // Unlock metallurg skill path on first camp room visit
+            if (!this.hero.metallurgistUnlocked) {
+                this.hero.metallurgistUnlocked = true;
+                this._floatingText(this.hero.gridX, this.hero.gridY - 1, 'Metallurg-stien er ulåst!', '#ff7722');
+            }
         } else if (!this._isInCampRoom()) {
             this._campRoomShown = false;
         }
@@ -240,6 +245,11 @@ class GameScene extends Phaser.Scene {
     _checkChemLab() {
         if (!this._chemLabShown && this._isInChemLab()) {
             this._chemLabShown = true;
+            // Unlock kjemiker skill path on first chem lab visit
+            if (!this.hero.chemistUnlocked) {
+                this.hero.chemistUnlocked = true;
+                this._floatingText(this.hero.gridX, this.hero.gridY - 1, 'Kjemiker-stien er ulåst!', '#33dd88');
+            }
             if (this.hero.chemLabUnlocked) {
                 this._showMessage('Kjemisk lab! Trykk C for å lage kjemikalier.', '#33dd88');
             } else {

--- a/src/scenes/SkillScene.js
+++ b/src/scenes/SkillScene.js
@@ -100,8 +100,8 @@ class SkillScene extends Phaser.Scene {
 
         // Check if entire path is locked
         const pathLocked = (path.unlockCondition === 'mineral_pickup' && !hero.geologistUnlocked)
-            || (path.unlockCondition === 'first_smelt' && !hero.metallurgistUnlocked)
-            || (path.unlockCondition === 'first_synthesis' && !hero.chemistUnlocked);
+            || (path.unlockCondition === 'camp_room_found' && !hero.metallurgistUnlocked)
+            || (path.unlockCondition === 'chem_lab_found' && !hero.chemistUnlocked);
 
         // Path header
         const hdrBg = this.add.graphics();
@@ -113,8 +113,8 @@ class SkillScene extends Phaser.Scene {
         this.add.text(colCX, areaTop + 6, `── ${path.name.toUpperCase()} ──`, {
             fontSize: '13px', color: pathLocked ? '#333344' : hexCol, fontFamily: 'monospace', fontStyle: 'bold'
         }).setOrigin(0.5);
-        const lockHint = path.unlockCondition === 'first_smelt' ? 'Smelt et mineral!'
-            : path.unlockCondition === 'first_synthesis' ? 'Lag en kjemikalie!'
+        const lockHint = path.unlockCondition === 'camp_room_found' ? 'Finn en leirplass!'
+            : path.unlockCondition === 'chem_lab_found' ? 'Finn et kjemisk lab!'
             : 'Finn et mineral!';
         this.add.text(colCX, areaTop + 18, pathLocked ? lockHint : path.desc, {
             fontSize: '10px', color: pathLocked ? '#333344' : '#445566', fontFamily: 'monospace'
@@ -123,10 +123,10 @@ class SkillScene extends Phaser.Scene {
         // If entire path is locked, show a lock overlay and skip drawing skill cards
         if (pathLocked) {
             this.add.text(colCX, areaTop + 80, '🔒', { fontSize: '24px' }).setOrigin(0.5);
-            const lockMsg = path.unlockCondition === 'first_smelt'
-                ? 'Smelt et mineral\ni leirplassen\nfor å låse opp'
-                : path.unlockCondition === 'first_synthesis'
-                ? 'Lag en kjemikalie\ni laboratoriet\nfor å låse opp'
+            const lockMsg = path.unlockCondition === 'camp_room_found'
+                ? 'Finn en leirplass\nfor å låse opp'
+                : path.unlockCondition === 'chem_lab_found'
+                ? 'Finn et kjemisk lab\nfor å låse opp'
                 : 'Plukk opp et\nmineral for å\nlåse opp';
             this.add.text(colCX, areaTop + 110, lockMsg, {
                 fontSize: '11px', color: '#333344', fontFamily: 'monospace', align: 'center'

--- a/src/scenes/SmelteryScene.js
+++ b/src/scenes/SmelteryScene.js
@@ -139,10 +139,36 @@ class SmelteryScene extends Phaser.Scene {
 
         switch (this._tab) {
             case 'stash': this._drawStashTab(); break;
-            case 'smelt': this._drawSmeltTab(); break;
-            case 'alloy': this._drawAlloyTab(); break;
-            case 'forge': this._drawForgeTab(); break;
+            case 'smelt':
+            case 'alloy':
+            case 'forge':
+                if (this._hasMetallurgSkill()) {
+                    if (this._tab === 'smelt') this._drawSmeltTab();
+                    else if (this._tab === 'alloy') this._drawAlloyTab();
+                    else this._drawForgeTab();
+                } else {
+                    this._drawLockedTab();
+                }
+                break;
         }
+    }
+
+    _hasMetallurgSkill() {
+        return (this.heroRef.skills || []).some(s =>
+            s === 'fast_smelting' || s === 'alloy_mastery' || s === 'master_smith'
+        );
+    }
+
+    _drawLockedTab() {
+        const cx = this.px + this.panelW / 2;
+        const cy = this.contentY + (this.panelH - (this.contentY - this.py)) / 2 - 40;
+        this._d(this.add.text(cx, cy, '🔒', { fontSize: '32px' }).setOrigin(0.5));
+        this._d(this.add.text(cx, cy + 30, 'Krever Metallurg-skill!', {
+            fontSize: '14px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
+        }).setOrigin(0.5));
+        this._d(this.add.text(cx, cy + 50, 'Lær Rask smelting i skilltreet\nfor å bruke smelteovnen.', {
+            fontSize: '12px', color: '#665544', fontFamily: 'monospace', align: 'center'
+        }).setOrigin(0.5));
     }
 
     _d(obj) { this._dyn.push(obj); return obj; }
@@ -401,11 +427,6 @@ class SmelteryScene extends Phaser.Scene {
         const result = this.smelter.smelt(mineralDef, hero);
 
         this.smelter.consumeFuel(hero, result.energyCost);
-
-        if (!hero.metallurgistUnlocked) {
-            hero.metallurgistUnlocked = true;
-            EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY - 1, msg: 'Metallurg-stien er ulåst!', color: '#ff7722' });
-        }
 
         // Remove one mineral from source
         if (source === 'stash') {

--- a/src/scenes/UIScene.js
+++ b/src/scenes/UIScene.js
@@ -64,6 +64,31 @@ class UIScene extends Phaser.Scene {
             }
         });
 
+        // Quick-access buttons (Element Book, Skill Tree, Inventory)
+        const quickBtns = [
+            { label: '📖', scene: 'ElementBookScene',
+              launchData: () => ({ heroRef: this.gameScene.hero }) },
+            { label: '⚔', scene: 'SkillScene',
+              launchData: () => ({ heroRef: this.gameScene.hero, viewOnly: true }) },
+            { label: '🎒', scene: 'InventoryScene',
+              launchData: () => ({}) },
+        ];
+        let btnX = W - 34;
+        quickBtns.forEach(def => {
+            const btn = this.add.text(btnX, 10, def.label, {
+                fontSize: '16px', color: '#445566', fontFamily: 'monospace'
+            }).setOrigin(1, 0).setInteractive({ useHandCursor: true });
+            btn.on('pointerover', () => btn.setColor('#88bbff'));
+            btn.on('pointerout',  () => btn.setColor('#445566'));
+            btn.on('pointerdown', () => {
+                Audio.init();
+                if (!this.scene.isActive(def.scene) && this.gameScene?.hero) {
+                    this.scene.launch(def.scene, def.launchData());
+                }
+            });
+            btnX -= 22;
+        });
+
         // Hide keyboard hints on touch devices
         if (this.game.registry.get('isTouchDevice')) {
             this.eHint.setVisible(false);

--- a/src/systems/ChemistrySystem.js
+++ b/src/systems/ChemistrySystem.js
@@ -59,11 +59,6 @@ class ChemistrySystem {
         // Create usable item from molecule definition
         const item = this._createUsableItem(mol, hero);
 
-        // Unlock chemist on first synthesis
-        if (!hero.chemistUnlocked) {
-            hero.chemistUnlocked = true;
-        }
-
         return { success: true, item, energyCost };
     }
 

--- a/src/systems/ItemSpawner.js
+++ b/src/systems/ItemSpawner.js
@@ -372,6 +372,11 @@ class ItemSpawner {
             this._drawOreIcon(g, px, py, s, mineralDef);
         }
 
+        // Hide mineral if hero doesn't have Geolog mineral_eye skill yet
+        if (!scene.hero || (scene.hero.mineralVisionRadius || 0) <= 0) {
+            g.setVisible(false);
+        }
+
         scene.itemObjects.push({ gridX: gx, gridY: gy, item: mineralDef, graphic: g, isMineral: true });
     }
 

--- a/src/systems/MapRenderer.js
+++ b/src/systems/MapRenderer.js
@@ -573,6 +573,22 @@ class MapRenderer {
             }
         }
 
+        // Toggle mineral graphic visibility based on Geolog skill
+        if (scene.itemObjects) {
+            const hasGeoSkill = mr > 0;
+            for (const obj of scene.itemObjects) {
+                if (!obj.isMineral) continue;
+                if (!hasGeoSkill) {
+                    obj.graphic.setVisible(false);
+                } else {
+                    const fx = obj.gridX, fy = obj.gridY;
+                    const inBounds = fx >= 0 && fx < scene.tileW && fy >= 0 && fy < scene.tileH;
+                    const fogState = inBounds ? scene.fog[fy][fx] : FOG.DARK;
+                    obj.graphic.setVisible(fogState !== FOG.DARK);
+                }
+            }
+        }
+
         this._drawFog();
     }
 


### PR DESCRIPTION
- Minerals are now invisible without Geolog skill (mineral_eye). Hero can still blind-pickup minerals to unlock the Geolog path.
- Smelting, alloying, and smithing require Metallurg skill. Stash tab remains accessible without the skill.
- Chemistry synthesis requires Kjemiker skill.
- Metallurg path now unlocks on first camp room visit (was: first smelt).
- Kjemiker path now unlocks on first chem lab visit (was: first synthesis).
- Added Element Book, Skill Tree, and Inventory buttons to HUD top bar.

https://claude.ai/code/session_01HUxxy3PA2frUYHDXNrs8qg