### PR TITLE
Fix mineral visibility and add geolog prerequisite for metallurg

### DIFF
--- a/src/data/minerals.js
+++ b/src/data/minerals.js
@@ -337,6 +337,37 @@ function rollBossMineral(worldNum) {
     return MINERAL_DEFS.malachite;
 }
 
+/**
+ * Return a display name for a mineral based on hero's identification ability.
+ * Without Geolog skill: generic description based on appearance (color/subtype).
+ * With Geolog skill: actual mineral name.
+ */
+function getMineralDisplayName(mineralDef, hero) {
+    if (!mineralDef || mineralDef.type !== 'mineral') return mineralDef ? mineralDef.name : '???';
+    if ((hero.mineralIdentifyLevel || 0) > 0) return mineralDef.name;
+
+    // Generic descriptions based on color and subtype
+    if (mineralDef.subtype === 'crystal') {
+        const col = mineralDef.color || 0xffffff;
+        const r = (col >> 16) & 0xff, g = (col >> 8) & 0xff, b = col & 0xff;
+        if (r > 180 && g < 100 && b < 100) return 'Rødlig krystall';
+        if (r < 100 && g > 150 && b < 100) return 'Grønnlig krystall';
+        if (r < 100 && g < 100 && b > 150) return 'Blålig krystall';
+        if (r > 180 && g > 150 && b < 100) return 'Gyllen krystall';
+        if (r > 150 && g < 100 && b > 150) return 'Fiolett krystall';
+        return 'Ukjent krystall';
+    }
+    const col = mineralDef.color || 0x888888;
+    const r = (col >> 16) & 0xff, g = (col >> 8) & 0xff, b = col & 0xff;
+    if (r > 150 && g < 100 && b < 100) return 'Rødlig malm';
+    if (r > 150 && g > 120 && b < 80) return 'Gulbrun malm';
+    if (r < 100 && g > 130) return 'Grønnlig malm';
+    if (r < 100 && g < 100 && b > 130) return 'Blålig malm';
+    if (r > 180 && g > 180 && b > 180) return 'Lys malm';
+    if (r < 80 && g < 80 && b < 80) return 'Mørk malm';
+    return 'Ukjent malm';
+}
+
 // Rarity color mapping for mineral tiers (matches existing rarity system visuals)
 const MINERAL_TIER_COLORS = {
     1: 0x888888, // grey – common

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -156,6 +156,7 @@ const SKILL_TREE_PATHS = [
         id:    'metallurg',
         name:  'Metallurg',
         desc:  'Smelting og legeringer',
+        prerequisitePath: 'geolog',  // must have at least 1 geolog skill
         color: 0xff7722,
         icon:  'M',
         unlockCondition: 'camp_room_found',
@@ -257,6 +258,15 @@ function isSkillUnlocked(hero, pathIndex, tierIndex) {
     if (path.unlockCondition === 'mineral_pickup' && !hero.geologistUnlocked) return false;
     if (path.unlockCondition === 'camp_room_found' && !hero.metallurgistUnlocked) return false;
     if (path.unlockCondition === 'chem_lab_found' && !hero.chemistUnlocked) return false;
+
+    // Check prerequisite path (e.g. metallurg requires at least 1 geolog skill)
+    if (path.prerequisitePath) {
+        const prereqPath = SKILL_TREE_PATHS.find(p => p.id === path.prerequisitePath);
+        if (prereqPath) {
+            const hasPrereq = prereqPath.tiers.some(t => _countSkill(hero, t.id) > 0);
+            if (!hasPrereq) return false;
+        }
+    }
 
     // Already at max stack → not available
     if (_countSkill(hero, skill.id) >= skill.maxStack) return false;

--- a/src/scenes/InventoryScene.js
+++ b/src/scenes/InventoryScene.js
@@ -213,7 +213,9 @@ class InventoryScene extends Phaser.Scene {
 
         if (item) {
             this._drawItemIcon(x, y, item, size - 12);
-            this._d(this.add.text(x, y - size / 2 - 10, this._shortName(item.name), {
+            const eqDispName = (item.type === 'mineral' && typeof getMineralDisplayName !== 'undefined')
+                ? getMineralDisplayName(item, this.hero) : item.name;
+            this._d(this.add.text(x, y - size / 2 - 10, this._shortName(eqDispName), {
                 fontSize: '11px', color: this._rarityTextColor(item), fontFamily: 'monospace'
             }).setOrigin(0.5));
 
@@ -275,7 +277,9 @@ class InventoryScene extends Phaser.Scene {
 
         if (itemDef) {
             this._drawItemIcon(x, y, itemDef, size - 12);
-            const sn = this._shortName(itemDef.name);
+            const quDispName = (itemDef.type === 'mineral' && typeof getMineralDisplayName !== 'undefined')
+                ? getMineralDisplayName(itemDef, this.hero) : itemDef.name;
+            const sn = this._shortName(quDispName);
             const label = qu.count > 1 ? `${sn} ×${qu.count}` : sn;
             this._d(this.add.text(x, y - size / 2 - 10, label, {
                 fontSize: '11px', color: '#ccddff', fontFamily: 'monospace'
@@ -343,7 +347,9 @@ class InventoryScene extends Phaser.Scene {
             const nameCol = itemDef.type === 'mineral' && typeof MINERAL_TIER_COLORS !== 'undefined'
                 ? '#' + (MINERAL_TIER_COLORS[itemDef.tier] || 0x997755).toString(16).padStart(6, '0')
                 : this._rarityTextColor(itemDef);
-            this._d(this.add.text(x, y + size / 2 - 2, this._shortName(itemDef.name), {
+            const bpDispName = (itemDef.type === 'mineral' && typeof getMineralDisplayName !== 'undefined')
+                ? getMineralDisplayName(itemDef, this.hero) : itemDef.name;
+            this._d(this.add.text(x, y + size / 2 - 2, this._shortName(bpDispName), {
                 fontSize: '11px', color: nameCol, fontFamily: 'monospace'
             }).setOrigin(0.5, 1));
 
@@ -468,7 +474,9 @@ class InventoryScene extends Phaser.Scene {
         if (itemDef) {
             this._drawItemIcon(x, y, itemDef, size - 10);
             const nameCol = this._rarityTextColor(itemDef);
-            this._d(this.add.text(x, y + size / 2 - 2, this._shortName(itemDef.name), {
+            const petDispName = (itemDef.type === 'mineral' && typeof getMineralDisplayName !== 'undefined')
+                ? getMineralDisplayName(itemDef, this.hero) : itemDef.name;
+            this._d(this.add.text(x, y + size / 2 - 2, this._shortName(petDispName), {
                 fontSize: '11px', color: nameCol, fontFamily: 'monospace'
             }).setOrigin(0.5, 1));
 
@@ -675,7 +683,11 @@ class InventoryScene extends Phaser.Scene {
         const { width: W, height: H } = this.cameras.main;
         const rarDef = item.rarity ? RARITY_BY_ID[item.rarity] : null;
         const rarTag = (rarDef && item.rarity !== 'common') ? `[${rarDef.label}]  ` : '';
-        const lines = [rarTag + item.name, item.desc || ''];
+        const dispName = (item.type === 'mineral' && typeof getMineralDisplayName !== 'undefined')
+            ? getMineralDisplayName(item, this.hero) : item.name;
+        const dispDesc = (item.type === 'mineral' && (this.hero.mineralIdentifyLevel || 0) <= 0)
+            ? '' : (item.desc || '');
+        const lines = [rarTag + dispName, dispDesc];
         const txtCol = this._rarityTextColor(item);
         this._tooltip = this.add.text(x, y, lines.join('\n'), {
             fontSize: '12px', color: txtCol, fontFamily: 'monospace',

--- a/src/scenes/SkillScene.js
+++ b/src/scenes/SkillScene.js
@@ -78,36 +78,60 @@ class SkillScene extends Phaser.Scene {
         const hexCol  = '#' + colColor.toString(16).padStart(6, '0');
         const hdrW = Math.min(220, this._colW - 12);
 
-        // Check if entire path is locked
+        // Check if entire path is locked (unlock condition not met)
         const pathLocked = (path.unlockCondition === 'mineral_pickup' && !hero.geologistUnlocked)
             || (path.unlockCondition === 'camp_room_found' && !hero.metallurgistUnlocked)
             || (path.unlockCondition === 'chem_lab_found' && !hero.chemistUnlocked);
 
+        // Check prerequisite path (e.g. metallurg requires geolog skill)
+        let prereqMissing = false;
+        if (!pathLocked && path.prerequisitePath) {
+            const prereqPath = SKILL_TREE_PATHS.find(p => p.id === path.prerequisitePath);
+            if (prereqPath) {
+                prereqMissing = !prereqPath.tiers.some(t =>
+                    (hero.skills || []).includes(t.id));
+            }
+        }
+
+        const isLocked = pathLocked || prereqMissing;
+
         // Path header
         const hdrBg = this.add.graphics();
-        hdrBg.fillStyle(pathLocked ? 0x111118 : colColor, pathLocked ? 0.15 : 0.12);
+        hdrBg.fillStyle(isLocked ? 0x111118 : colColor, isLocked ? 0.15 : 0.12);
         hdrBg.fillRoundedRect(colCX - hdrW / 2, areaTop, hdrW, 26, 4);
-        hdrBg.lineStyle(1, pathLocked ? 0x222233 : colColor, pathLocked ? 0.3 : 0.5);
+        hdrBg.lineStyle(1, isLocked ? 0x222233 : colColor, isLocked ? 0.3 : 0.5);
         hdrBg.strokeRoundedRect(colCX - hdrW / 2, areaTop, hdrW, 26, 4);
 
         this.add.text(colCX, areaTop + 6, `── ${path.name.toUpperCase()} ──`, {
-            fontSize: '13px', color: pathLocked ? '#333344' : hexCol, fontFamily: 'monospace', fontStyle: 'bold'
+            fontSize: '13px', color: isLocked ? '#333344' : hexCol, fontFamily: 'monospace', fontStyle: 'bold'
         }).setOrigin(0.5);
-        const lockHint = path.unlockCondition === 'camp_room_found' ? 'Finn en leirplass!'
-            : path.unlockCondition === 'chem_lab_found' ? 'Finn et kjemisk lab!'
-            : 'Finn et mineral!';
-        this.add.text(colCX, areaTop + 18, pathLocked ? lockHint : path.desc, {
-            fontSize: '10px', color: pathLocked ? '#333344' : '#445566', fontFamily: 'monospace'
+        let lockHint;
+        if (prereqMissing) {
+            const prereqName = SKILL_TREE_PATHS.find(p => p.id === path.prerequisitePath)?.name || '???';
+            lockHint = `Krever ${prereqName}-skill!`;
+        } else {
+            lockHint = path.unlockCondition === 'camp_room_found' ? 'Finn en leirplass!'
+                : path.unlockCondition === 'chem_lab_found' ? 'Finn et kjemisk lab!'
+                : 'Finn et mineral!';
+        }
+        this.add.text(colCX, areaTop + 18, isLocked ? lockHint : path.desc, {
+            fontSize: '10px', color: isLocked ? '#333344' : '#445566', fontFamily: 'monospace'
         }).setOrigin(0.5);
 
         // If entire path is locked, show a lock overlay and skip drawing skill cards
-        if (pathLocked) {
+        if (isLocked) {
             this.add.text(colCX, areaTop + 80, '🔒', { fontSize: '24px' }).setOrigin(0.5);
-            const lockMsg = path.unlockCondition === 'camp_room_found'
-                ? 'Finn en leirplass\nfor å låse opp'
-                : path.unlockCondition === 'chem_lab_found'
-                ? 'Finn et kjemisk lab\nfor å låse opp'
-                : 'Plukk opp et\nmineral for å\nlåse opp';
+            let lockMsg;
+            if (prereqMissing) {
+                const prereqName = SKILL_TREE_PATHS.find(p => p.id === path.prerequisitePath)?.name || '???';
+                lockMsg = `Lær ${prereqName}-skill\nfør du kan velge\ndenne stien`;
+            } else if (path.unlockCondition === 'camp_room_found') {
+                lockMsg = 'Finn en leirplass\nfor å låse opp';
+            } else if (path.unlockCondition === 'chem_lab_found') {
+                lockMsg = 'Finn et kjemisk lab\nfor å låse opp';
+            } else {
+                lockMsg = 'Plukk opp et\nmineral for å\nlåse opp';
+            }
             this.add.text(colCX, areaTop + 110, lockMsg, {
                 fontSize: '11px', color: '#333344', fontFamily: 'monospace', align: 'center'
             }).setOrigin(0.5);

--- a/src/scenes/SmelteryScene.js
+++ b/src/scenes/SmelteryScene.js
@@ -159,6 +159,12 @@ class SmelteryScene extends Phaser.Scene {
         );
     }
 
+    _hasGeologSkill() {
+        return (this.heroRef.skills || []).some(s =>
+            s === 'mineral_eye' || s === 'efficient_mining' || s === 'master_prospector'
+        );
+    }
+
     _drawLockedTab() {
         const cx = this.px + this.panelW / 2;
         const cy = this.contentY + (this.panelH - (this.contentY - this.py)) / 2 - 40;
@@ -166,7 +172,10 @@ class SmelteryScene extends Phaser.Scene {
         this._d(this.add.text(cx, cy + 30, 'Krever Metallurg-skill!', {
             fontSize: '14px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
         }).setOrigin(0.5));
-        this._d(this.add.text(cx, cy + 50, 'Lær Rask smelting i skilltreet\nfor å bruke smelteovnen.', {
+        const hint = this._hasGeologSkill()
+            ? 'Lær Rask smelting i skilltreet\nfor å bruke smelteovnen.'
+            : 'Du trenger Geolog-skill først,\nderetter Metallurg-skill.';
+        this._d(this.add.text(cx, cy + 50, hint, {
             fontSize: '12px', color: '#665544', fontFamily: 'monospace', align: 'center'
         }).setOrigin(0.5));
     }
@@ -204,7 +213,9 @@ class SmelteryScene extends Phaser.Scene {
             const col = def.color || 0xaaaaaa;
             const hexCol = '#' + col.toString(16).padStart(6, '0');
 
-            this._d(this.add.text(leftX + 4, bpY, `${def.name} ×${entry.count}`, {
+            const stashDepName = (def.type === 'mineral' && typeof getMineralDisplayName !== 'undefined')
+                ? getMineralDisplayName(def, hero) : def.name;
+            this._d(this.add.text(leftX + 4, bpY, `${stashDepName} ×${entry.count}`, {
                 fontSize: '12px', color: hexCol, fontFamily: 'monospace'
             }));
 
@@ -241,11 +252,13 @@ class SmelteryScene extends Phaser.Scene {
                 if (sY > this.py + this.panelH - 60) break;
 
                 const def = this._getStashItemDef(stashEntry.id);
-                const name = def ? def.name : stashEntry.id;
+                const rawStName = def ? def.name : stashEntry.id;
+                const stName = (def && def.type === 'mineral' && typeof getMineralDisplayName !== 'undefined')
+                    ? getMineralDisplayName(def, hero) : rawStName;
                 const col = def ? def.color : 0xaaaaaa;
                 const hexCol = '#' + col.toString(16).padStart(6, '0');
 
-                this._d(this.add.text(rightX + 4, sY, `${name} ×${stashEntry.count}`, {
+                this._d(this.add.text(rightX + 4, sY, `${stName} ×${stashEntry.count}`, {
                     fontSize: '12px', color: hexCol, fontFamily: 'monospace'
                 }));
 
@@ -378,14 +391,19 @@ class SmelteryScene extends Phaser.Scene {
             // Source label
             const srcLabel = m.source === 'stash' ? ' [lager]' : '';
 
-            // Mineral name + count – truncate to fit slot
-            const mName = m.def.name.length > 22 ? m.def.name.slice(0, 21) + '…' : m.def.name;
+            // Mineral name + count – show generic name if not identified
+            const canId = (hero.mineralIdentifyLevel || 0) > 0;
+            const rawName = (typeof getMineralDisplayName !== 'undefined')
+                ? getMineralDisplayName(m.def, hero) : m.def.name;
+            const mName = rawName.length > 22 ? rawName.slice(0, 21) + '…' : rawName;
             this._d(this.add.text(startX + 8, my + 6, `${mName} (×${m.count})${srcLabel}`, {
                 fontSize: '13px', color: hexCol, fontFamily: 'monospace', fontStyle: 'bold'
             }));
 
-            // Yield preview
-            const yieldStr = m.def.yields.map(y => `${y.symbol}×${y.amount}`).join(', ');
+            // Yield preview – hide element details if not identified
+            const yieldStr = canId
+                ? m.def.yields.map(y => `${y.symbol}×${y.amount}`).join(', ')
+                : '???';
             this._d(this.add.text(startX + 8, my + 22, `→ ${yieldStr}  |  Energi: ${check.energyCost}`, {
                 fontSize: '13px', color: '#776655', fontFamily: 'monospace'
             }));

--- a/src/systems/ItemSpawner.js
+++ b/src/systems/ItemSpawner.js
@@ -372,11 +372,6 @@ class ItemSpawner {
             this._drawOreIcon(g, px, py, s, mineralDef);
         }
 
-        // Hide mineral if hero doesn't have Geolog mineral_eye skill yet
-        if (!scene.hero || (scene.hero.mineralVisionRadius || 0) <= 0) {
-            g.setVisible(false);
-        }
-
         scene.itemObjects.push({ gridX: gx, gridY: gy, item: mineralDef, graphic: g, isMineral: true });
     }
 
@@ -457,6 +452,9 @@ class ItemSpawner {
                     obj.graphic.destroy();
                     scene.itemObjects.splice(i, 1);
 
+                    // Can hero identify minerals? (requires Geolog skill)
+                    const canIdentify = obj.isMineral && (scene.hero.mineralIdentifyLevel || 0) > 0;
+
                     // Element discovery for minerals
                     if (obj.isMineral && obj.item.yields && scene.hero.elementTracker) {
                         // Unlock geologist path on first mineral pickup
@@ -464,8 +462,6 @@ class ItemSpawner {
                             scene.hero.geologistUnlocked = true;
                             scene._floatingText(hx, hy - 1, 'Geolog-stien er ulåst!', '#997755');
                         }
-                        // Only discover/identify elements if hero has Geologist skill
-                        const canIdentify = (scene.hero.mineralIdentifyLevel || 0) > 0;
                         if (canIdentify) {
                             for (const y of obj.item.yields) {
                                 const isNew = scene.hero.elementTracker.discover(y.symbol);
@@ -494,7 +490,9 @@ class ItemSpawner {
                     const pickupColor = tierColor
                         || ((rarDef && obj.item.rarity !== 'common') ? rarDef.textColor : '#ffee88');
                     const suffix = toPet ? ` (${scene.pet.petName})` : '';
-                    scene._floatingText(hx, hy, `+ ${obj.item.name}${suffix}`, pickupColor);
+                    const displayName = (obj.isMineral && typeof getMineralDisplayName !== 'undefined')
+                        ? getMineralDisplayName(obj.item, scene.hero) : obj.item.name;
+                    scene._floatingText(hx, hy, `+ ${displayName}${suffix}`, pickupColor);
                 } else {
                     scene._showMessage('Ryggsekken er full! (Høyreklikk for å droppe)', '#ff8844');
                 }

--- a/src/systems/MapRenderer.js
+++ b/src/systems/MapRenderer.js
@@ -573,22 +573,6 @@ class MapRenderer {
             }
         }
 
-        // Toggle mineral graphic visibility based on Geolog skill
-        if (scene.itemObjects) {
-            const hasGeoSkill = mr > 0;
-            for (const obj of scene.itemObjects) {
-                if (!obj.isMineral) continue;
-                if (!hasGeoSkill) {
-                    obj.graphic.setVisible(false);
-                } else {
-                    const fx = obj.gridX, fy = obj.gridY;
-                    const inBounds = fx >= 0 && fx < scene.tileW && fy >= 0 && fy < scene.tileH;
-                    const fogState = inBounds ? scene.fog[fy][fx] : FOG.DARK;
-                    obj.graphic.setVisible(fogState !== FOG.DARK);
-                }
-            }
-        }
-
         this._drawFog();
     }
 


### PR DESCRIPTION
- Minerals are now always visible on the map but show as generic descriptions (e.g. "Rødlig malm", "Blålig krystall") without Geolog skill. With Geolog skill, minerals are properly identified.
- Generic mineral names shown consistently in inventory, smeltery, and pickup text via new getMineralDisplayName() helper.
- Smeltery yield preview shows "???" for unidentified minerals.
- Metallurg skill path now requires at least one Geolog skill before skills can be learned (prerequisitePath check in isSkillUnlocked).
- SkillScene shows "Krever Geolog-skill!" lock message for metallurg when geolog prerequisite is not met.

https://claude.ai/code/session_01HUxxy3PA2frUYHDXNrs8qg