### PR TITLE
Restructure touch controls and balance world scaling (v0.35)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,18 +6,18 @@
 
 ### Nye funksjoner
 - **Lukkeknapp på alle menyer (#92):** SkillScene (ferdighetstreet) har nå en ✕-knapp for å lukke i visnings-modus. LeaderboardScene har fått lukkeknapp og ESC-snarvei
-- **Touch-kontroller omstrukturert (#88):** Handlingsknapper (ATK, BOW, USE) er nå separert fra menyknapper (INV, MAP, SKL, BOK, SMI, LAB). Menyknapper vises kun når funksjonen er opplåst. D-pad flyttet lenger til venstre. Nye touch-knapper for Skilltre (SKL) og Elementbok (BOK)
+- **Touch-kontroller omstrukturert (#88):** Handlingsknapper (ATK, BOW, USE) er nå separert fra menyknapper (INV, MAP, SKL, BOK, SMI, LAB). Menyknapper vises kun når funksjonen er opplåst. D-pad er nå DOM-basert og plasseres i letterbox-området ved siden av spillvinduet på brede skjermer. Nye touch-knapper for Skilltre (SKL) og Elementbok (BOK)
 - **Tier 5-utstyr (#89):** Runesverd (+6 ATK), Mithriløks (+7 ATK), Dragebue (+7 ATK bue), Mithrilrustning (+5 DEF, +1 hjerte) tilgjengelig fra verden 9+
 
 ### Balansering
 - **Enklere lett modus (#89):** Monster-HP multiplier redusert fra 0.65→0.50, angrep fra 0.75→0.60, XP-bonus økt til 1.30
 - **Mykere monsterskalering (#89):** HP-vekst per verden redusert fra 0.5→0.35 (med ekstra 0.15 etter verden 8). Angrepsvekst redusert fra 0.25→0.20
 - **Økt base-angrep (#89):** Helten starter med 3 angrep i stedet for 2
-- **Bomber og potions skalerer med verden (#90):** Alle bomber, elixirer, helbredelse og buffs fra kjemisystemet skalerer nå +25% per verden. Vanlige bomber, styrkebrygg og forsvarsbrygg skalerer også
+- **Bomber og potions skalerer med verden (#90):** Alle bomber, elixirer, helbredelse og buffs fra kjemisystemet skalerer nå +40% per verden. Base-skade på kjemibomber økt kraftig (salpeter 5→8, krutt 8→12, syrebombe 6→10, dynamitt 15→20). Vanlige bomber (8 base), styrkebrygg og forsvarsbrygg skalerer også
 - **Sterkere blendgranater (#90):** Blendgranater reduserer nå monsterangrep med et fast tall som skalerer med verden, i stedet for å halvere
 
 ### Tekniske endringer
-- TouchControls omskrevet med separate action/meny-grupper og dynamisk synlighet via updateVisibility()
+- TouchControls omskrevet: D-pad er nå DOM-basert (HTML-elementer) for plassering utenfor canvas. Reposisjoneres automatisk ved resize. Action/meny separert med dynamisk synlighet via updateVisibility()
 - ChemistrySystem.synthesize() og _createUsableItem() mottar nå worldNum for skalering
 - ChemLabScene sender worldNum ved oppstart
 - Hero-objektet får worldNum satt i GameScene.create()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ---
 
+## v0.35 – 2026-04-11
+
+### Nye funksjoner
+- **Lukkeknapp på alle menyer (#92):** SkillScene (ferdighetstreet) har nå en ✕-knapp for å lukke i visnings-modus. LeaderboardScene har fått lukkeknapp og ESC-snarvei
+- **Touch-kontroller omstrukturert (#88):** Handlingsknapper (ATK, BOW, USE) er nå separert fra menyknapper (INV, MAP, SKL, BOK, SMI, LAB). Menyknapper vises kun når funksjonen er opplåst. D-pad flyttet lenger til venstre. Nye touch-knapper for Skilltre (SKL) og Elementbok (BOK)
+- **Tier 5-utstyr (#89):** Runesverd (+6 ATK), Mithriløks (+7 ATK), Dragebue (+7 ATK bue), Mithrilrustning (+5 DEF, +1 hjerte) tilgjengelig fra verden 9+
+
+### Balansering
+- **Enklere lett modus (#89):** Monster-HP multiplier redusert fra 0.65→0.50, angrep fra 0.75→0.60, XP-bonus økt til 1.30
+- **Mykere monsterskalering (#89):** HP-vekst per verden redusert fra 0.5→0.35 (med ekstra 0.15 etter verden 8). Angrepsvekst redusert fra 0.25→0.20
+- **Økt base-angrep (#89):** Helten starter med 3 angrep i stedet for 2
+- **Bomber og potions skalerer med verden (#90):** Alle bomber, elixirer, helbredelse og buffs fra kjemisystemet skalerer nå +25% per verden. Vanlige bomber, styrkebrygg og forsvarsbrygg skalerer også
+- **Sterkere blendgranater (#90):** Blendgranater reduserer nå monsterangrep med et fast tall som skalerer med verden, i stedet for å halvere
+
+### Tekniske endringer
+- TouchControls omskrevet med separate action/meny-grupper og dynamisk synlighet via updateVisibility()
+- ChemistrySystem.synthesize() og _createUsableItem() mottar nå worldNum for skalering
+- ChemLabScene sender worldNum ved oppstart
+- Hero-objektet får worldNum satt i GameScene.create()
+- GameScene håndterer nye touch-registreringsnøkler (touch_skilltree, touch_elementbook)
+- UIScene kaller touchControls.updateVisibility() i refresh()
+
+---
+
 ## v0.34 – 2026-04-10
 
 ### Nye funksjoner

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,6 +1,6 @@
 # Labyrint Hero – Game Design Document
-**Versjon:** 0.34
-**Sist oppdatert:** 2026-04-10
+**Versjon:** 0.35
+**Sist oppdatert:** 2026-04-11
 
 ---
 
@@ -32,7 +32,7 @@ src/
   maze.js                   – MazeGenerator (DFS + ekstra passasjer)
   utils/SaveManager.js      – localStorage persistens
   data/skills.js            – 12 passive evner
-  data/items.js             – 27 gjenstander (våpen, rustning, forbruk, verktøy) + sjeldenhetsystem
+  data/items.js             – 31 gjenstander (våpen, rustning, forbruk, verktøy) + sjeldenhetsystem
   graphics/CharacterSprite.js – prosedyrekaraktertegning (4 raser, 2 kjønn, 10 frisyrer, 4 klesstiler)
   graphics/DetailedCharacterSprite.js – høyoppløselig karakterportrett (64-grid) med utstyrsvisning for menyskjermer
   graphics/SceneBackgrounds.js – tematiske bakgrunner for leirplass og kjemilab
@@ -163,15 +163,22 @@ Heltens grunnstats gjør at verden 1 er farlig uten noe utstyr. Utstyr og evner 
 - **Monsterangrep:** `attack + 30% sjanse: +1`
 - **Forsvar:** trekkes fra innkommende skade, minimum 1
 
-### Monstere (v0.19 balanse)
+### Monstere (v0.35 balanse)
 | Type | Base-HP | Base-ATK | XP | HP-skala | ATK-skala |
 |------|---------|----------|-----|----------|-----------|
-| Goblin | 10 | 2 | 10 | +50% per verden | +25% per verden |
-| Orc | 18 | 4 | 25 | +50% per verden | +25% per verden |
-| Troll | 30 | 6 | 50 | +50% per verden | +25% per verden |
+| Goblin | 10 | 2 | 10 | +35% per verden (+15% ekstra etter V8) | +20% per verden (+8% ekstra etter V8) |
+| Orc | 18 | 4 | 25 | +35% per verden (+15% ekstra etter V8) | +20% per verden (+8% ekstra etter V8) |
+| Troll | 30 | 6 | 50 | +35% per verden (+15% ekstra etter V8) | +20% per verden (+8% ekstra etter V8) |
 | Boss | 50 + V×35 | 3 + V×2 | 150 | – (eget uttrykk) | – (570ms tick) |
 
-Verdensnummer V brukes til å skalere både HP og skade – kamp bør alltid føles risikofylt.
+Helten starter med 3 base-angrep. Verdensnummer V brukes til å skalere både HP og skade. Skalering er mykere tidlig og hardere sent for å bevare utfordringen.
+
+### Vanskelighetsgrader (v0.35)
+| Innstilling | Monster HP | Monster ATK | XP-bonus | Felle-skade |
+|-------------|-----------|-------------|----------|-------------|
+| Lett | ×0.50 | ×0.60 | ×1.30 | ×0.3 |
+| Normal | ×1.00 | ×1.00 | ×1.00 | ×1.0 |
+| Vanskelig | ×1.40 | ×1.25 | ×0.80 | ×1.6 |
 
 ### Bump-mekanikk
 Bevegelse inn i monster-rute: helten setter facing uten å angripe (visuell flash). Trykk SPACE/F for å angripe i facing-retning.
@@ -255,19 +262,21 @@ Våpen og rustning har sjeldenhetsgrader som påvirker stats:
 - **E** åpner/lukker; bruk holder inventory åpent (refresh-in-place)
 - **Venstreklikk:** bruk/utstyr — **Høyreklikk/Hold:** flytt til kjæledyr (eller slipp på gulvet)
 
-### Våpen (tier 1–4)
-Melee: Dolk, Tresverd, Spyd, Jernsverd, Stridsøks, Krigshammer, Trollstav
-Bue (R-angrep): Kortbue, Alvebue, Armbrøst
+### Våpen (tier 1–5)
+Melee: Dolk, Tresverd, Spyd, Jernsverd, Stridsøks, Krigshammer, Trollstav, Runesverd (T5), Mithriløks (T5)
+Bue (R-angrep): Kortbue, Alvebue, Armbrøst, Dragebue (T5)
 
-### Rustning (tier 1–4)
-Lærpansring, Vattert vest (+1 hjerte), Ringbrynje, Platedrakt, Magikappe, Drageskjell
+### Rustning (tier 1–5)
+Lærpansring, Vattert vest (+1 hjerte), Ringbrynje, Platedrakt, Magikappe, Drageskjell, Mithrilrustning (T5, +1 hjerte)
 
 ### Verktøy
 - **Nøkkel:** auto-konsumeres ved DOOR
 - **Hakke:** konsumeres ved SPACE/F mot CRACKED_WALL
 
 ### Forbruksgjenstander
-Livspotte, Stor livspotte, Styrkebrygg (midlertidig +2 ATK i 60 sek), Forsvarsbrygg (midlertidig +1 DEF i 60 sek), Hjerte-krystall, Erfaringsrulle, Kart-rulle, Bombe, Blendgranate, Motgift
+Livspotte, Stor livspotte, Styrkebrygg (midlertidig +ATK i 60 sek, skalerer med verden), Forsvarsbrygg (midlertidig +DEF i 60 sek, skalerer med verden), Hjerte-krystall, Erfaringsrulle, Kart-rulle, Bombe (skade skalerer med verden), Blendgranate (ATK-reduksjon skalerer med verden), Motgift
+
+**Verdenskalering (v0.35):** Bomber, potions og kjemiske produkter skalerer med +25% per verdensnummer. F.eks. en vanlig bombe gjør 6 skade i verden 1, ~15 i verden 5 og ~21 i verden 9.
 
 ---
 
@@ -364,7 +373,7 @@ Aktiveres automatisk når helten har evner fra begge stier i et par:
 | 4 monstertyper + sprites | ✅ Ferdig | Goblin, Orc, Troll, Boss |
 | Boss-faser (2 faser) | ✅ Ferdig | Fase 2 ved ≤50% HP: rasende, økt ATK |
 | Inventory + drop | ✅ Ferdig | 10-spors, høyreklikk-drop |
-| 27 gjenstander | ✅ Ferdig | Alle tier 1–4 |
+| 31 gjenstander | ✅ Ferdig | Alle tier 1–5 |
 | Skattekiste-system | ✅ Ferdig | 2–3 per verden |
 | Monster-drop system | ✅ Ferdig | 45% per drap, boss-garantert |
 | Nøkkel/hakke-mekanikk | ✅ Ferdig | |

--- a/src/constants.js
+++ b/src/constants.js
@@ -60,7 +60,7 @@ const BOSS_TICK_MS   = 570;  // ms between boss attack ticks (slower than regula
 const MOVE_DELAY_MS   = 140;  // ms between steps when key held
 const MOVE_ANIM_MS    = 90;   // ms for hero/monster slide tween
 
-const HERO_BASE_ATTACK  = 2;
+const HERO_BASE_ATTACK  = 3;
 const HERO_BASE_HEARTS  = 5;
 // v0.7 balance: monsters are significantly tougher
 const MONSTER_BASE_HP   = { goblin: 10, orc: 18,  troll: 30,  boss: 35 };

--- a/src/data/items.js
+++ b/src/data/items.js
@@ -93,6 +93,14 @@ const ITEM_DEFS = {
         id: 'magic_staff', name: 'Trollstav', type: 'weapon',
         color: 0xaa44ff, desc: '+3 Angrep, +2 Forsvar', atk: 3, def: 2, tier: 3
     },
+    runic_blade: {
+        id: 'runic_blade', name: 'Runesverd', type: 'weapon',
+        color: 0x44aaff, desc: '+6 Angrep', atk: 6, tier: 5
+    },
+    mithril_axe: {
+        id: 'mithril_axe', name: 'Mithriløks', type: 'weapon',
+        color: 0xaaddff, desc: '+7 Angrep', atk: 7, tier: 5
+    },
 
     // ── Ranged Weapons (subtype: 'bow') ───────────────────────────────────────
     shortbow: {
@@ -106,6 +114,10 @@ const ITEM_DEFS = {
     crossbow: {
         id: 'crossbow', name: 'Armbrøst', type: 'weapon', subtype: 'bow',
         color: 0x886644, desc: '+5 Angrep på avstand (trykk R)', atk: 5, tier: 4
+    },
+    dragon_bow: {
+        id: 'dragon_bow', name: 'Dragebue', type: 'weapon', subtype: 'bow',
+        color: 0xff6622, desc: '+7 Angrep på avstand (trykk R)', atk: 7, tier: 5
     },
 
     // ── Armor ─────────────────────────────────────────────────────────────────
@@ -133,6 +145,10 @@ const ITEM_DEFS = {
         id: 'dragon_scale', name: 'Drageskjell', type: 'armor',
         color: 0xff6622, desc: '+4 Forsvar', def: 4, tier: 4
     },
+    mithril_armor: {
+        id: 'mithril_armor', name: 'Mithrilrustning', type: 'armor',
+        color: 0xaaddff, desc: '+5 Forsvar, +1 Hjerte', def: 5, hearts: 1, tier: 5
+    },
 
     // ── Consumables ───────────────────────────────────────────────────────────
     health_pot: {
@@ -155,13 +171,23 @@ const ITEM_DEFS = {
     },
     strength_brew: {
         id: 'strength_brew', name: 'Styrkebrygg', type: 'consumable',
-        color: 0xff8800, desc: '+2 Angrep (60 sek)', tier: 2,
-        use(hero) { hero.addTempBuff('attack', 2, 60000); return true; }
+        color: 0xff8800, desc: '+Angrep (60 sek)', tier: 2,
+        use(hero, scene) {
+            const worldScale = 1 + ((scene?.worldNum || hero.worldNum || 1) - 1) * 0.15;
+            const amt = Math.max(2, Math.round(2 * worldScale));
+            hero.addTempBuff('attack', amt, 60000);
+            return true;
+        }
     },
     defense_brew: {
         id: 'defense_brew', name: 'Forsvarsbrygg', type: 'consumable',
-        color: 0x4488ff, desc: '+1 Forsvar (60 sek)', tier: 2,
-        use(hero) { hero.addTempBuff('defense', 1, 60000); return true; }
+        color: 0x4488ff, desc: '+Forsvar (60 sek)', tier: 2,
+        use(hero, scene) {
+            const worldScale = 1 + ((scene?.worldNum || hero.worldNum || 1) - 1) * 0.15;
+            const amt = Math.max(1, Math.round(1 * worldScale));
+            hero.addTempBuff('defense', amt, 60000);
+            return true;
+        }
     },
     xp_scroll: {
         id: 'xp_scroll', name: 'Erfaringsrulle', type: 'consumable',
@@ -202,36 +228,38 @@ const ITEM_DEFS = {
     },
     bomb: {
         id: 'bomb', name: 'Bombe', type: 'consumable',
-        color: 0x333333, desc: 'Skader alle monstre innen 3 ruter (6 skade). Tilordne til Q.', tier: 2,
+        color: 0x333333, desc: 'Skader alle monstre innen 3 ruter. Tilordne til Q.', tier: 2,
         use(hero, scene) {
             if (!scene) return false;
+            const worldScale = 1 + ((scene.worldNum || 1) - 1) * 0.25;
+            const baseDmg = Math.round(6 * worldScale);
             let hits = 0;
             for (const m of scene.monsters) {
                 if (!m.alive) continue;
                 const d = Math.abs(m.gridX - hero.gridX) + Math.abs(m.gridY - hero.gridY);
-                if (d <= 3) { m.takeDamage(6); hits++; }
+                if (d <= 3) { m.takeDamage(baseDmg); hits++; }
             }
             scene.monsters = scene.monsters.filter(m => m.alive);
-            // Visual explosion effect
             scene.cameras.main.shake(200, 0.015);
-            scene._floatingText(hero.gridX, hero.gridY, `💥 Bombe! ${hits} treff`, '#ff4400');
+            scene._floatingText(hero.gridX, hero.gridY, `💥 Bombe! ${hits} treff (${baseDmg})`, '#ff4400');
             return true;
         }
     },
     flashbang: {
         id: 'flashbang', name: 'Blendgranate', type: 'consumable',
-        color: 0xffffcc, desc: 'Halvér angrepet til monstre innen 4 ruter. Tilordne til Q.', tier: 2,
+        color: 0xffffcc, desc: 'Redusér angrepet til monstre innen 4 ruter. Tilordne til Q.', tier: 2,
         use(hero, scene) {
             if (!scene) return false;
+            const worldScale = 1 + ((scene.worldNum || 1) - 1) * 0.1;
+            const reduction = Math.max(2, Math.round(2 * worldScale));
             let hits = 0;
             for (const m of scene.monsters) {
                 if (!m.alive) continue;
                 const d = Math.abs(m.gridX - hero.gridX) + Math.abs(m.gridY - hero.gridY);
-                if (d <= 4) { m.attack = Math.max(1, Math.floor(m.attack / 2)); hits++; }
+                if (d <= 4) { m.attack = Math.max(1, m.attack - reduction); hits++; }
             }
-            // Visual flash effect
             scene.cameras.main.flash(200, 255, 255, 200);
-            scene._floatingText(hero.gridX, hero.gridY, `✦ Blendet ${hits} monstre!`, '#ffffaa');
+            scene._floatingText(hero.gridX, hero.gridY, `✦ Blendet ${hits} monstre! (-${reduction} ATK)`, '#ffffaa');
             return true;
         }
     },
@@ -291,6 +319,9 @@ const ITEM_POOL = {
         'flashbang', 'heart_crystal', 'map_scroll', 'frost_salve', 'burn_salve'],
     4: ['war_hammer', 'crossbow', 'magic_staff', 'robe_magic', 'plate_armor',
         'dragon_scale', 'big_health_pot', 'strength_brew', 'bomb',
+        'heart_crystal', 'flashbang', 'frost_salve', 'burn_salve'],
+    5: ['runic_blade', 'mithril_axe', 'dragon_bow', 'mithril_armor',
+        'dragon_scale', 'big_health_pot', 'strength_brew', 'bomb',
         'heart_crystal', 'flashbang', 'frost_salve', 'burn_salve']
 };
 
@@ -299,7 +330,7 @@ const ITEM_POOL = {
  *  @param {number} minRarityIdx  Minimum rarity (0=common, 1=rare, etc.)
  */
 function randomItemForWorld(worldNum, minRarityIdx = 0) {
-    const tier = Math.min(4, Math.ceil(worldNum / 2));
+    const tier = Math.min(5, Math.ceil(worldNum / 2));
     const pool = ITEM_POOL[tier];
     const baseDef = ITEM_DEFS[pool[Math.floor(Math.random() * pool.length)]];
     const rarity = rollRarity(worldNum, minRarityIdx);
@@ -308,7 +339,7 @@ function randomItemForWorld(worldNum, minRarityIdx = 0) {
 
 /** Return a random item of a specific type for the given tier, excluding ids in the exclude Set */
 function randomItemByType(worldNum, type, exclude = new Set(), minRarityIdx = 0) {
-    const tier = Math.min(4, Math.ceil(worldNum / 2));
+    const tier = Math.min(5, Math.ceil(worldNum / 2));
     const pool = ITEM_POOL[tier].filter(id => ITEM_DEFS[id].type === type && !exclude.has(id));
     if (pool.length === 0) return null;
     const baseDef = ITEM_DEFS[pool[Math.floor(Math.random() * pool.length)]];

--- a/src/data/items.js
+++ b/src/data/items.js
@@ -231,8 +231,8 @@ const ITEM_DEFS = {
         color: 0x333333, desc: 'Skader alle monstre innen 3 ruter. Tilordne til Q.', tier: 2,
         use(hero, scene) {
             if (!scene) return false;
-            const worldScale = 1 + ((scene.worldNum || 1) - 1) * 0.25;
-            const baseDmg = Math.round(6 * worldScale);
+            const worldScale = 1 + ((scene.worldNum || 1) - 1) * 0.4;
+            const baseDmg = Math.round(8 * worldScale);
             let hits = 0;
             for (const m of scene.monsters) {
                 if (!m.alive) continue;

--- a/src/data/molecules.js
+++ b/src/data/molecules.js
@@ -26,8 +26,8 @@ const MOLECULE_DEFS = {
         formula: 'KNO₃', tier: 2, color: 0xcccccc, stackSize: 20,
         recipe: [{ symbol: 'K', amount: 1 }, { symbol: 'N', amount: 1 }],
         energyCost: 1,
-        effects: { onUse: 'bomb', damage: 5, radius: 2 },
-        desc: 'Svakt sprengstoff. 5 skade i radius 2.'
+        effects: { onUse: 'bomb', damage: 8, radius: 2 },
+        desc: 'Svakt sprengstoff. 8 skade i radius 2.'
     },
 
     // ── Acids ────────────────────────────────────────────────────────────────
@@ -36,15 +36,15 @@ const MOLECULE_DEFS = {
         formula: 'H₂SO₄', tier: 2, color: 0xdddd00, stackSize: 10,
         recipe: [{ symbol: 'S', amount: 1 }, { symbol: 'H', amount: 1 }],
         energyCost: 1,
-        effects: { onUse: 'acid_bomb', damage: 4, radius: 2, statusEffect: 'acid_burn', duration: 3 },
-        desc: 'Sterk syre. Kast for å etse monstre (4 skade).'
+        effects: { onUse: 'acid_bomb', damage: 7, radius: 2, statusEffect: 'acid_burn', duration: 3 },
+        desc: 'Sterk syre. Kast for å etse monstre (7 skade).'
     },
     hydrochloric_acid: {
         id: 'hydrochloric_acid', name: 'Saltsyre', type: 'molecule', subtype: 'acid',
         formula: 'HCl', tier: 2, color: 0xaaff44, stackSize: 10,
         recipe: [{ symbol: 'H', amount: 1 }, { symbol: 'Cl', amount: 1 }],
         energyCost: 1,
-        effects: { onUse: 'acid_bomb', damage: 3, radius: 2, statusEffect: 'acid_burn', duration: 2 },
+        effects: { onUse: 'acid_bomb', damage: 5, radius: 2, statusEffect: 'acid_burn', duration: 2 },
         desc: 'Svakere syre. Billig å lage.'
     },
 
@@ -106,8 +106,8 @@ const MOLECULE_DEFS = {
         formula: 'K + S + C', tier: 2, color: 0x333333, stackSize: 10,
         recipe: [{ symbol: 'K', amount: 1 }, { symbol: 'S', amount: 1 }, { symbol: 'C', amount: 1 }],
         energyCost: 1,
-        effects: { onUse: 'bomb', damage: 8, radius: 3 },
-        desc: 'Klassisk krutt. 8 skade i radius 3.'
+        effects: { onUse: 'bomb', damage: 12, radius: 3 },
+        desc: 'Klassisk krutt. 12 skade i radius 3.'
     },
     smoke_bomb: {
         id: 'smoke_bomb', name: 'Røykbombe', type: 'molecule', subtype: 'explosive',
@@ -122,16 +122,16 @@ const MOLECULE_DEFS = {
         formula: 'S + Fe', tier: 3, color: 0xcccc00, stackSize: 5,
         recipe: [{ symbol: 'S', amount: 2 }, { symbol: 'Fe', amount: 1 }],
         energyCost: 2,
-        effects: { onUse: 'acid_bomb', damage: 6, radius: 3, statusEffect: 'acid_burn', duration: 4 },
-        desc: 'AoE syreskade: 6 skade + etsende i 4 runder.'
+        effects: { onUse: 'acid_bomb', damage: 10, radius: 3, statusEffect: 'acid_burn', duration: 4 },
+        desc: 'AoE syreskade: 10 skade + etsende i 4 runder.'
     },
     dynamite: {
         id: 'dynamite', name: 'Dynamitt', type: 'molecule', subtype: 'explosive',
         formula: 'C + N', tier: 4, color: 0xff4422, stackSize: 5,
         recipe: [{ symbol: 'C', amount: 2 }, { symbol: 'N', amount: 2 }],
         energyCost: 3,
-        effects: { onUse: 'bomb', damage: 15, radius: 4 },
-        desc: 'Massiv eksplosjon! 15 skade i radius 4.'
+        effects: { onUse: 'bomb', damage: 20, radius: 4 },
+        desc: 'Massiv eksplosjon! 20 skade i radius 4.'
     },
 };
 

--- a/src/entities/Monster.js
+++ b/src/entities/Monster.js
@@ -10,8 +10,8 @@ class Monster {
 
         // Stats from lookup tables in constants.js
         const worldMul = scene.worldNum || 1;
-        const hpScale  = 1 + (worldMul - 1) * 0.5;
-        const atkScale = 1 + (worldMul - 1) * 0.25;
+        const hpScale  = 1 + (worldMul - 1) * 0.35 + Math.max(0, worldMul - 8) * 0.15;
+        const atkScale = 1 + (worldMul - 1) * 0.20 + Math.max(0, worldMul - 8) * 0.08;
 
         this.maxHp    = Math.round((MONSTER_BASE_HP[type]  || 4) * hpScale);
         this.hp       = this.maxHp;

--- a/src/scenes/ChemLabScene.js
+++ b/src/scenes/ChemLabScene.js
@@ -7,6 +7,7 @@ class ChemLabScene extends Phaser.Scene {
 
     init(data) {
         this.heroRef = data.heroRef || null;
+        this.worldNum = data.worldNum || 1;
     }
 
     create() {
@@ -239,7 +240,7 @@ class ChemLabScene extends Phaser.Scene {
 
     _doSynthesize(moleculeId) {
         const hero = this.heroRef;
-        const result = this.chem.synthesize(moleculeId, hero);
+        const result = this.chem.synthesize(moleculeId, hero, this.worldNum);
         if (!result.success) return;
 
         // Consume fuel if needed

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -18,7 +18,7 @@ class GameScene extends Phaser.Scene {
     /** Returns multipliers based on difficulty setting */
     _diffMods() {
         switch (this.difficulty) {
-            case 'easy': return { hpMul: 0.65, atkMul: 0.75, trapCount: 0, xpMul: 1.20, trapDmgMul: 0.5 };
+            case 'easy': return { hpMul: 0.50, atkMul: 0.60, trapCount: 0, xpMul: 1.30, trapDmgMul: 0.3 };
             case 'hard': return { hpMul: 1.40, atkMul: 1.25, trapCount: 3, xpMul: 0.80, trapDmgMul: 1.6 };
             default:     return { hpMul: 1.00, atkMul: 1.00, trapCount: 0, xpMul: 1.00, trapDmgMul: 1.0 };
         }
@@ -58,6 +58,7 @@ class GameScene extends Phaser.Scene {
 
         // ── Hero ─────────────────────────────────────────────────────────────
         this.hero = new Hero(this, 1, 1);
+        this.hero.worldNum = this.worldNum;
         this._shownSynergies = [];
         if (this.heroStats) {
             this.hero.applyStats(this.heroStats, true);
@@ -175,7 +176,9 @@ class GameScene extends Phaser.Scene {
             if (Phaser.Input.Keyboard.JustDown(this.eKey) || touchInv) {
                 this.scene.launch('InventoryScene');
             }
-            if (Phaser.Input.Keyboard.JustDown(this.elementBookKey) && !this.scene.isActive('ElementBookScene')) {
+            const touchBook = this.game.registry.get('touch_elementbook');
+            if (touchBook) this.game.registry.set('touch_elementbook', false);
+            if ((Phaser.Input.Keyboard.JustDown(this.elementBookKey) || touchBook) && !this.scene.isActive('ElementBookScene')) {
                 this.scene.launch('ElementBookScene', { heroRef: this.hero });
             }
             const touchSmelt = this.game.registry.get('touch_smeltery');
@@ -188,13 +191,15 @@ class GameScene extends Phaser.Scene {
             if (touchChem) this.game.registry.set('touch_chemlab', false);
             if ((Phaser.Input.Keyboard.JustDown(this.chemLabKey) || touchChem) && !this.scene.isActive('ChemLabScene') && this._isInChemLab()) {
                 if (this.hero.chemLabUnlocked) {
-                    this.scene.launch('ChemLabScene', { heroRef: this.hero });
+                    this.scene.launch('ChemLabScene', { heroRef: this.hero, worldNum: this.worldNum });
                 } else {
                     this._showMessage('Beseir en soneboss for å låse opp laboratoriet!', '#33dd88');
                 }
             }
 
-            if (Phaser.Input.Keyboard.JustDown(this.skillTreeKey) && !this.scene.isActive('SkillScene')) {
+            const touchSkill = this.game.registry.get('touch_skilltree');
+            if (touchSkill) this.game.registry.set('touch_skilltree', false);
+            if ((Phaser.Input.Keyboard.JustDown(this.skillTreeKey) || touchSkill) && !this.scene.isActive('SkillScene')) {
                 this.scene.launch('SkillScene', { heroRef: this.hero, viewOnly: true });
             }
 

--- a/src/scenes/LeaderboardScene.js
+++ b/src/scenes/LeaderboardScene.js
@@ -41,6 +41,17 @@ class LeaderboardScene extends Phaser.Scene {
             this._refreshList();
         });
 
+        // Close button (top-right)
+        const closeBtn = this.add.text(W - 30, 30, '✕', {
+            fontSize: '20px', color: '#667788', fontFamily: 'monospace'
+        }).setOrigin(0.5).setInteractive({ useHandCursor: true });
+        closeBtn.on('pointerover', () => closeBtn.setColor('#ff6666'));
+        closeBtn.on('pointerout',  () => closeBtn.setColor('#667788'));
+        closeBtn.on('pointerdown', () => this.scene.start('MenuScene'));
+
+        // ESC keyboard shortcut
+        this.input.keyboard.on('keydown-ESC', () => this.scene.start('MenuScene'));
+
         // Back button
         const back = this.add.text(cx, H - 30, '[ TILBAKE ]', {
             fontSize: '18px', color: '#666688', fontFamily: 'monospace'

--- a/src/scenes/SkillScene.js
+++ b/src/scenes/SkillScene.js
@@ -45,6 +45,14 @@ class SkillScene extends Phaser.Scene {
         if (this.viewOnly) {
             this.input.keyboard.on('keydown-T', () => this.scene.stop());
             this.input.keyboard.on('keydown-ESC', () => this.scene.stop());
+
+            // Close button (top-right)
+            const closeBtn = this.add.text(px + panelW - 20, py + 8, '✕', {
+                fontSize: '18px', color: '#88aacc', fontFamily: 'monospace'
+            }).setOrigin(0.5).setInteractive({ useHandCursor: true });
+            closeBtn.on('pointerover', () => closeBtn.setColor('#ff6666'));
+            closeBtn.on('pointerout',  () => closeBtn.setColor('#88aacc'));
+            closeBtn.on('pointerdown', () => this.scene.stop());
         }
 
         this.add.rectangle(cx, py + 38, panelW - 30, 1, 0x2a2060);

--- a/src/scenes/UIScene.js
+++ b/src/scenes/UIScene.js
@@ -362,5 +362,10 @@ class UIScene extends Phaser.Scene {
         } else {
             this.bossBar.setVisible(false);
         }
+
+        // ── Touch button visibility (unlock-gated) ───────────────────────────
+        if (this.touchControls) {
+            this.touchControls.updateVisibility(hero);
+        }
     }
 }

--- a/src/systems/AudioManager.js
+++ b/src/systems/AudioManager.js
@@ -140,7 +140,11 @@ const Audio = (function () {
 
         /** Call once on first user gesture (browser AudioContext requirement) */
         init() {
-            if (ctx) return;
+            if (ctx) {
+                // Context already created but might be suspended (browser autoplay policy)
+                if (ctx.state === 'suspended') ctx.resume();
+                return;
+            }
             try {
                 ctx = new (window.AudioContext || window.webkitAudioContext)();
                 masterGain = ctx.createGain();

--- a/src/systems/ChemistrySystem.js
+++ b/src/systems/ChemistrySystem.js
@@ -87,7 +87,7 @@ class ChemistrySystem {
     _createUsableItem(mol, hero, worldNum) {
         const eff = mol.effects;
         const wn = worldNum || hero.worldNum || 1;
-        const worldScale = 1 + (wn - 1) * 0.25;
+        const worldScale = 1 + (wn - 1) * 0.4;
         const potencyMul = 1 + (hero.potionPotencyBonus || 0);
         const durationMul = 1 + (hero.potionDurationBonus || 0);
         const bombDmgMul = 1 + (hero.chemBombBonus || 0);

--- a/src/systems/ChemistrySystem.js
+++ b/src/systems/ChemistrySystem.js
@@ -42,7 +42,7 @@ class ChemistrySystem {
      * @param {object} hero
      * @returns {{ success: boolean, item: object, energyCost: number }}
      */
-    synthesize(moleculeId, hero) {
+    synthesize(moleculeId, hero, worldNum) {
         const mol = MOLECULE_DEFS[moleculeId];
         if (!mol) return { success: false };
 
@@ -57,7 +57,7 @@ class ChemistrySystem {
         const energyCost = this._adjustedEnergy(mol.energyCost, hero);
 
         // Create usable item from molecule definition
-        const item = this._createUsableItem(mol, hero);
+        const item = this._createUsableItem(mol, hero, worldNum);
 
         return { success: true, item, energyCost };
     }
@@ -84,8 +84,10 @@ class ChemistrySystem {
 
     // ── Create usable inventory item from molecule ──────────────────────────
 
-    _createUsableItem(mol, hero) {
+    _createUsableItem(mol, hero, worldNum) {
         const eff = mol.effects;
+        const wn = worldNum || hero.worldNum || 1;
+        const worldScale = 1 + (wn - 1) * 0.25;
         const potencyMul = 1 + (hero.potionPotencyBonus || 0);
         const durationMul = 1 + (hero.potionDurationBonus || 0);
         const bombDmgMul = 1 + (hero.chemBombBonus || 0);
@@ -109,7 +111,7 @@ class ChemistrySystem {
 
         // Build the use() function based on effect type
         if (eff.onUse === 'heal') {
-            const hp = Math.round(eff.healHP * potencyMul);
+            const hp = Math.round(eff.healHP * potencyMul * worldScale);
             item.desc = `+${hp} HP`;
             item.use = (hero, scene) => {
                 hero.hearts = Math.min(hero.hearts + hp, hero.maxHearts);
@@ -117,7 +119,7 @@ class ChemistrySystem {
                 return true;
             };
         } else if (eff.onUse === 'buff') {
-            const amt = Math.round(eff.amount * potencyMul);
+            const amt = Math.round(eff.amount * potencyMul * worldScale);
             const dur = Math.round(eff.durationMs * durationMul);
             item.desc = `+${amt} ${eff.stat} (${Math.round(dur / 1000)}s)`;
             item.use = (hero) => {
@@ -125,7 +127,7 @@ class ChemistrySystem {
                 return true;
             };
         } else if (eff.onUse === 'cure_all') {
-            const hp = Math.round((eff.healHP || 0) * potencyMul);
+            const hp = Math.round((eff.healHP || 0) * potencyMul * worldScale);
             item.use = (hero, scene) => {
                 hero.clearAllEffects();
                 if (hp > 0) hero.hearts = Math.min(hero.hearts + hp, hero.maxHearts);
@@ -133,7 +135,7 @@ class ChemistrySystem {
                 return true;
             };
         } else if (eff.onUse === 'bomb') {
-            const dmg = Math.round(eff.damage * bombDmgMul);
+            const dmg = Math.round(eff.damage * bombDmgMul * worldScale);
             const rad = Math.round(eff.radius * bombRadMul);
             item.desc = `${dmg} skade, radius ${rad}`;
             item.use = (hero, scene) => {
@@ -147,7 +149,7 @@ class ChemistrySystem {
                 return true;
             };
         } else if (eff.onUse === 'acid_bomb') {
-            const dmg = Math.round(eff.damage * bombDmgMul);
+            const dmg = Math.round(eff.damage * bombDmgMul * worldScale);
             const rad = Math.round(eff.radius * bombRadMul);
             const dur = eff.duration || 3;
             item.desc = `${dmg} skade + etsende ${dur} runder, radius ${rad}`;

--- a/src/systems/TouchControls.js
+++ b/src/systems/TouchControls.js
@@ -6,6 +6,7 @@ class TouchControls {
         this.game  = scene.game;
         this.widgets = [];
         this._menuWidgets = []; // menu buttons tracked separately for visibility
+        this._domDpad = null;   // DOM-based d-pad container (for off-canvas placement)
     }
 
     create() {
@@ -27,67 +28,125 @@ class TouchControls {
         this._createDpad();
         this._createActionButtons();
         this._createMenuButtons();
+
+        // Reposition DOM d-pad on resize / orientation change
+        this._resizeHandler = () => this._repositionDomDpad();
+        window.addEventListener('resize', this._resizeHandler);
     }
 
-    // ── D-Pad (bottom-left, shifted further left on wide screens) ────────────
+    // ── D-Pad ────────────────────────────────────────────────────────────────
+    // Uses DOM elements so the d-pad can be placed outside the game canvas
+    // in the letterbox area on wide screens.
 
     _createDpad() {
-        const sz   = 58;
-        const gap  = 6;
-        const W = this.scene.cameras.main.width;
-        const H = this.scene.cameras.main.height;
-        // Move d-pad further left: use 15% from left edge, but cap at original position
-        const baseX = Math.min(24 + sz + gap, Math.round(W * 0.06) + sz / 2);
-        const baseY = H - 24 - sz - gap;
+        const reg = this.game.registry;
+
+        // Create a DOM container for the d-pad
+        const container = document.createElement('div');
+        container.id = 'touch-dpad';
+        container.style.cssText = 'position:fixed;z-index:9999;pointer-events:none;';
+        document.body.appendChild(container);
+        this._domDpad = container;
+
+        const sz = 58;
+        const gap = 6;
 
         const directions = [
-            { label: '\u25B2', dx:  0, dy: -1, ox: 0,           oy: -(sz + gap) },
-            { label: '\u25BC', dx:  0, dy:  1, ox: 0,           oy:  (sz + gap) },
-            { label: '\u25C0', dx: -1, dy:  0, ox: -(sz + gap), oy: 0           },
-            { label: '\u25B6', dx:  1, dy:  0, ox:  (sz + gap), oy: 0           },
+            { label: '\u25B2', dx:  0, dy: -1, ox: 0,            oy: -(sz + gap) },
+            { label: '\u25BC', dx:  0, dy:  1, ox: 0,            oy:  (sz + gap) },
+            { label: '\u25C0', dx: -1, dy:  0, ox: -(sz + gap),  oy: 0           },
+            { label: '\u25B6', dx:  1, dy:  0, ox:  (sz + gap),  oy: 0           },
         ];
 
+        this._dpadButtons = [];
         for (const dir of directions) {
-            const x = baseX + dir.ox;
-            const y = baseY + dir.oy;
-            this._makeDpadButton(x, y, sz, dir.label, dir.dx, dir.dy);
+            const btn = document.createElement('div');
+            btn.textContent = dir.label;
+            btn.style.cssText = `
+                position:absolute;
+                width:${sz}px; height:${sz}px;
+                border-radius:10px;
+                background:rgba(51,68,102,0.5);
+                border:2px solid rgba(51,68,102,0.7);
+                color:#aabbdd;
+                font-family:monospace;
+                font-size:26px;
+                display:flex; align-items:center; justify-content:center;
+                pointer-events:auto;
+                user-select:none;
+                -webkit-user-select:none;
+                touch-action:none;
+            `;
+            // Position relative to container center
+            btn._ox = dir.ox;
+            btn._oy = dir.oy;
+
+            btn.addEventListener('touchstart', (e) => {
+                e.preventDefault();
+                reg.set('touch_dx', dir.dx);
+                reg.set('touch_dy', dir.dy);
+                btn.style.background = 'rgba(68,102,170,0.75)';
+                btn.style.color = '#ffffff';
+            }, { passive: false });
+
+            const release = () => {
+                reg.set('touch_dx', 0);
+                reg.set('touch_dy', 0);
+                btn.style.background = 'rgba(51,68,102,0.5)';
+                btn.style.color = '#aabbdd';
+            };
+
+            btn.addEventListener('touchend', release);
+            btn.addEventListener('touchcancel', release);
+
+            container.appendChild(btn);
+            this._dpadButtons.push(btn);
         }
+
+        // Position immediately
+        this._repositionDomDpad();
     }
 
-    _makeDpadButton(x, y, sz, label, dx, dy) {
-        const scene = this.scene;
-        const reg   = this.game.registry;
-        const alpha = 0.4;
-        const pressAlpha = 0.75;
+    /** Reposition DOM d-pad: place in letterbox area if space, otherwise over canvas left edge */
+    _repositionDomDpad() {
+        if (!this._domDpad) return;
 
-        const bg = scene.add.graphics();
-        this._drawRoundedBtn(bg, x, y, sz, 0x334466, alpha);
-        bg.setDepth(100);
+        const canvas = this.game.canvas;
+        const rect = canvas.getBoundingClientRect();
+        const sz = 58;
+        const gap = 6;
+        const dpadW = sz * 3 + gap * 2; // total d-pad width
+        const dpadH = sz * 3 + gap * 2; // total d-pad height
 
-        const txt = scene.add.text(x, y, label, {
-            fontSize: '26px', color: '#aabbdd', fontFamily: 'monospace'
-        }).setOrigin(0.5).setDepth(101).setAlpha(0.7);
+        // Available space to the left of the game canvas
+        const leftSpace = rect.left;
 
-        const zone = scene.add.zone(x, y, sz, sz).setInteractive().setDepth(102);
+        // Center of d-pad placement
+        let centerX, centerY;
 
-        zone.on('pointerdown', () => {
-            reg.set('touch_dx', dx);
-            reg.set('touch_dy', dy);
-            this._drawRoundedBtn(bg, x, y, sz, 0x4466aa, pressAlpha);
-            txt.setAlpha(1);
-        });
+        if (leftSpace > dpadW / 2 + 20) {
+            // Enough space in the letterbox: place d-pad centered in the left bar
+            centerX = leftSpace / 2;
+        } else {
+            // Not enough space: place at left edge of canvas + small offset
+            centerX = rect.left + (sz + gap + 24) * (rect.width / 1280);
+        }
 
-        const release = () => {
-            reg.set('touch_dx', 0);
-            reg.set('touch_dy', 0);
-            this._drawRoundedBtn(bg, x, y, sz, 0x334466, alpha);
-            txt.setAlpha(0.7);
-        };
+        // Vertically: bottom area of the screen, matching game's bottom area
+        centerY = rect.bottom - (24 + sz + gap) * (rect.height / 800);
 
-        zone.on('pointerup', release);
-        zone.on('pointerout', release);
-
-        this.widgets.push(bg, txt, zone);
+        // Position each button relative to center
+        for (const btn of this._dpadButtons) {
+            const scale = rect.height / 800; // scale buttons with canvas
+            const scaledSz = Math.round(sz * scale);
+            const scaledGap = Math.round(gap * scale);
+            btn.style.width = scaledSz + 'px';
+            btn.style.height = scaledSz + 'px';
+            btn.style.fontSize = Math.round(26 * scale) + 'px';
+            btn.style.borderRadius = Math.round(10 * scale) + 'px';
+            btn.style.left = Math.round(centerX + btn._ox * scale - scaledSz / 2) + 'px';
+            btn.style.top  = Math.round(centerY + btn._oy * scale - scaledSz / 2) + 'px';
+        }
     }
 
     // ── Action Buttons (bottom-right, always visible) ────────────────────────
@@ -319,5 +378,15 @@ class TouchControls {
         for (const w of this.widgets) w.destroy();
         this.widgets = [];
         this._menuWidgets = [];
+        // Clean up DOM d-pad
+        if (this._domDpad) {
+            this._domDpad.remove();
+            this._domDpad = null;
+        }
+        if (this._resizeHandler) {
+            window.removeEventListener('resize', this._resizeHandler);
+            this._resizeHandler = null;
+        }
+        this._dpadButtons = [];
     }
 }

--- a/src/systems/TouchControls.js
+++ b/src/systems/TouchControls.js
@@ -29,15 +29,11 @@ class TouchControls {
         this._createDpad();
         this._createActionButtons();
         this._createMenuButtons();
-
-        // Reposition DOM d-pad on resize / orientation change
-        this._resizeHandler = () => this._repositionDomDpad();
-        window.addEventListener('resize', this._resizeHandler);
     }
 
     // ── D-Pad ────────────────────────────────────────────────────────────────
-    // Uses DOM elements so the d-pad can be placed outside the game canvas
-    // in the letterbox area on wide screens.
+    // DOM-based d-pad fixed to the bottom-left corner of the viewport.
+    // CSS position:fixed handles rotation and resize automatically.
 
     _createDpad() {
         const reg = this.game.registry;
@@ -46,51 +42,69 @@ class TouchControls {
         const old = document.getElementById('touch-dpad');
         if (old) old.remove();
 
-        // Create a full-viewport fixed container
+        // Container: fixed to bottom-left, no JS repositioning needed
         const container = document.createElement('div');
         container.id = 'touch-dpad';
         container.style.cssText =
-            'position:fixed;top:0;left:0;width:100vw;height:100vh;' +
-            'z-index:9999;pointer-events:none;overflow:visible;';
+            'position:fixed;bottom:12px;left:12px;' +
+            'z-index:9999;pointer-events:none;';
         document.body.appendChild(container);
         this._domDpad = container;
 
-        const sz = 58;
-        const gap = 6;
+        // Use vmin-based sizing so buttons scale with screen size
+        // 8vmin ≈ 58px on a 720px screen, scales up/down naturally
+        const btnSize = '8vmin';
+        const btnGap  = '1vmin';
+        const fontSize = '3.5vmin';
 
-        const directions = [
-            { label: '\u25B2', dx:  0, dy: -1, ox: 0,            oy: -(sz + gap) },
-            { label: '\u25BC', dx:  0, dy:  1, ox: 0,            oy:  (sz + gap) },
-            { label: '\u25C0', dx: -1, dy:  0, ox: -(sz + gap),  oy: 0           },
-            { label: '\u25B6', dx:  1, dy:  0, ox:  (sz + gap),  oy: 0           },
+        // D-pad grid: 3×3 grid with buttons at cross positions
+        const grid = document.createElement('div');
+        grid.style.cssText =
+            'display:grid;' +
+            'grid-template-columns:' + btnSize + ' ' + btnSize + ' ' + btnSize + ';' +
+            'grid-template-rows:' + btnSize + ' ' + btnSize + ' ' + btnSize + ';' +
+            'gap:' + btnGap + ';';
+        container.appendChild(grid);
+
+        // Grid cells: 0=empty, {label,dx,dy} = button
+        const cells = [
+            null,                                   // 0,0
+            { label: '\u25B2', dx:  0, dy: -1 },   // 1,0 (up)
+            null,                                   // 2,0
+            { label: '\u25C0', dx: -1, dy:  0 },   // 0,1 (left)
+            null,                                   // 1,1 (center - empty)
+            { label: '\u25B6', dx:  1, dy:  0 },   // 2,1 (right)
+            null,                                   // 0,2
+            { label: '\u25BC', dx:  0, dy:  1 },   // 1,2 (down)
+            null,                                   // 2,2
         ];
 
         this._dpadButtons = [];
-        for (const dir of directions) {
+        for (const cell of cells) {
+            if (!cell) {
+                // Empty grid cell
+                const spacer = document.createElement('div');
+                grid.appendChild(spacer);
+                continue;
+            }
+
             const btn = document.createElement('div');
-            btn.textContent = dir.label;
+            btn.textContent = cell.label;
             btn.style.cssText =
-                'position:absolute;' +
-                'width:' + sz + 'px;height:' + sz + 'px;' +
                 'border-radius:10px;' +
                 'background:rgba(51,68,102,0.5);' +
                 'border:2px solid rgba(51,68,102,0.7);' +
                 'color:#aabbdd;' +
-                'font-family:monospace;font-size:26px;' +
+                'font-family:monospace;font-size:' + fontSize + ';' +
                 'display:flex;align-items:center;justify-content:center;' +
                 'pointer-events:auto;' +
                 'user-select:none;-webkit-user-select:none;' +
                 'touch-action:none;';
 
-            // Store offset for positioning
-            btn._ox = dir.ox;
-            btn._oy = dir.oy;
-
-            // Press handler (both touch and mouse)
             const onPress = (e) => {
                 e.preventDefault();
-                reg.set('touch_dx', dir.dx);
-                reg.set('touch_dy', dir.dy);
+                reg.set('touch_dx', cell.dx);
+                reg.set('touch_dy', cell.dy);
                 btn.style.background = 'rgba(68,102,170,0.75)';
                 btn.style.color = '#ffffff';
             };
@@ -109,65 +123,8 @@ class TouchControls {
             btn.addEventListener('mouseup', onRelease);
             btn.addEventListener('mouseleave', onRelease);
 
-            container.appendChild(btn);
+            grid.appendChild(btn);
             this._dpadButtons.push(btn);
-        }
-
-        // Position after a short delay so the canvas has time to be sized
-        requestAnimationFrame(() => {
-            requestAnimationFrame(() => {
-                this._repositionDomDpad();
-            });
-        });
-    }
-
-    /** Reposition DOM d-pad: place in letterbox area if space, otherwise over canvas left edge */
-    _repositionDomDpad() {
-        if (!this._domDpad || !this._dpadButtons.length) return;
-
-        const canvas = this.game.canvas;
-        const rect = canvas.getBoundingClientRect();
-
-        // Guard: if canvas isn't rendered yet, retry next frame
-        if (rect.width === 0 || rect.height === 0) {
-            requestAnimationFrame(() => this._repositionDomDpad());
-            return;
-        }
-
-        const sz = 58;
-        const gap = 6;
-        const dpadW = sz * 3 + gap * 2;
-
-        // Scale factor: how much the canvas is scaled from internal 1280x800
-        const scale = rect.height / 800;
-
-        // Available space to the left of the game canvas
-        const leftSpace = rect.left;
-
-        // Center of d-pad placement
-        let centerX, centerY;
-
-        if (leftSpace > dpadW * scale / 2 + 20) {
-            // Enough space in the letterbox: place d-pad centered in the left bar
-            centerX = leftSpace / 2;
-        } else {
-            // Not enough space: place at left edge of canvas + offset (inside canvas)
-            centerX = rect.left + (sz + gap + 24) * scale;
-        }
-
-        // Vertically: bottom area of the screen
-        centerY = rect.bottom - (24 + sz + gap) * scale;
-
-        // Position and scale each button
-        for (const btn of this._dpadButtons) {
-            const scaledSz  = Math.round(sz * scale);
-            const scaledGap = Math.round(gap * scale);
-            btn.style.width  = scaledSz + 'px';
-            btn.style.height = scaledSz + 'px';
-            btn.style.fontSize    = Math.round(26 * scale) + 'px';
-            btn.style.borderRadius = Math.round(10 * scale) + 'px';
-            btn.style.left = Math.round(centerX + btn._ox * scale - scaledSz / 2) + 'px';
-            btn.style.top  = Math.round(centerY + btn._oy * scale - scaledSz / 2) + 'px';
         }
     }
 
@@ -396,10 +353,6 @@ class TouchControls {
         if (this._domDpad) {
             this._domDpad.remove();
             this._domDpad = null;
-        }
-        if (this._resizeHandler) {
-            window.removeEventListener('resize', this._resizeHandler);
-            this._resizeHandler = null;
         }
         this._dpadButtons = [];
     }

--- a/src/systems/TouchControls.js
+++ b/src/systems/TouchControls.js
@@ -5,6 +5,7 @@ class TouchControls {
         this.scene = scene;
         this.game  = scene.game;
         this.widgets = [];
+        this._menuWidgets = []; // menu buttons tracked separately for visibility
     }
 
     create() {
@@ -20,18 +21,23 @@ class TouchControls {
         reg.set('touch_use', false);
         reg.set('touch_smeltery', false);
         reg.set('touch_chemlab', false);
+        reg.set('touch_skilltree', false);
+        reg.set('touch_elementbook', false);
 
         this._createDpad();
         this._createActionButtons();
+        this._createMenuButtons();
     }
 
-    // ── D-Pad (bottom-left) ──────────────────────────────────────────────────
+    // ── D-Pad (bottom-left, shifted further left on wide screens) ────────────
 
     _createDpad() {
         const sz   = 58;
         const gap  = 6;
-        const baseX = 24 + sz + gap;
+        const W = this.scene.cameras.main.width;
         const H = this.scene.cameras.main.height;
+        // Move d-pad further left: use 15% from left edge, but cap at original position
+        const baseX = Math.min(24 + sz + gap, Math.round(W * 0.06) + sz / 2);
         const baseY = H - 24 - sz - gap;
 
         const directions = [
@@ -84,7 +90,7 @@ class TouchControls {
         this.widgets.push(bg, txt, zone);
     }
 
-    // ── Action Buttons (bottom-right) ────────────────────────────────────────
+    // ── Action Buttons (bottom-right, always visible) ────────────────────────
 
     _createActionButtons() {
         const sz   = 56;
@@ -95,13 +101,9 @@ class TouchControls {
         const baseY = H - 24 - sz / 2;
 
         const buttons = [
-            { label: 'ATK', key: 'touch_attack',    color: 0xaa3333, ox: 0,           oy: 0           },
-            { label: 'BOW', key: 'touch_bow',       color: 0x997722, ox: -(sz + gap), oy: 0           },
-            { label: 'USE', key: 'touch_use',       color: 0x339988, ox: -(sz + gap) * 2, oy: 0       },
-            { label: 'INV', key: 'touch_inventory', color: 0x335588, ox: 0,           oy: -(sz + gap) },
-            { label: 'MAP', key: 'touch_minimap',   color: 0x338844, ox: -(sz + gap), oy: -(sz + gap) },
-            { label: 'SMI', key: 'touch_smeltery',  color: 0xff7722, ox: -(sz + gap) * 2, oy: -(sz + gap) },
-            { label: 'LAB', key: 'touch_chemlab',   color: 0x33dd88, ox: 0,            oy: -(sz + gap) * 2 },
+            { label: 'ATK', key: 'touch_attack',    color: 0xaa3333, ox: 0,               oy: 0 },
+            { label: 'BOW', key: 'touch_bow',       color: 0x997722, ox: -(sz + gap),      oy: 0 },
+            { label: 'USE', key: 'touch_use',       color: 0x339988, ox: -(sz + gap) * 2,  oy: 0 },
         ];
 
         for (const btn of buttons) {
@@ -112,6 +114,39 @@ class TouchControls {
 
         // ── Zoom & fullscreen buttons (top-right corner) ─────────────────────
         this._createZoomButtons();
+    }
+
+    // ── Menu Buttons (above action row, conditional visibility) ──────────────
+
+    _createMenuButtons() {
+        const sz   = 48;
+        const gap  = 8;
+        const W = this.scene.cameras.main.width;
+        const H = this.scene.cameras.main.height;
+        const baseX = W - 24 - sz / 2;
+        const baseY = H - 24 - 56 / 2 - 10 - 56 - 10 - sz / 2; // above action row
+
+        // Menu buttons: always-visible first, then conditional ones
+        const menuDefs = [
+            { label: 'INV', key: 'touch_inventory',   color: 0x335588, unlockKey: null },
+            { label: 'MAP', key: 'touch_minimap',      color: 0x338844, unlockKey: null },
+            { label: 'SKL', key: 'touch_skilltree',    color: 0x8866cc, unlockKey: null },
+            { label: 'BOK', key: 'touch_elementbook',  color: 0x997755, unlockKey: 'geologistUnlocked' },
+            { label: 'SMI', key: 'touch_smeltery',     color: 0xff7722, unlockKey: 'metallurgistUnlocked' },
+            { label: 'LAB', key: 'touch_chemlab',      color: 0x33dd88, unlockKey: 'chemLabUnlocked' },
+        ];
+
+        // Layout: 3 columns, rows going up
+        const cols = 3;
+        for (let i = 0; i < menuDefs.length; i++) {
+            const col = i % cols;
+            const row = Math.floor(i / cols);
+            const x = baseX - col * (sz + gap);
+            const y = baseY - row * (sz + gap);
+            const def = menuDefs[i];
+            const btnWidgets = this._makeMenuButton(x, y, sz, def.label, def.key, def.color);
+            this._menuWidgets.push({ widgets: btnWidgets, unlockKey: def.unlockKey });
+        }
     }
 
     // ── Zoom & fullscreen (top-right) ────────────────────────────────────────
@@ -219,6 +254,53 @@ class TouchControls {
         this.widgets.push(bg, txt, zone);
     }
 
+    /** Creates a menu button and returns its widget array for visibility control */
+    _makeMenuButton(x, y, sz, label, regKey, color) {
+        const scene = this.scene;
+        const reg   = this.game.registry;
+        const alpha = 0.35;
+        const pressAlpha = 0.7;
+
+        const bg = scene.add.graphics();
+        this._drawRoundedBtn(bg, x, y, sz, color, alpha);
+        bg.setDepth(100);
+
+        const txt = scene.add.text(x, y, label, {
+            fontSize: '12px', color: '#eeeeff', fontFamily: 'monospace', fontStyle: 'bold'
+        }).setOrigin(0.5).setDepth(101).setAlpha(0.6);
+
+        const zone = scene.add.zone(x, y, sz, sz).setInteractive().setDepth(102);
+
+        zone.on('pointerdown', () => {
+            reg.set(regKey, true);
+            this._drawRoundedBtn(bg, x, y, sz, color, pressAlpha);
+            txt.setAlpha(1);
+        });
+
+        const release = () => {
+            this._drawRoundedBtn(bg, x, y, sz, color, alpha);
+            txt.setAlpha(0.6);
+        };
+
+        zone.on('pointerup', release);
+        zone.on('pointerout', release);
+
+        this.widgets.push(bg, txt, zone);
+        return [bg, txt, zone];
+    }
+
+    /** Update menu button visibility based on hero unlock flags */
+    updateVisibility(hero) {
+        if (!hero) return;
+        for (const entry of this._menuWidgets) {
+            if (!entry.unlockKey) continue;
+            const visible = !!hero[entry.unlockKey];
+            for (const w of entry.widgets) {
+                w.setVisible(visible);
+            }
+        }
+    }
+
     // ── Shared draw helper ───────────────────────────────────────────────────
 
     _drawRoundedBtn(gfx, cx, cy, sz, color, alpha) {
@@ -236,5 +318,6 @@ class TouchControls {
     destroy() {
         for (const w of this.widgets) w.destroy();
         this.widgets = [];
+        this._menuWidgets = [];
     }
 }

--- a/src/systems/TouchControls.js
+++ b/src/systems/TouchControls.js
@@ -7,6 +7,7 @@ class TouchControls {
         this.widgets = [];
         this._menuWidgets = []; // menu buttons tracked separately for visibility
         this._domDpad = null;   // DOM-based d-pad container (for off-canvas placement)
+        this._dpadButtons = [];
     }
 
     create() {
@@ -41,10 +42,16 @@ class TouchControls {
     _createDpad() {
         const reg = this.game.registry;
 
-        // Create a DOM container for the d-pad
+        // Remove any lingering d-pad from previous world
+        const old = document.getElementById('touch-dpad');
+        if (old) old.remove();
+
+        // Create a full-viewport fixed container
         const container = document.createElement('div');
         container.id = 'touch-dpad';
-        container.style.cssText = 'position:fixed;z-index:9999;pointer-events:none;';
+        container.style.cssText =
+            'position:fixed;top:0;left:0;width:100vw;height:100vh;' +
+            'z-index:9999;pointer-events:none;overflow:visible;';
         document.body.appendChild(container);
         this._domDpad = container;
 
@@ -62,61 +69,77 @@ class TouchControls {
         for (const dir of directions) {
             const btn = document.createElement('div');
             btn.textContent = dir.label;
-            btn.style.cssText = `
-                position:absolute;
-                width:${sz}px; height:${sz}px;
-                border-radius:10px;
-                background:rgba(51,68,102,0.5);
-                border:2px solid rgba(51,68,102,0.7);
-                color:#aabbdd;
-                font-family:monospace;
-                font-size:26px;
-                display:flex; align-items:center; justify-content:center;
-                pointer-events:auto;
-                user-select:none;
-                -webkit-user-select:none;
-                touch-action:none;
-            `;
-            // Position relative to container center
+            btn.style.cssText =
+                'position:absolute;' +
+                'width:' + sz + 'px;height:' + sz + 'px;' +
+                'border-radius:10px;' +
+                'background:rgba(51,68,102,0.5);' +
+                'border:2px solid rgba(51,68,102,0.7);' +
+                'color:#aabbdd;' +
+                'font-family:monospace;font-size:26px;' +
+                'display:flex;align-items:center;justify-content:center;' +
+                'pointer-events:auto;' +
+                'user-select:none;-webkit-user-select:none;' +
+                'touch-action:none;';
+
+            // Store offset for positioning
             btn._ox = dir.ox;
             btn._oy = dir.oy;
 
-            btn.addEventListener('touchstart', (e) => {
+            // Press handler (both touch and mouse)
+            const onPress = (e) => {
                 e.preventDefault();
                 reg.set('touch_dx', dir.dx);
                 reg.set('touch_dy', dir.dy);
                 btn.style.background = 'rgba(68,102,170,0.75)';
                 btn.style.color = '#ffffff';
-            }, { passive: false });
+            };
 
-            const release = () => {
+            const onRelease = () => {
                 reg.set('touch_dx', 0);
                 reg.set('touch_dy', 0);
                 btn.style.background = 'rgba(51,68,102,0.5)';
                 btn.style.color = '#aabbdd';
             };
 
-            btn.addEventListener('touchend', release);
-            btn.addEventListener('touchcancel', release);
+            btn.addEventListener('touchstart', onPress, { passive: false });
+            btn.addEventListener('touchend', onRelease);
+            btn.addEventListener('touchcancel', onRelease);
+            btn.addEventListener('mousedown', onPress);
+            btn.addEventListener('mouseup', onRelease);
+            btn.addEventListener('mouseleave', onRelease);
 
             container.appendChild(btn);
             this._dpadButtons.push(btn);
         }
 
-        // Position immediately
-        this._repositionDomDpad();
+        // Position after a short delay so the canvas has time to be sized
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                this._repositionDomDpad();
+            });
+        });
     }
 
     /** Reposition DOM d-pad: place in letterbox area if space, otherwise over canvas left edge */
     _repositionDomDpad() {
-        if (!this._domDpad) return;
+        if (!this._domDpad || !this._dpadButtons.length) return;
 
         const canvas = this.game.canvas;
         const rect = canvas.getBoundingClientRect();
+
+        // Guard: if canvas isn't rendered yet, retry next frame
+        if (rect.width === 0 || rect.height === 0) {
+            requestAnimationFrame(() => this._repositionDomDpad());
+            return;
+        }
+
         const sz = 58;
         const gap = 6;
-        const dpadW = sz * 3 + gap * 2; // total d-pad width
-        const dpadH = sz * 3 + gap * 2; // total d-pad height
+        const dpadW = sz * 3 + gap * 2;
+
+        // Scale factor: how much the canvas is scaled from internal 1280x800
+        const scale = rect.height / 800;
 
         // Available space to the left of the game canvas
         const leftSpace = rect.left;
@@ -124,25 +147,24 @@ class TouchControls {
         // Center of d-pad placement
         let centerX, centerY;
 
-        if (leftSpace > dpadW / 2 + 20) {
+        if (leftSpace > dpadW * scale / 2 + 20) {
             // Enough space in the letterbox: place d-pad centered in the left bar
             centerX = leftSpace / 2;
         } else {
-            // Not enough space: place at left edge of canvas + small offset
-            centerX = rect.left + (sz + gap + 24) * (rect.width / 1280);
+            // Not enough space: place at left edge of canvas + offset (inside canvas)
+            centerX = rect.left + (sz + gap + 24) * scale;
         }
 
-        // Vertically: bottom area of the screen, matching game's bottom area
-        centerY = rect.bottom - (24 + sz + gap) * (rect.height / 800);
+        // Vertically: bottom area of the screen
+        centerY = rect.bottom - (24 + sz + gap) * scale;
 
-        // Position each button relative to center
+        // Position and scale each button
         for (const btn of this._dpadButtons) {
-            const scale = rect.height / 800; // scale buttons with canvas
-            const scaledSz = Math.round(sz * scale);
+            const scaledSz  = Math.round(sz * scale);
             const scaledGap = Math.round(gap * scale);
-            btn.style.width = scaledSz + 'px';
+            btn.style.width  = scaledSz + 'px';
             btn.style.height = scaledSz + 'px';
-            btn.style.fontSize = Math.round(26 * scale) + 'px';
+            btn.style.fontSize    = Math.round(26 * scale) + 'px';
             btn.style.borderRadius = Math.round(10 * scale) + 'px';
             btn.style.left = Math.round(centerX + btn._ox * scale - scaledSz / 2) + 'px';
             btn.style.top  = Math.round(centerY + btn._oy * scale - scaledSz / 2) + 'px';
@@ -185,7 +207,6 @@ class TouchControls {
         const baseX = W - 24 - sz / 2;
         const baseY = H - 24 - 56 / 2 - 10 - 56 - 10 - sz / 2; // above action row
 
-        // Menu buttons: always-visible first, then conditional ones
         const menuDefs = [
             { label: 'INV', key: 'touch_inventory',   color: 0x335588, unlockKey: null },
             { label: 'MAP', key: 'touch_minimap',      color: 0x338844, unlockKey: null },
@@ -195,7 +216,6 @@ class TouchControls {
             { label: 'LAB', key: 'touch_chemlab',      color: 0x33dd88, unlockKey: 'chemLabUnlocked' },
         ];
 
-        // Layout: 3 columns, rows going up
         const cols = 3;
         for (let i = 0; i < menuDefs.length; i++) {
             const col = i % cols;
@@ -219,17 +239,12 @@ class TouchControls {
         const startX = W - 20 - sz / 2;
         const startY = 64 + sz / 2;
 
-        // Zoom in (+)
         this._makeSimpleButton(startX, startY, sz, '+', 0x336699, () => {
             reg.set('touch_zoom_in', true);
         });
-
-        // Zoom out (-)
         this._makeSimpleButton(startX - (sz + gap), startY, sz, '−', 0x336699, () => {
             reg.set('touch_zoom_out', true);
         });
-
-        // Fullscreen toggle
         this._makeSimpleButton(startX - (sz + gap) * 2, startY, sz, '⛶', 0x446688, () => {
             this._toggleFullscreen();
         });
@@ -313,7 +328,6 @@ class TouchControls {
         this.widgets.push(bg, txt, zone);
     }
 
-    /** Creates a menu button and returns its widget array for visibility control */
     _makeMenuButton(x, y, sz, label, regKey, color) {
         const scene = this.scene;
         const reg   = this.game.registry;


### PR DESCRIPTION
## Summary
This PR restructures the touch control system to separate action buttons from menu buttons with conditional visibility, converts the D-pad to DOM-based positioning, adds Tier 5 equipment, and rebalances monster scaling and consumable potency across worlds.

## Key Changes

### Touch Controls Refactor (#88)
- **D-pad conversion to DOM:** Moved from Phaser graphics to HTML elements with `position:fixed` for off-canvas placement. Uses viewport-relative sizing (vmin units) for responsive scaling.
- **Action/Menu separation:** Split buttons into `_createActionButtons()` (ATK, BOW, USE - always visible) and `_createMenuButtons()` (INV, MAP, SKL, BOK, SMI, LAB - conditionally visible).
- **Dynamic visibility:** Added `updateVisibility(hero)` method that shows/hides menu buttons based on unlock flags (e.g., `metallurgistUnlocked`, `chemLabUnlocked`).
- **New touch buttons:** Added SKL (Skill Tree) and BOK (Element Book) to touch controls with registry keys `touch_skilltree` and `touch_elementbook`.
- **Cleanup:** Proper DOM cleanup in `destroy()` method to prevent memory leaks across scene transitions.

### Equipment & Progression (#89)
- **Tier 5 weapons:** Runesverd (+6 ATK), Mithriløks (+7 ATK), Dragebue (+7 ranged ATK)
- **Tier 5 armor:** Mithrilrustning (+5 DEF, +1 heart)
- **Item pool expansion:** Added tier 5 to `ITEM_POOL` with new equipment available from world 9+
- **Hero base attack:** Increased from 2 to 3 (set in `constants.js`)

### Monster & Difficulty Balancing (#89)
- **Softer scaling curve:** Monster HP growth reduced from +50% to +35% per world, with additional +15% scaling after world 8. Attack growth reduced from +25% to +20% per world (+8% after world 8).
- **Easy mode adjustment:** HP multiplier 0.65→0.50, attack 0.75→0.60, XP bonus 1.20→1.30, trap damage 0.5→0.3
- **Monster.js:** Updated scaling formulas to use piecewise calculation: `1 + (worldMul - 1) * baseRate + Math.max(0, worldMul - 8) * extraRate`

### Consumable World Scaling (#90)
- **Chemistry system:** `synthesize()` and `_createUsableItem()` now accept `worldNum` parameter for damage/healing scaling.
- **Scaling factor:** +40% per world (`worldScale = 1 + (worldNum - 1) * 0.4`)
- **Updated items:**
  - Salpeter bomb: 5→8 base damage
  - Gunpowder: 8→12 base damage
  - Sulfuric acid: 4→7 base damage
  - Hydrochloric acid: 3→5 base damage
  - Dynamite: 15→20 base damage
  - Regular bombs: 6→8 base damage
  - Strength/Defense brews: Now scale with world (min 2/1 respectively)
  - Flashbang: Changed from halving attack to fixed reduction that scales with world
- **ChemLabScene:** Now receives and passes `worldNum` to chemistry system
- **GameScene:** Sets `hero.worldNum` during creation for consumable scaling

### UI Enhancements
- **SkillScene:** Added close button (✕) in top-right corner for view-only mode
- **LeaderboardScene:** Added close button and ESC keyboard shortcut
- **UIScene:** Calls `touchControls.updateVisibility()` in refresh loop to sync menu button visibility with hero unlock state
- **AudioManager:** Added context resume handling for browser autoplay policy compliance

### Documentation
- Updated GDD.md with v0.35 changes, new equipment tiers, difficulty table, and world scaling mechanics

https://claude.ai/code/session_01JCXk5jVTbm4G5urmZmATNL