### PR TITLE
Add global leaderboard with Local/Global tabs and new categories (#64)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,38 @@
+# Labyrint Hero – Global Leaderboard Backend
+
+Cloudflare Worker + KV store for the global leaderboard.
+
+## Setup
+
+1. Install Wrangler CLI: `npm install -g wrangler`
+2. Login: `wrangler login`
+3. Create a KV namespace:
+   ```
+   wrangler kv namespace create LEADERBOARD
+   ```
+4. Copy the returned namespace ID into `wrangler.toml`
+5. Deploy:
+   ```
+   wrangler deploy
+   ```
+6. Update `GlobalLeaderboard.API_URL` in `src/utils/GlobalLeaderboard.js` with your worker URL.
+
+## Endpoints
+
+| Method | Path            | Description                                      |
+|--------|-----------------|--------------------------------------------------|
+| POST   | /scores         | Submit a score (JSON body)                       |
+| GET    | /scores         | Fetch top 100 (?race=&difficulty= optional)      |
+| GET    | /scores/count   | Total number of stored scores                    |
+
+## Anti-cheat
+
+The worker rejects obviously impossible scores:
+- World 3+ at level 1
+- World completion in under 10 seconds
+- Out-of-range numeric values
+- Invalid race/difficulty values
+
+## Cost
+
+Cloudflare Workers free tier includes 100k requests/day and 1 GB KV storage – more than enough for a casual game leaderboard.

--- a/backend/worker.js
+++ b/backend/worker.js
@@ -1,0 +1,181 @@
+// ─── Labyrint Hero – Global Leaderboard Worker ──────────────────────────────
+// Cloudflare Worker + KV store for the global leaderboard.
+//
+// Setup:
+//   1. Create a KV namespace called LEADERBOARD in your Cloudflare dashboard.
+//   2. Bind it to this worker as the variable LEADERBOARD.
+//   3. Deploy: wrangler deploy
+//
+// Endpoints:
+//   POST /scores        – Submit a new score
+//   GET  /scores        – Fetch top 100 (optional ?race=&difficulty= filters)
+//   GET  /scores/count  – Total score count
+//
+// Anti-cheat: rejects obviously impossible scores.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const CORS_HEADERS = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+const MAX_SCORES = 500;       // total stored in KV
+const MAX_RETURNED = 100;     // max returned per request
+const KV_KEY = 'scores_v1';   // single KV key for the leaderboard
+
+// ── Anti-cheat validation ────────────────────────────────────────────────────
+
+function validateScore(entry) {
+    if (!entry || typeof entry !== 'object') return 'Invalid payload';
+
+    const { worldsCleared, level, monstersKilled, goldEarned, timeSeconds,
+            mineralsCollected, elementsDiscovered } = entry;
+
+    if (typeof worldsCleared !== 'number' || worldsCleared < 0 || worldsCleared > 100)
+        return 'Invalid worldsCleared';
+    if (typeof level !== 'number' || level < 1 || level > 200)
+        return 'Invalid level';
+    if (typeof monstersKilled !== 'number' || monstersKilled < 0 || monstersKilled > 10000)
+        return 'Invalid monstersKilled';
+    if (typeof goldEarned !== 'number' || goldEarned < 0 || goldEarned > 999999)
+        return 'Invalid goldEarned';
+    if (typeof timeSeconds !== 'number' || timeSeconds < 0 || timeSeconds > 360000)
+        return 'Invalid timeSeconds';
+
+    // Impossible: cleared many worlds at level 1
+    if (worldsCleared >= 3 && level <= 1)
+        return 'Impossible: high worlds at level 1';
+
+    // Impossible: cleared worlds in zero time
+    if (worldsCleared >= 1 && timeSeconds < 10)
+        return 'Impossible: too fast';
+
+    // Validate optional numeric fields
+    if (mineralsCollected !== undefined && (typeof mineralsCollected !== 'number' || mineralsCollected < 0 || mineralsCollected > 50000))
+        return 'Invalid mineralsCollected';
+    if (elementsDiscovered !== undefined && (typeof elementsDiscovered !== 'number' || elementsDiscovered < 0 || elementsDiscovered > 120))
+        return 'Invalid elementsDiscovered';
+
+    // Validate string fields
+    const validRaces = ['human', 'dwarf', 'elf', 'hobbit'];
+    const validDiffs = ['easy', 'normal', 'hard'];
+    if (entry.race && !validRaces.includes(entry.race)) return 'Invalid race';
+    if (entry.difficulty && !validDiffs.includes(entry.difficulty)) return 'Invalid difficulty';
+
+    // Hero name length check
+    if (entry.heroName && (typeof entry.heroName !== 'string' || entry.heroName.length > 30))
+        return 'Invalid heroName';
+
+    return null; // valid
+}
+
+// ── Sanitize entry for storage ───────────────────────────────────────────────
+
+function sanitizeEntry(entry) {
+    return {
+        heroName:           String(entry.heroName || 'Helt').slice(0, 30),
+        race:               entry.race || 'human',
+        difficulty:         entry.difficulty || 'normal',
+        worldsCleared:      Math.floor(entry.worldsCleared || 0),
+        level:              Math.floor(entry.level || 1),
+        monstersKilled:     Math.floor(entry.monstersKilled || 0),
+        goldEarned:         Math.floor(entry.goldEarned || 0),
+        mineralsCollected:  Math.floor(entry.mineralsCollected || 0),
+        elementsDiscovered: Math.floor(entry.elementsDiscovered || 0),
+        timeSeconds:        Math.floor(entry.timeSeconds || 0),
+        result:             entry.result === 'death' ? 'death' : 'worldComplete',
+        date:               entry.date || new Date().toISOString().slice(0, 10),
+    };
+}
+
+// ── Sort: worldsCleared desc → level desc → monstersKilled desc ─────────────
+
+function sortScores(scores) {
+    scores.sort((a, b) =>
+        (b.worldsCleared - a.worldsCleared) ||
+        (b.level - a.level) ||
+        (b.monstersKilled - a.monstersKilled)
+    );
+}
+
+// ── Request handler ──────────────────────────────────────────────────────────
+
+export default {
+    async fetch(request, env) {
+        // CORS preflight
+        if (request.method === 'OPTIONS') {
+            return new Response(null, { headers: CORS_HEADERS });
+        }
+
+        const url = new URL(request.url);
+        const path = url.pathname;
+
+        // POST /scores – submit a score
+        if (request.method === 'POST' && path === '/scores') {
+            let body;
+            try {
+                body = await request.json();
+            } catch {
+                return jsonResponse({ error: 'Invalid JSON' }, 400);
+            }
+
+            const err = validateScore(body);
+            if (err) return jsonResponse({ error: err }, 422);
+
+            const entry = sanitizeEntry(body);
+
+            // Read current scores from KV
+            let scores = [];
+            try {
+                const raw = await env.LEADERBOARD.get(KV_KEY);
+                if (raw) scores = JSON.parse(raw);
+            } catch { /* start fresh */ }
+
+            scores.push(entry);
+            sortScores(scores);
+            scores = scores.slice(0, MAX_SCORES);
+
+            await env.LEADERBOARD.put(KV_KEY, JSON.stringify(scores));
+
+            return jsonResponse({ ok: true, rank: scores.indexOf(entry) + 1 }, 201);
+        }
+
+        // GET /scores – fetch top scores
+        if (request.method === 'GET' && path === '/scores') {
+            let scores = [];
+            try {
+                const raw = await env.LEADERBOARD.get(KV_KEY);
+                if (raw) scores = JSON.parse(raw);
+            } catch { /* empty */ }
+
+            // Optional filters
+            const raceFilter = url.searchParams.get('race');
+            const diffFilter = url.searchParams.get('difficulty');
+
+            if (raceFilter)  scores = scores.filter(s => s.race === raceFilter);
+            if (diffFilter)  scores = scores.filter(s => s.difficulty === diffFilter);
+
+            return jsonResponse(scores.slice(0, MAX_RETURNED));
+        }
+
+        // GET /scores/count
+        if (request.method === 'GET' && path === '/scores/count') {
+            let scores = [];
+            try {
+                const raw = await env.LEADERBOARD.get(KV_KEY);
+                if (raw) scores = JSON.parse(raw);
+            } catch { /* empty */ }
+            return jsonResponse({ count: scores.length });
+        }
+
+        return jsonResponse({ error: 'Not found' }, 404);
+    }
+};
+
+function jsonResponse(data, status = 200) {
+    return new Response(JSON.stringify(data), {
+        status,
+        headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
+    });
+}

--- a/backend/worker.js
+++ b/backend/worker.js
@@ -67,6 +67,14 @@ function validateScore(entry) {
     if (entry.heroName && (typeof entry.heroName !== 'string' || entry.heroName.length > 30))
         return 'Invalid heroName';
 
+    // Only accept world completions, not deaths
+    if (entry.result === 'death')
+        return 'Deaths are not recorded on the global leaderboard';
+
+    // Must have cleared at least 1 world
+    if (worldsCleared < 1)
+        return 'Must have cleared at least 1 world';
+
     return null; // valid
 }
 
@@ -84,7 +92,7 @@ function sanitizeEntry(entry) {
         mineralsCollected:  Math.floor(entry.mineralsCollected || 0),
         elementsDiscovered: Math.floor(entry.elementsDiscovered || 0),
         timeSeconds:        Math.floor(entry.timeSeconds || 0),
-        result:             entry.result === 'death' ? 'death' : 'worldComplete',
+        result:             'worldComplete',
         date:               entry.date || new Date().toISOString().slice(0, 10),
     };
 }

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -1,0 +1,9 @@
+name = "labyrint-hero-leaderboard"
+main = "worker.js"
+compatibility_date = "2024-01-01"
+
+[[kv_namespaces]]
+binding = "LEADERBOARD"
+id = "<YOUR_KV_NAMESPACE_ID>"
+# Create with: wrangler kv namespace create LEADERBOARD
+# Then replace the id above with the output.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ---
 
+## v0.38 – 2026-04-13
+
+### Nye funksjoner
+- **Global ledertavle (#64):** Spillere kan nå sammenligne resultater med andre spillere over hele verden via en global ledertavle. Lokal og global fane med «Lokal»/«Global»-veksler. Globale resultater hentes fra en Cloudflare Worker + KV-backend
+- **Nye ledertavle-kategorier (#64):** To nye kolonner i ledertavlen: «Min» (mineraler samlet) og «Elem» (grunnstoffer oppdaget). Begge spores gjennom hele spillet og lagres i ledertavlen
+- **Global innsending ved verdensklarering:** Poengsummen sendes automatisk til den globale ledertavlen ved verdensklarering (brann-og-glem, blokkerer ikke seierskjermen). Feiler stille ved nettverksproblemer
+- **Grunnleggende anti-juks:** Serveren avviser umulige poengsummer (f.eks. verden 25 på nivå 1, verdensklarering på under 10 sekunder)
+
+### Tekniske endringer
+- Ny fil `src/utils/GlobalLeaderboard.js`: API-klient med `submitScore()` og `fetchScores()` for global ledertavle
+- Ny backend `backend/worker.js`: Cloudflare Worker med KV-lagring, REST API (`POST /scores`, `GET /scores`), CORS-støtte og anti-juks-validering
+- HeroCrafting: Ny `mineralsCollected`-egenskap som økes ved mineralopptak i ItemSpawner
+- Leaderboard: Nye felter `mineralsCollected` og `elementsDiscovered` i innleggsobjektet
+- LeaderboardScene: Fullstendig omskrevet med fane-veksler (Lokal/Global), lasting/feiltilstander og 10 kolonner
+- GameOverScene: Sender inn poengsum til global ledertavle ved verdensklarering
+
+---
+
 ## v0.37 – 2026-04-13
 
 ### Nye funksjoner

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,5 +1,5 @@
 # Labyrint Hero – Game Design Document
-**Versjon:** 0.37
+**Versjon:** 0.38
 **Sist oppdatert:** 2026-04-13
 
 ---
@@ -355,6 +355,38 @@ Aktiveres automatisk når helten har evner fra begge stier i et par:
 
 ---
 
+## 11b. Ledertavle (v0.38)
+
+### Lokal ledertavle
+- Lagres i `localStorage` under nøkkel `labyrint_hero_leaderboard`
+- Maks 50 innlegg, sortert etter verdener klarert → nivå → drap
+- Registrerer kun verdensklarering, ikke død
+
+### Global ledertavle (#64)
+- Backend: Cloudflare Worker + KV-lagring (`backend/worker.js`)
+- REST API: `POST /scores` for innsending, `GET /scores` for henting (topp 100)
+- Automatisk innsending ved verdensklarering (brann-og-glem, feiler stille)
+- Filtrering: rase og vanskelighetsgrad
+
+### Kategorier
+| Kolonne | Beskrivelse |
+|---------|-------------|
+| Verden | Antall verdener klarert |
+| Nivå | Heltens nivå ved registrering |
+| Drap | Totalt antall monstre drept |
+| Gull | Gull opptjent |
+| Min | Mineraler samlet i løpet av spillet |
+| Elem | Unike grunnstoffer oppdaget |
+| Tid | Tid brukt (mm:ss) |
+
+### Anti-juks
+Serveren avviser umulige poengsummer:
+- Verden 3+ på nivå 1
+- Verdensklarering på under 10 sekunder
+- Verdier utenfor gyldige områder
+
+---
+
 ## 12. Implementert – statusoversikt (v0.8)
 
 | System | Status | Kommentar |
@@ -395,7 +427,7 @@ Aktiveres automatisk når helten har evner fra begge stier i et par:
 | Gull + økonomi | ✅ Ferdig | Gullvaluta fra monstre/kister; handelsmann |
 | Gjenstandssjeldenhet | ✅ Ferdig | 5 sjeldenhetsgrader med stat-boost |
 | Touch/mobil-støtte | ✅ Ferdig | D-pad, handlingsknapper, responsiv skalering, langt-trykk drop |
-| Leaderboard | ✅ Ferdig | Ledertavle med filtrering og tidssporing per verden |
+| Leaderboard | ✅ Ferdig | Lokal + global ledertavle med filtrering, mineraler samlet, elementer oppdaget |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
 <script src="src/maze.js"></script>
 <script src="src/utils/SaveManager.js"></script>
 <script src="src/utils/Leaderboard.js"></script>
+<script src="src/utils/GlobalLeaderboard.js"></script>
 <script src="src/utils/UIHelper.js"></script>
 <script src="src/utils/EventBus.js"></script>
 

--- a/src/entities/HeroCrafting.js
+++ b/src/entities/HeroCrafting.js
@@ -14,6 +14,7 @@ const HeroCrafting = {
         hero.miningYieldBonus = 0;
         hero.smeltBonusElement = 0;
         hero.guaranteedRareMineral = false;
+        hero.mineralsCollected = 0;
 
         // Metallurgy mod (Phase 2)
         hero.metallurgistUnlocked = false;
@@ -65,6 +66,7 @@ const HeroCrafting = {
             miningYieldBonus:     hero.miningYieldBonus,
             smeltBonusElement:    hero.smeltBonusElement,
             guaranteedRareMineral: hero.guaranteedRareMineral,
+            mineralsCollected:    hero.mineralsCollected,
             metallurgistUnlocked: hero.metallurgistUnlocked,
             smeltingSpeedMul:     hero.smeltingSpeedMul,
             smeltingEfficiency:   hero.smeltingEfficiency,
@@ -106,6 +108,7 @@ const HeroCrafting = {
         hero.miningYieldBonus     = stats.miningYieldBonus     || 0;
         hero.smeltBonusElement    = stats.smeltBonusElement    || 0;
         hero.guaranteedRareMineral = stats.guaranteedRareMineral || false;
+        hero.mineralsCollected    = stats.mineralsCollected    || 0;
         hero.metallurgistUnlocked = stats.metallurgistUnlocked || false;
         hero.smeltingSpeedMul     = stats.smeltingSpeedMul     || 1.0;
         hero.smeltingEfficiency   = stats.smeltingEfficiency   || 1.0;

--- a/src/scenes/GameOverScene.js
+++ b/src/scenes/GameOverScene.js
@@ -20,17 +20,28 @@ class GameOverScene extends Phaser.Scene {
 
         // Record to leaderboard only on world completion, not death (#58)
         if (this.type !== 'death') {
-            Leaderboard.record({
-                heroName:       this.heroStats.heroName || 'Helt',
-                race:           this.heroStats.race || 'human',
-                difficulty:     this.difficulty,
-                worldsCleared:  this.worldNum,
-                level:          this.heroStats.level || 1,
-                monstersKilled: this.monstersKilled,
-                goldEarned:     this.heroStats.gold || 0,
-                result:         'worldComplete',
-                timeSeconds:    this.timeSeconds
-            });
+            const et = this.heroStats.elementTracker || {};
+            const elementsDiscovered = et.discovered
+                ? Object.keys(et.discovered).length : 0;
+            const entry = {
+                heroName:           this.heroStats.heroName || 'Helt',
+                race:               this.heroStats.race || 'human',
+                difficulty:         this.difficulty,
+                worldsCleared:      this.worldNum,
+                level:              this.heroStats.level || 1,
+                monstersKilled:     this.monstersKilled,
+                goldEarned:         this.heroStats.gold || 0,
+                mineralsCollected:  this.heroStats.mineralsCollected || 0,
+                elementsDiscovered: elementsDiscovered,
+                result:             'worldComplete',
+                timeSeconds:        this.timeSeconds
+            };
+            Leaderboard.record(entry);
+
+            // Submit to global leaderboard (fire-and-forget) (#64)
+            if (typeof GlobalLeaderboard !== 'undefined') {
+                GlobalLeaderboard.submitScore(entry);
+            }
         }
 
         if (this.type === 'death') {

--- a/src/scenes/LeaderboardScene.js
+++ b/src/scenes/LeaderboardScene.js
@@ -31,13 +31,13 @@ class LeaderboardScene extends Phaser.Scene {
         this.add.rectangle(cx, 52, 400, 1, 0x333355);
 
         // Tab buttons (Local / Global)
-        this._buildTabs(cx, 60);
+        this._buildTabs(cx, 58);
 
-        // Filter buttons
-        this._buildFilters(cx, 80);
+        // Filter buttons (race row + difficulty row)
+        this._buildFilters(cx, 76);
 
         // Scroll area
-        this._listY = 100;
+        this._listY = 112;
         this._scrollOffset = 0;
         this._refreshList();
 
@@ -48,7 +48,8 @@ class LeaderboardScene extends Phaser.Scene {
 
         // Mouse wheel scrolling
         this.input.on('wheel', (pointer, gameObjects, deltaX, deltaY) => {
-            const maxScroll = Math.max(0, (this._totalRows - 12) * 20);
+            const visibleRows = Math.floor((H - this._listY - 70) / 20);
+            const maxScroll = Math.max(0, (this._totalRows - visibleRows) * 20);
             this._scrollOffset = Phaser.Math.Clamp(this._scrollOffset + deltaY * 0.5, 0, maxScroll);
             this._refreshList();
         });
@@ -120,40 +121,32 @@ class LeaderboardScene extends Phaser.Scene {
         ];
 
         const ts = { fontSize: '11px', color: '#556677', fontFamily: 'monospace' };
-        this.add.text(cx - 220, y, 'Rase:', ts);
+        const restartWith = (race, diff) => {
+            this.scene.restart({ filterRace: race, filterDiff: diff, tab: this._tab });
+        };
 
+        // Row 1: Race filter
+        this.add.text(cx - 220, y, 'Rase:', ts);
         let rx = cx - 185;
         for (const r of RACES) {
             const btn = this.add.text(rx, y, `[${r.label}]`, {
                 fontSize: '11px', color: this._filterRace === r.id ? '#f5e642' : '#667788',
                 fontFamily: 'monospace'
             }).setInteractive({ useHandCursor: true });
-            btn.on('pointerdown', () => {
-                this._filterRace = r.id;
-                this.scene.restart({
-                    filterRace: this._filterRace,
-                    filterDiff: this._filterDiff,
-                    tab: this._tab
-                });
-            });
+            btn.on('pointerdown', () => restartWith(r.id, this._filterDiff));
             rx += btn.width + 6;
         }
 
-        this.add.text(cx + 40, y, 'Diff:', ts);
-        let dx = cx + 70;
+        // Row 2: Difficulty filter
+        const y2 = y + 15;
+        this.add.text(cx - 220, y2, 'Diff:', ts);
+        let dx = cx - 185;
         for (const d of DIFFS) {
-            const btn = this.add.text(dx, y, `[${d.label}]`, {
+            const btn = this.add.text(dx, y2, `[${d.label}]`, {
                 fontSize: '11px', color: this._filterDiff === d.id ? '#f5e642' : '#667788',
                 fontFamily: 'monospace'
             }).setInteractive({ useHandCursor: true });
-            btn.on('pointerdown', () => {
-                this._filterDiff = d.id;
-                this.scene.restart({
-                    filterRace: this._filterRace,
-                    filterDiff: this._filterDiff,
-                    tab: this._tab
-                });
-            });
+            btn.on('pointerdown', () => restartWith(this._filterRace, d.id));
             dx += btn.width + 6;
         }
     }
@@ -239,16 +232,16 @@ class LeaderboardScene extends Phaser.Scene {
         // Header – 10 columns: #, Navn, Rase, Verden, Nivå, Drap, Gull, Min, Elem, Tid
         const hdrStyle = { fontSize: '11px', color: '#556677', fontFamily: 'monospace' };
         const cols = [
-            cx - 235,  // #
-            cx - 185,  // Navn
-            cx - 115,  // Rase
-            cx - 55,   // Verden
-            cx - 15,   // Nivå
-            cx + 25,   // Drap
+            cx - 280,  // #
+            cx - 240,  // Navn
+            cx - 150,  // Rase
+            cx - 90,   // Verden
+            cx - 40,   // Nivå
+            cx + 10,   // Drap
             cx + 65,   // Gull
-            cx + 105,  // Min (minerals)
-            cx + 140,  // Elem (elements)
-            cx + 180,  // Tid
+            cx + 130,  // Min (minerals)
+            cx + 180,  // Elem (elements)
+            cx + 235,  // Tid
         ];
         const headers = ['#', 'Navn', 'Rase', 'Vrdn', 'Niv\u00e5', 'Drap', 'Gull', 'Min', 'Elem', 'Tid'];
         headers.forEach((h, i) => {
@@ -287,7 +280,7 @@ class LeaderboardScene extends Phaser.Scene {
             // Result indicator
             const resCol = s.result === 'death' ? '#ff4444' : '#44ee66';
             const resIcon = s.result === 'death' ? '\u2620' : '\u2713';
-            this._dyn.push(this.add.text(cols[9] + 40, ry, resIcon, { ...style, color: resCol }));
+            this._dyn.push(this.add.text(cols[9] + 45, ry, resIcon, { ...style, color: resCol }));
         }
     }
 }

--- a/src/scenes/LeaderboardScene.js
+++ b/src/scenes/LeaderboardScene.js
@@ -1,5 +1,6 @@
 // ─── Labyrint Hero – LeaderboardScene ─────────────────────────────────────────
-// Displays high scores with optional race/difficulty filters.
+// Displays high scores with Local/Global tabs, race/difficulty filters,
+// and columns for minerals collected and elements discovered (#64).
 
 class LeaderboardScene extends Phaser.Scene {
     constructor() { super({ key: 'LeaderboardScene' }); }
@@ -7,6 +8,9 @@ class LeaderboardScene extends Phaser.Scene {
     init(data) {
         this._filterRace = (data && data.filterRace) || null;
         this._filterDiff = (data && data.filterDiff) || null;
+        this._tab = (data && data.tab) || 'local'; // 'local' | 'global'
+        this._globalScores = null;  // null = not fetched, [] = fetched empty
+        this._globalError = false;
     }
 
     create() {
@@ -26,13 +30,21 @@ class LeaderboardScene extends Phaser.Scene {
 
         this.add.rectangle(cx, 52, 400, 1, 0x333355);
 
+        // Tab buttons (Local / Global)
+        this._buildTabs(cx, 60);
+
         // Filter buttons
-        this._buildFilters(cx, 70);
+        this._buildFilters(cx, 80);
 
         // Scroll area
-        this._listY = 110;
+        this._listY = 100;
         this._scrollOffset = 0;
         this._refreshList();
+
+        // Fetch global scores if on global tab
+        if (this._tab === 'global') {
+            this._fetchGlobal();
+        }
 
         // Mouse wheel scrolling
         this.input.on('wheel', (pointer, gameObjects, deltaX, deltaY) => {
@@ -42,7 +54,7 @@ class LeaderboardScene extends Phaser.Scene {
         });
 
         // Close button (top-right)
-        const closeBtn = this.add.text(W - 30, 30, '✕', {
+        const closeBtn = this.add.text(W - 30, 30, '\u2715', {
             fontSize: '20px', color: '#667788', fontFamily: 'monospace'
         }).setOrigin(0.5).setInteractive({ useHandCursor: true });
         closeBtn.on('pointerover', () => closeBtn.setColor('#ff6666'));
@@ -61,6 +73,37 @@ class LeaderboardScene extends Phaser.Scene {
         back.on('pointerdown', () => this.scene.start('MenuScene'));
     }
 
+    // ── Tab toggle ──────────────────────────────────────────────────────────
+
+    _buildTabs(cx, y) {
+        const tabs = [
+            { id: 'local',  label: 'Lokal' },
+            { id: 'global', label: 'Global' },
+        ];
+        let tx = cx - 60;
+        for (const tab of tabs) {
+            const isActive = this._tab === tab.id;
+            const btn = this.add.text(tx, y, `[${tab.label}]`, {
+                fontSize: '14px',
+                color: isActive ? '#f5e642' : '#556677',
+                fontFamily: 'monospace',
+                fontStyle: isActive ? 'bold' : 'normal'
+            }).setInteractive({ useHandCursor: true });
+            btn.on('pointerdown', () => {
+                if (this._tab !== tab.id) {
+                    this.scene.restart({
+                        filterRace: this._filterRace,
+                        filterDiff: this._filterDiff,
+                        tab: tab.id
+                    });
+                }
+            });
+            tx += btn.width + 16;
+        }
+    }
+
+    // ── Filter buttons ──────────────────────────────────────────────────────
+
     _buildFilters(cx, y) {
         const RACES = [
             { id: null, label: 'Alle' },
@@ -76,43 +119,112 @@ class LeaderboardScene extends Phaser.Scene {
             { id: 'hard', label: 'Vanskelig' },
         ];
 
-        const ts = { fontSize: '12px', color: '#556677', fontFamily: 'monospace' };
-        this.add.text(cx - 200, y, 'Rase:', ts);
+        const ts = { fontSize: '11px', color: '#556677', fontFamily: 'monospace' };
+        this.add.text(cx - 220, y, 'Rase:', ts);
 
-        let rx = cx - 165;
+        let rx = cx - 185;
         for (const r of RACES) {
             const btn = this.add.text(rx, y, `[${r.label}]`, {
-                fontSize: '12px', color: this._filterRace === r.id ? '#f5e642' : '#667788',
+                fontSize: '11px', color: this._filterRace === r.id ? '#f5e642' : '#667788',
                 fontFamily: 'monospace'
             }).setInteractive({ useHandCursor: true });
             btn.on('pointerdown', () => {
                 this._filterRace = r.id;
-                this.scene.restart({ filterRace: this._filterRace, filterDiff: this._filterDiff });
+                this.scene.restart({
+                    filterRace: this._filterRace,
+                    filterDiff: this._filterDiff,
+                    tab: this._tab
+                });
             });
-            rx += btn.width + 8;
+            rx += btn.width + 6;
         }
 
         this.add.text(cx + 40, y, 'Diff:', ts);
-        let dx = cx + 75;
+        let dx = cx + 70;
         for (const d of DIFFS) {
             const btn = this.add.text(dx, y, `[${d.label}]`, {
-                fontSize: '12px', color: this._filterDiff === d.id ? '#f5e642' : '#667788',
+                fontSize: '11px', color: this._filterDiff === d.id ? '#f5e642' : '#667788',
                 fontFamily: 'monospace'
             }).setInteractive({ useHandCursor: true });
             btn.on('pointerdown', () => {
                 this._filterDiff = d.id;
-                this.scene.restart({ filterRace: this._filterRace, filterDiff: this._filterDiff });
+                this.scene.restart({
+                    filterRace: this._filterRace,
+                    filterDiff: this._filterDiff,
+                    tab: this._tab
+                });
             });
-            dx += btn.width + 8;
+            dx += btn.width + 6;
         }
     }
+
+    // ── Global score fetching ───────────────────────────────────────────────
+
+    _fetchGlobal() {
+        if (typeof GlobalLeaderboard === 'undefined') {
+            this._globalError = true;
+            this._refreshList();
+            return;
+        }
+        GlobalLeaderboard.fetchScores({
+            race: this._filterRace,
+            difficulty: this._filterDiff
+        }).then(scores => {
+            this._globalScores = scores;
+            this._globalError = false;
+            this._scrollOffset = 0;
+            this._refreshList();
+        }).catch(() => {
+            this._globalScores = [];
+            this._globalError = true;
+            this._refreshList();
+        });
+    }
+
+    // ── Score table rendering ───────────────────────────────────────────────
 
     _refreshList() {
         for (const o of this._dyn) { if (o && o.destroy) o.destroy(); }
         this._dyn = [];
 
+        if (this._tab === 'global') {
+            this._renderGlobalList();
+        } else {
+            this._renderLocalList();
+        }
+    }
+
+    _renderLocalList() {
         const scores = Leaderboard.getFiltered(this._filterRace, this._filterDiff);
-        const { width: W } = this.cameras.main;
+        this._renderScoreTable(scores);
+    }
+
+    _renderGlobalList() {
+        if (this._globalScores === null) {
+            // Still loading
+            const { width: W } = this.cameras.main;
+            this._dyn.push(this.add.text(W / 2, this._listY + 60, 'Henter globale resultater...', {
+                fontSize: '14px', color: '#556677', fontFamily: 'monospace', align: 'center'
+            }).setOrigin(0.5));
+            this._totalRows = 0;
+            return;
+        }
+
+        if (this._globalError && this._globalScores.length === 0) {
+            const { width: W } = this.cameras.main;
+            this._dyn.push(this.add.text(W / 2, this._listY + 60,
+                'Kunne ikke hente globale resultater.\nSjekk internettforbindelsen.', {
+                fontSize: '14px', color: '#664444', fontFamily: 'monospace', align: 'center'
+            }).setOrigin(0.5));
+            this._totalRows = 0;
+            return;
+        }
+
+        this._renderScoreTable(this._globalScores);
+    }
+
+    _renderScoreTable(scores) {
+        const { width: W, height: H } = this.cameras.main;
         const cx = W / 2;
         const y0 = this._listY;
 
@@ -120,23 +232,33 @@ class LeaderboardScene extends Phaser.Scene {
             this._dyn.push(this.add.text(cx, y0 + 60, 'Ingen resultater enn\u00e5.\nSpill et eventyr for \u00e5 komme p\u00e5 tavlen!', {
                 fontSize: '14px', color: '#445566', fontFamily: 'monospace', align: 'center'
             }).setOrigin(0.5));
+            this._totalRows = 0;
             return;
         }
 
-        // Header
-        const hdrStyle = { fontSize: '12px', color: '#556677', fontFamily: 'monospace' };
-        const cols = [cx - 215, cx - 150, cx - 85, cx - 30, cx + 15, cx + 60, cx + 110, cx + 160];
-        ['#', 'Navn', 'Rase', 'Verden', 'Niv\u00e5', 'Drap', 'Gull', 'Tid'].forEach((h, i) => {
+        // Header – 10 columns: #, Navn, Rase, Verden, Nivå, Drap, Gull, Min, Elem, Tid
+        const hdrStyle = { fontSize: '11px', color: '#556677', fontFamily: 'monospace' };
+        const cols = [
+            cx - 235,  // #
+            cx - 185,  // Navn
+            cx - 115,  // Rase
+            cx - 55,   // Verden
+            cx - 15,   // Nivå
+            cx + 25,   // Drap
+            cx + 65,   // Gull
+            cx + 105,  // Min (minerals)
+            cx + 140,  // Elem (elements)
+            cx + 180,  // Tid
+        ];
+        const headers = ['#', 'Navn', 'Rase', 'Vrdn', 'Niv\u00e5', 'Drap', 'Gull', 'Min', 'Elem', 'Tid'];
+        headers.forEach((h, i) => {
             this._dyn.push(this.add.text(cols[i], y0, h, hdrStyle));
         });
-        this._dyn.push(this.add.rectangle(cx, y0 + 14, 480, 1, 0x223344));
+        this._dyn.push(this.add.rectangle(cx, y0 + 14, W - 40, 1, 0x223344));
 
-        const RACE_NAMES = { human: 'Menneske', dwarf: 'Dverg', elf: 'Alv', hobbit: 'Hobbit' };
+        const RACE_NAMES = { human: 'Mns', dwarf: 'Dvr', elf: 'Alv', hobbit: 'Hbt' };
         const rowH = 20;
         this._totalRows = scores.length;
-        const { height: H } = this.cameras.main;
-        const visibleArea = H - y0 - 60;
-        const maxVisible = Math.floor(visibleArea / rowH);
 
         for (let i = 0; i < scores.length; i++) {
             const s = scores[i];
@@ -144,25 +266,28 @@ class LeaderboardScene extends Phaser.Scene {
             if (ry < y0 + 10 || ry > H - 50) continue; // clip rows outside visible area
             const isTop3 = i < 3;
             const col = isTop3 ? ['#f5e642', '#cccccc', '#cc8844'][i] : '#667788';
-            const style = { fontSize: '13px', color: col, fontFamily: 'monospace' };
+            const style = { fontSize: '12px', color: col, fontFamily: 'monospace' };
 
             const medal = i === 0 ? '1.' : i === 1 ? '2.' : i === 2 ? '3.' : `${i + 1}.`;
             this._dyn.push(this.add.text(cols[0], ry, medal, style));
-            this._dyn.push(this.add.text(cols[1], ry, s.heroName || 'Helt', style));
-            this._dyn.push(this.add.text(cols[2], ry, RACE_NAMES[s.race] || s.race, { ...style, fontSize: '13px' }));
+            this._dyn.push(this.add.text(cols[1], ry, (s.heroName || 'Helt').slice(0, 8), style));
+            this._dyn.push(this.add.text(cols[2], ry, RACE_NAMES[s.race] || s.race, style));
             this._dyn.push(this.add.text(cols[3], ry, `${s.worldsCleared}`, style));
             this._dyn.push(this.add.text(cols[4], ry, `${s.level}`, style));
             this._dyn.push(this.add.text(cols[5], ry, `${s.monstersKilled}`, style));
-            this._dyn.push(this.add.text(cols[6], ry, `${s.goldEarned}g`, style));
+            this._dyn.push(this.add.text(cols[6], ry, `${s.goldEarned}`, style));
+            this._dyn.push(this.add.text(cols[7], ry, `${s.mineralsCollected || 0}`, style));
+            this._dyn.push(this.add.text(cols[8], ry, `${s.elementsDiscovered || 0}`, style));
+
             // Time column (mm:ss)
             const t = s.timeSeconds || 0;
             const tStr = `${Math.floor(t / 60)}:${String(t % 60).padStart(2, '0')}`;
-            this._dyn.push(this.add.text(cols[7], ry, tStr, style));
+            this._dyn.push(this.add.text(cols[9], ry, tStr, style));
 
             // Result indicator
             const resCol = s.result === 'death' ? '#ff4444' : '#44ee66';
             const resIcon = s.result === 'death' ? '\u2620' : '\u2713';
-            this._dyn.push(this.add.text(cols[7] + 45, ry, resIcon, { ...style, color: resCol }));
+            this._dyn.push(this.add.text(cols[9] + 40, ry, resIcon, { ...style, color: resCol }));
         }
     }
 }

--- a/src/systems/ItemSpawner.js
+++ b/src/systems/ItemSpawner.js
@@ -454,6 +454,9 @@ class ItemSpawner {
                     obj.graphic.destroy();
                     scene.itemObjects.splice(i, 1);
 
+                    // Track mineral pickups for leaderboard
+                    if (obj.isMineral) scene.hero.mineralsCollected++;
+
                     // Can hero identify minerals? (requires Geolog skill)
                     const canIdentify = obj.isMineral && (scene.hero.mineralIdentifyLevel || 0) > 0;
 

--- a/src/utils/GlobalLeaderboard.js
+++ b/src/utils/GlobalLeaderboard.js
@@ -1,9 +1,23 @@
 // ─── Labyrint Hero – Global Leaderboard API Client ───────────────────────────
 // Thin wrapper for the global leaderboard REST API.
 // Fails silently on network errors – local leaderboard is the fallback.
+//
+// ┌──────────────────────────────────────────────────────────────────────────┐
+// │  HOW TO ACTIVATE THE GLOBAL LEADERBOARD                                 │
+// │                                                                          │
+// │  1. cd backend/                                                          │
+// │  2. npm install -g wrangler                                              │
+// │  3. wrangler login                                                       │
+// │  4. wrangler kv namespace create LEADERBOARD                             │
+// │  5. Copy the namespace ID into backend/wrangler.toml                     │
+// │  6. wrangler deploy                                                      │
+// │  7. Set the API_URL below to your deployed worker URL                    │
+// │                                                                          │
+// │  See backend/README.md for full details.                                 │
+// └──────────────────────────────────────────────────────────────────────────┘
 
 const GlobalLeaderboard = {
-    // Configure this URL to point to your deployed Cloudflare Worker (or other backend)
+    // ⬇ CHANGE THIS to your deployed Cloudflare Worker URL ⬇
     API_URL: 'https://labyrint-hero-leaderboard.workers.dev',
 
     /**

--- a/src/utils/GlobalLeaderboard.js
+++ b/src/utils/GlobalLeaderboard.js
@@ -1,0 +1,60 @@
+// ─── Labyrint Hero – Global Leaderboard API Client ───────────────────────────
+// Thin wrapper for the global leaderboard REST API.
+// Fails silently on network errors – local leaderboard is the fallback.
+
+const GlobalLeaderboard = {
+    // Configure this URL to point to your deployed Cloudflare Worker (or other backend)
+    API_URL: 'https://labyrint-hero-leaderboard.workers.dev',
+
+    /**
+     * Submit a score to the global leaderboard (fire-and-forget).
+     * @param {Object} entry - Leaderboard entry (same shape as local entries)
+     */
+    submitScore(entry) {
+        const payload = {
+            heroName:           entry.heroName || 'Helt',
+            race:               entry.race || 'human',
+            difficulty:         entry.difficulty || 'normal',
+            worldsCleared:      entry.worldsCleared || 0,
+            level:              entry.level || 1,
+            monstersKilled:     entry.monstersKilled || 0,
+            goldEarned:         entry.goldEarned || 0,
+            mineralsCollected:  entry.mineralsCollected || 0,
+            elementsDiscovered: entry.elementsDiscovered || 0,
+            timeSeconds:        entry.timeSeconds || 0,
+            result:             entry.result || 'worldComplete',
+            date:               new Date().toISOString().slice(0, 10)
+        };
+
+        fetch(`${this.API_URL}/scores`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        }).catch(() => {
+            // Silent failure – local leaderboard still works
+        });
+    },
+
+    /**
+     * Fetch global top scores.
+     * @param {Object} filters - Optional { race, difficulty }
+     * @returns {Promise<Array>} Top 100 scores, or empty array on failure
+     */
+    async fetchScores(filters = {}) {
+        const params = new URLSearchParams();
+        if (filters.race)       params.set('race', filters.race);
+        if (filters.difficulty)  params.set('difficulty', filters.difficulty);
+
+        const qs = params.toString();
+        const url = `${this.API_URL}/scores${qs ? '?' + qs : ''}`;
+
+        try {
+            const res = await fetch(url);
+            if (!res.ok) return [];
+            const data = await res.json();
+            return Array.isArray(data) ? data : (data.scores || []);
+        } catch (e) {
+            return [];
+        }
+    }
+};

--- a/src/utils/Leaderboard.js
+++ b/src/utils/Leaderboard.js
@@ -15,10 +15,12 @@ const Leaderboard = {
             worldsCleared:  entry.worldsCleared || 0,
             level:          entry.level || 1,
             monstersKilled: entry.monstersKilled || 0,
-            goldEarned:     entry.goldEarned || 0,
-            timeSeconds:    entry.timeSeconds || 0,
-            result:         entry.result || 'death',
-            date:           new Date().toISOString().slice(0, 10)
+            goldEarned:         entry.goldEarned || 0,
+            mineralsCollected:  entry.mineralsCollected || 0,
+            elementsDiscovered: entry.elementsDiscovered || 0,
+            timeSeconds:        entry.timeSeconds || 0,
+            result:             entry.result || 'death',
+            date:               new Date().toISOString().slice(0, 10)
         });
         // Sort by worlds cleared (desc), then level (desc), then monsters killed (desc)
         scores.sort((a, b) =>


### PR DESCRIPTION
- Add GlobalLeaderboard.js API client (submitScore, fetchScores)
- Add Cloudflare Worker + KV backend with anti-cheat validation
- Update LeaderboardScene with Local/Global tab toggle and 10 columns
- Track mineralsCollected on Hero, elementsDiscovered from ElementTracker
- Submit scores to global API on world completion (fire-and-forget)
- Update docs/CHANGELOG.md and docs/GDD.md for v0.38

Closes #64

https://claude.ai/code/session_01UNPgpfiqeM77MNLpQmvVSR