### PR TITLE
Add global leaderboard with new categories (#64)

### DIFF
--- a/src/entities/HeroCrafting.js
+++ b/src/entities/HeroCrafting.js
@@ -15,6 +15,7 @@ const HeroCrafting = {
         hero.smeltBonusElement = 0;
         hero.guaranteedRareMineral = false;
         hero.mineralsCollected = 0;
+        hero.totalPlayTime = 0; // cumulative seconds across all worlds
 
         // Metallurgy mod (Phase 2)
         hero.metallurgistUnlocked = false;
@@ -67,6 +68,7 @@ const HeroCrafting = {
             smeltBonusElement:    hero.smeltBonusElement,
             guaranteedRareMineral: hero.guaranteedRareMineral,
             mineralsCollected:    hero.mineralsCollected,
+            totalPlayTime:        hero.totalPlayTime,
             metallurgistUnlocked: hero.metallurgistUnlocked,
             smeltingSpeedMul:     hero.smeltingSpeedMul,
             smeltingEfficiency:   hero.smeltingEfficiency,
@@ -109,6 +111,7 @@ const HeroCrafting = {
         hero.smeltBonusElement    = stats.smeltBonusElement    || 0;
         hero.guaranteedRareMineral = stats.guaranteedRareMineral || false;
         hero.mineralsCollected    = stats.mineralsCollected    || 0;
+        hero.totalPlayTime        = stats.totalPlayTime        || 0;
         hero.metallurgistUnlocked = stats.metallurgistUnlocked || false;
         hero.smeltingSpeedMul     = stats.smeltingSpeedMul     || 1.0;
         hero.smeltingEfficiency   = stats.smeltingEfficiency   || 1.0;

--- a/src/scenes/GameOverScene.js
+++ b/src/scenes/GameOverScene.js
@@ -34,7 +34,7 @@ class GameOverScene extends Phaser.Scene {
                 mineralsCollected:  this.heroStats.mineralsCollected || 0,
                 elementsDiscovered: elementsDiscovered,
                 result:             'worldComplete',
-                timeSeconds:        this.timeSeconds
+                timeSeconds:        this.heroStats.totalPlayTime || this.timeSeconds
             };
             Leaderboard.record(entry);
 

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -344,8 +344,9 @@ class GameScene extends Phaser.Scene {
             }
         }
 
-        SaveManager.save(this.worldNum + 1, this._getFullStats());
         const worldTime = Math.round((Date.now() - this._worldStartTime) / 1000);
+        this.hero.totalPlayTime = (this.hero.totalPlayTime || 0) + worldTime;
+        SaveManager.save(this.worldNum + 1, this._getFullStats());
         this.time.delayedCall(300, () => {
             this.scene.start('GameOverScene', {
                 type: 'worldComplete', worldNum: this.worldNum,
@@ -363,8 +364,9 @@ class GameScene extends Phaser.Scene {
         Audio.playDeath();
         Audio.stopMusic();
         this._stopOverlayScenes();
-        SaveManager.save(this.worldNum, this._getFullStats());
         const worldTime = Math.round((Date.now() - this._worldStartTime) / 1000);
+        this.hero.totalPlayTime = (this.hero.totalPlayTime || 0) + worldTime;
+        SaveManager.save(this.worldNum, this._getFullStats());
         this.time.delayedCall(700, () => {
             this.scene.start('GameOverScene', {
                 type: 'death', worldNum: this.worldNum,

--- a/src/scenes/LeaderboardScene.js
+++ b/src/scenes/LeaderboardScene.js
@@ -243,7 +243,7 @@ class LeaderboardScene extends Phaser.Scene {
             cx + 180,  // Elem (elements)
             cx + 235,  // Tid
         ];
-        const headers = ['#', 'Navn', 'Rase', 'Vrdn', 'Niv\u00e5', 'Drap', 'Gull', 'Min', 'Elem', 'Tid'];
+        const headers = ['#', 'Navn', 'Rase', 'Vrdn', 'Niv\u00e5', 'Drap', 'Gull', 'Min', 'Grst', 'Tid'];
         headers.forEach((h, i) => {
             this._dyn.push(this.add.text(cols[i], y0, h, hdrStyle));
         });


### PR DESCRIPTION
## Summary
- **Global leaderboard** with Cloudflare Worker + KV backend (`backend/worker.js`) and thin API client (`src/utils/GlobalLeaderboard.js`)
- **Local/Global tab toggle** in LeaderboardScene — local works offline, global fetches top 100 from API
- **New leaderboard categories**: Minerals collected (Min) and Elements discovered (Grst) columns
- **Total play time** tracked across all worlds instead of per-world time
- **Anti-cheat validation**: server rejects impossible scores (high worlds at level 1, sub-10s clears, death entries)
- Race and difficulty filters work for both tabs; filters split into two rows for clean layout
- Score submission is fire-and-forget on world completion — never blocks the victory screen

## Files changed
- `src/utils/GlobalLeaderboard.js` — new API client with setup instructions
- `backend/worker.js` + `wrangler.toml` + `README.md` — Cloudflare Worker backend
- `src/scenes/LeaderboardScene.js` — rewritten with tabs, 10 columns, loading/error states
- `src/scenes/GameOverScene.js` — submits to global leaderboard, uses totalPlayTime
- `src/scenes/GameScene.js` — accumulates totalPlayTime on exit and death
- `src/entities/HeroCrafting.js` — new `mineralsCollected` and `totalPlayTime` properties
- `src/systems/ItemSpawner.js` — increments mineralsCollected on mineral pickup
- `src/utils/Leaderboard.js` — new entry fields
- `index.html` — loads GlobalLeaderboard.js
- `docs/CHANGELOG.md`, `docs/GDD.md` — v0.38 documentation

## Test plan
- [ ] Open leaderboard from menu — Local tab shows with empty state or existing scores
- [ ] Switch to Global tab — shows loading message, then error (backend not deployed) or scores
- [ ] Switch back to Local — scores display correctly
- [ ] Race and difficulty filters work on both tabs
- [ ] Complete a world — score appears in local leaderboard with minerals, elements, and total time
- [ ] Verify time column shows cumulative time, not just last world
- [ ] Die mid-world — no entry added to leaderboard
- [ ] Deploy backend (see `backend/README.md`) and verify global submission works

Closes #64

https://claude.ai/code/session_01UNPgpfiqeM77MNLpQmvVSR