### PR TITLE
claude/resize-camp-scene-QV2fI

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ---
 
+## v0.39 – 2026-04-15
+
+### Nye funksjoner
+- **Mindre og mer lesbare leir-/kjemi-paneler (#98):** SmelteryScene krymper fra nesten hele lerretet (W-20 × H-20) til et sentrert panel på maks 1080×680, og ChemLabScene utvider litt til 760×600 for å romme større fonter. Tittel, faner, knapper og listetekst har fått økt skriftstørrelse (12–14px → 14–18px) for bedre lesbarhet
+- **Drag-scrolling med mus og berøring (#98):** Begge scener støtter nå å scrolle ved å dra med musen eller med fingeren i tillegg til musehjulet. En 8px-terskel sørger for at korte klikk fortsatt utløser knapper
+- **Scrollbar-indikator (#98):** Tynn vertikal scrollbar på høyre side av innholdsområdet viser nåværende posisjon og scroll-rekkevidde. Scroll-offset klampes automatisk til innholdets høyde slik at over-scrolling er umulig
+
+### Tekniske endringer
+- SmelteryScene: Ny `_clampScroll()`, `_viewportHeight()` og `_maxScrolls` per fane. Hver `_draw*Tab()` setter `_contentEndY` som brukes i `_refresh()` til å beregne maks scroll og tegne scrollbar-tommel
+- ChemLabScene: Samme mønster for en enkelt `_scrollOffset`/`_maxScroll`. Panelet har også fått litt større karakter-portrett (120 → 130px)
+- Felles input-mønster: `pointerdown`/`pointermove`/`pointerup` på scene-input med drag-threshold, eksisterer side om side med eksisterende `wheel`-handler
+
+---
+
 ## v0.38 – 2026-04-13
 
 ### Nye funksjoner

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,6 +1,6 @@
 # Labyrint Hero – Game Design Document
-**Versjon:** 0.38
-**Sist oppdatert:** 2026-04-13
+**Versjon:** 0.39
+**Sist oppdatert:** 2026-04-15
 
 ---
 
@@ -515,7 +515,7 @@ Synergi: **Jordens kraft** (Geolog + Vokter) → +1 forsvar, +1 mineralsynsradiu
 
 Smelting, legeringer og smiing av utstyr.
 
-**Leirplass (Camp Room):** Garantert fra verden 2+, 50% sjanse i verden 1. Trygg sone med smelteovn og **persistent lager (stash)** der spilleren kan lagre mineraler, brensel og andre ressurser mellom besøk. Frigjør ryggsekken for kamp. Åpnes med V-tast. Visuelt tema med bål, telt, trær, stjernehimmel og røyk. Panelet bruker nesten full skjermstørrelse. Alle faner støtter scrolling med musehjul, og grunnstoff-merker er klikkbare for å filtrere minerallisten etter element.
+**Leirplass (Camp Room):** Garantert fra verden 2+, 50% sjanse i verden 1. Trygg sone med smelteovn og **persistent lager (stash)** der spilleren kan lagre mineraler, brensel og andre ressurser mellom besøk. Frigjør ryggsekken for kamp. Åpnes med V-tast. Visuelt tema med bål, telt, trær, stjernehimmel og røyk. Panelet er sentrert med luft rundt kanten (opptil 1080×680) og har større fonter for lesbarhet. Alle faner støtter scrolling med musehjul, drag med mus og drag med finger (touch), og en scrollbar-tommel viser posisjonen. Grunnstoff-merker er klikkbare for å filtrere minerallisten etter element.
 
 **Smelting:** Mineraler + brensel → rene grunnstoffer. Brensel (tre=1, kull=3 energi) spawner i labyrinten.
 
@@ -535,7 +535,7 @@ Låses opp ved første besøk i leirplass. **Minst én Metallurg-skill kreves fo
 
 Kjemisk syntese av potions, bomber, medisiner og syrer fra rene grunnstoffer.
 
-**Kjemisk laboratorium:** Spesialrom fra verden 3+ med grønn glød. Åpnes med C-tast. Filterbare oppskrifter etter kategori. Visuelt tema med labbenk, hyller med flasker, erlenmeyerkolber, reagensrør, periodisk tabell-hint og bobler. Karakterportrett i nedre høyre hjørne.
+**Kjemisk laboratorium:** Spesialrom fra verden 3+ med grønn glød. Åpnes med C-tast. Filterbare oppskrifter etter kategori. Visuelt tema med labbenk, hyller med flasker, erlenmeyerkolber, reagensrør, periodisk tabell-hint og bobler. Karakterportrett i nedre høyre hjørne. Panelet (760×600) har større fonter og støtter scrolling via musehjul, drag (mus eller finger) og en synlig scrollbar-tommel.
 
 **Produkter:** 15 kjemiske produkter i 5 kategorier. Kraftigere enn vanlige consumables – kjemisk livselixir healer 4 HP (vs 2), krutt gjør 8 skade i radius 3 (vs 6 for vanlig bombe), dynamitt 15 skade.
 

--- a/src/scenes/ChemLabScene.js
+++ b/src/scenes/ChemLabScene.js
@@ -22,8 +22,10 @@ class ChemLabScene extends Phaser.Scene {
         this.add.rectangle(cx, cy, W, H, 0x000000, 0.82);
 
         // ── Panel ─────────────────────────────────────────────────────────────
-        this.panelW = Math.min(W - 10, 700);
-        this.panelH = Math.min(H - 10, 520);
+        // Slightly larger than before to accommodate bumped fonts without
+        // crowding the portrait. Leaves margin around the canvas.
+        this.panelW = Math.min(W - 80, 760);
+        this.panelH = Math.min(H - 80, 600);
         this.px = cx - this.panelW / 2;
         this.py = cy - this.panelH / 2;
 
@@ -36,7 +38,7 @@ class ChemLabScene extends Phaser.Scene {
         }
 
         // ── Character portrait (sits in the scene, lower-right of bg) ─────────
-        const portraitSize = 120;
+        const portraitSize = 130;
         const portraitX = this.px + this.panelW - portraitSize - 6;
         const portraitY = this.py + this.panelH - portraitSize - 6;
         const portraitGfx = this.add.graphics();
@@ -63,17 +65,17 @@ class ChemLabScene extends Phaser.Scene {
         panel.strokeRoundedRect(this.px, this.py, this.panelW, this.panelH, 8);
 
         // Title
-        this.add.text(cx, this.py + 18, 'KJEMISK LABORATORIUM', {
-            fontSize: '14px', color: '#33dd88', fontFamily: 'monospace', fontStyle: 'bold'
+        this.add.text(cx, this.py + 22, 'KJEMISK LABORATORIUM', {
+            fontSize: '18px', color: '#33dd88', fontFamily: 'monospace', fontStyle: 'bold'
         }).setOrigin(0.5);
 
         // Fuel indicator
         const fuel = this.smelter.calculateFuelEnergy(this.heroRef);
-        this._fuelText = this.add.text(this.px + this.panelW - 20, this.py + 18, `Energi: ${fuel}`, {
-            fontSize: '12px', color: '#448844', fontFamily: 'monospace'
+        this._fuelText = this.add.text(this.px + this.panelW - 20, this.py + 22, `Energi: ${fuel}`, {
+            fontSize: '14px', color: '#448844', fontFamily: 'monospace'
         }).setOrigin(1, 0.5);
 
-        this.add.rectangle(cx, this.py + 34, this.panelW - 20, 1, 0x113322);
+        this.add.rectangle(cx, this.py + 42, this.panelW - 20, 1, 0x113322);
 
         // ── Filter buttons ────────────────────────────────────────────────────
         this._filterBtns = [];
@@ -84,38 +86,68 @@ class ChemLabScene extends Phaser.Scene {
             { id: 'medicine', label: 'Medisin' },
             { id: 'acid', label: 'Syrer' },
         ];
-        const filterY = this.py + 50;
+        const filterY = this.py + 62;
+        const filterStep = Math.min(120, (this.panelW - 80) / filters.length);
         filters.forEach((f, i) => {
-            const fx = this.px + 30 + i * 100 + 45;
+            const fx = this.px + 30 + i * filterStep + filterStep / 2;
             const active = this._filter === f.id;
             const btn = this.add.text(fx, filterY, f.label, {
-                fontSize: '12px', color: active ? '#33dd88' : '#335533',
+                fontSize: '16px', color: active ? '#33dd88' : '#335533',
                 fontFamily: 'monospace', fontStyle: active ? 'bold' : 'normal'
             }).setOrigin(0.5).setInteractive({ useHandCursor: true });
             btn.on('pointerdown', () => { this._filter = f.id; this._refresh(); });
             this._filterBtns.push(btn);
         });
 
-        this.add.rectangle(cx, filterY + 12, this.panelW - 20, 1, 0x113322);
+        this.add.rectangle(cx, filterY + 16, this.panelW - 20, 1, 0x113322);
 
         // Close
-        const closeBtn = this.add.text(this.px + this.panelW - 20, this.py + 8, '✕', {
-            fontSize: '18px', color: '#448844', fontFamily: 'monospace'
+        const closeBtn = this.add.text(this.px + this.panelW - 20, this.py + 10, '✕', {
+            fontSize: '22px', color: '#448844', fontFamily: 'monospace'
         }).setOrigin(0.5).setInteractive({ useHandCursor: true });
         closeBtn.on('pointerdown', () => this.scene.stop());
         this.input.keyboard.on('keydown-ESC', () => this.scene.stop());
         this.input.keyboard.on('keydown-C', () => this.scene.stop());
 
-        this.contentY = filterY + 22;
+        this.contentY = filterY + 28;
         this._scrollOffset = 0;
+        this._maxScroll = 0;
 
         // Mouse wheel scrolling for recipe list
         this.input.on('wheel', (pointer, gameObjects, deltaX, deltaY) => {
-            this._scrollOffset = Math.max(0, this._scrollOffset + deltaY * 0.5);
+            this._scrollOffset = this._clampScroll(this._scrollOffset + deltaY * 0.5);
             this._refresh();
         });
 
+        // Touch / mouse-drag scrolling with small movement threshold so that
+        // short taps still trigger interactive [Lag] buttons.
+        this._dragState = { active: false, startY: 0, startOffset: 0, engaged: false };
+        this.input.on('pointerdown', (pointer) => {
+            this._dragState.active = true;
+            this._dragState.engaged = false;
+            this._dragState.startY = pointer.y;
+            this._dragState.startOffset = this._scrollOffset;
+        });
+        this.input.on('pointermove', (pointer) => {
+            if (!this._dragState.active || !pointer.isDown) return;
+            const dy = pointer.y - this._dragState.startY;
+            if (!this._dragState.engaged && Math.abs(dy) < 8) return;
+            this._dragState.engaged = true;
+            this._scrollOffset = this._clampScroll(this._dragState.startOffset - dy);
+            this._refresh();
+        });
+        this.input.on('pointerup', () => { this._dragState.active = false; });
+        this.input.on('pointerupoutside', () => { this._dragState.active = false; });
+
         this._refresh();
+    }
+
+    _clampScroll(v) {
+        return Math.max(0, Math.min(v, this._maxScroll || 0));
+    }
+
+    _viewportHeight() {
+        return this.panelH - (this.contentY - this.py) - 30;
     }
 
     _refresh() {
@@ -124,7 +156,7 @@ class ChemLabScene extends Phaser.Scene {
         // Dark backing behind content for readability
         const cbg = this._d(this.add.graphics());
         cbg.fillStyle(0x080a10, 0.78);
-        cbg.fillRoundedRect(this.px + 6, this.contentY - 4, this.panelW - 150, this.panelH - (this.contentY - this.py) - 10, 4);
+        cbg.fillRoundedRect(this.px + 6, this.contentY - 4, this.panelW - 160, this.panelH - (this.contentY - this.py) - 10, 4);
 
         UIHelper.updateTabButtons(this._filterBtns, ['all', 'potion', 'explosive', 'medicine', 'acid'], this._filter, '#33dd88', '#335533');
 
@@ -135,6 +167,26 @@ class ChemLabScene extends Phaser.Scene {
             this._drawRecipes(fuel);
         } else {
             this._drawLockedMessage();
+            this._contentEndY = this.contentY;
+        }
+
+        // Compute max scroll from last-drawn content, clamp and draw scrollbar.
+        const viewportH = this._viewportHeight();
+        const contentSpan = Math.max(0, (this._contentEndY || 0) - this.contentY);
+        this._maxScroll = Math.max(0, contentSpan - viewportH);
+        this._scrollOffset = this._clampScroll(this._scrollOffset);
+
+        if (this._maxScroll > 0) {
+            const trackX = this.px + this.panelW - 170;
+            const trackY = this.contentY;
+            const trackH = viewportH;
+            const thumbH = Math.max(24, trackH * (trackH / (trackH + this._maxScroll)));
+            const thumbY = trackY + (trackH - thumbH) * (this._scrollOffset / this._maxScroll);
+            const bar = this._d(this.add.graphics());
+            bar.fillStyle(0x113322, 0.6);
+            bar.fillRoundedRect(trackX, trackY, 4, trackH, 2);
+            bar.fillStyle(0x33dd88, 0.7);
+            bar.fillRoundedRect(trackX, thumbY, 4, thumbH, 2);
         }
     }
 
@@ -147,12 +199,12 @@ class ChemLabScene extends Phaser.Scene {
     _drawLockedMessage() {
         const cx = this.px + this.panelW / 2;
         const cy = this.contentY + (this.panelH - (this.contentY - this.py)) / 2 - 40;
-        this._d(this.add.text(cx, cy, '🔒', { fontSize: '32px' }).setOrigin(0.5));
-        this._d(this.add.text(cx, cy + 30, 'Krever Kjemiker-skill!', {
-            fontSize: '14px', color: '#33dd88', fontFamily: 'monospace', fontStyle: 'bold'
+        this._d(this.add.text(cx, cy, '🔒', { fontSize: '36px' }).setOrigin(0.5));
+        this._d(this.add.text(cx, cy + 34, 'Krever Kjemiker-skill!', {
+            fontSize: '16px', color: '#33dd88', fontFamily: 'monospace', fontStyle: 'bold'
         }).setOrigin(0.5));
-        this._d(this.add.text(cx, cy + 50, 'Lær Potente potions i skilltreet\nfor å bruke laboratoriet.', {
-            fontSize: '12px', color: '#445544', fontFamily: 'monospace', align: 'center'
+        this._d(this.add.text(cx, cy + 58, 'Lær Potente potions i skilltreet\nfor å bruke laboratoriet.', {
+            fontSize: '14px', color: '#445544', fontFamily: 'monospace', align: 'center'
         }).setOrigin(0.5));
     }
 
@@ -162,9 +214,11 @@ class ChemLabScene extends Phaser.Scene {
         const hero = this.heroRef;
         const cx = this.px + this.panelW / 2;
         let y = this.contentY;
-        const colW = Math.min(340, this.panelW - 40);
+        // Leave room on the right for element inventory column.
+        const colW = Math.min(400, this.panelW - 180);
         const leftX = this.px + 20;
-        const rightX = cx + 10;
+        const rightX = this.px + this.panelW - 160;
+        const rowStep = 62;
 
         // Left column: recipes
         let allMols = this.chem.getAvailableMolecules(hero, fuel);
@@ -175,14 +229,17 @@ class ChemLabScene extends Phaser.Scene {
         }
 
         if (allMols.length === 0) {
-            this._d(this.add.text(cx, y + 40, 'Ingen oppskrifter tilgjengelig.', {
-                fontSize: '13px', color: '#334433', fontFamily: 'monospace'
+            this._d(this.add.text(leftX + colW / 2, y + 40, 'Ingen oppskrifter tilgjengelig.', {
+                fontSize: '14px', color: '#334433', fontFamily: 'monospace'
             }).setOrigin(0.5));
         }
 
+        const visBot = this.py + this.panelH - 30;
+
         allMols.forEach((entry, idx) => {
-            const my = y + idx * 58 - (this._scrollOffset || 0);
-            if (my > this.py + this.panelH - 80 || my < y - 20) return;
+            const baseY = y + idx * rowStep;
+            const my = baseY - (this._scrollOffset || 0);
+            if (my > visBot || my < y - rowStep) return;
             const m = entry.mol;
             const can = entry.canCraft;
             const col = can ? 0x33dd88 : 0x223322;
@@ -190,22 +247,22 @@ class ChemLabScene extends Phaser.Scene {
 
             const bg = this._d(this.add.graphics());
             bg.fillStyle(col, 0.08);
-            bg.fillRoundedRect(leftX, my, colW, 52, 4);
+            bg.fillRoundedRect(leftX, my, colW, 56, 4);
             bg.lineStyle(1, col, 0.3);
-            bg.strokeRoundedRect(leftX, my, colW, 52, 4);
+            bg.strokeRoundedRect(leftX, my, colW, 56, 4);
 
             // Subtype icon
             const icons = { base: '⚗', acid: '🧪', potion: '🧪', medicine: '💊', explosive: '💣', salt: '⚗' };
             const icon = icons[m.subtype] || '⚗';
-            this._d(this.add.text(leftX + 6, my + 4, icon, { fontSize: '12px' }));
+            this._d(this.add.text(leftX + 6, my + 4, icon, { fontSize: '14px' }));
 
             // Name + formula – truncate long names to fit slot
-            const dispName = m.name.length > 28 ? m.name.slice(0, 27) + '…' : m.name;
-            this._d(this.add.text(leftX + 24, my + 5, dispName, {
-                fontSize: '13px', color: hexCol, fontFamily: 'monospace', fontStyle: 'bold'
+            const dispName = m.name.length > 26 ? m.name.slice(0, 25) + '…' : m.name;
+            this._d(this.add.text(leftX + 28, my + 5, dispName, {
+                fontSize: '15px', color: hexCol, fontFamily: 'monospace', fontStyle: 'bold'
             }));
-            this._d(this.add.text(leftX + 24, my + 19, `${m.formula}  [T${m.tier}]`, {
-                fontSize: '12px', color: '#556655', fontFamily: 'monospace'
+            this._d(this.add.text(leftX + 28, my + 22, `${m.formula}  [T${m.tier}]`, {
+                fontSize: '13px', color: '#556655', fontFamily: 'monospace'
             }));
 
             // Recipe elements
@@ -214,18 +271,18 @@ class ChemLabScene extends Phaser.Scene {
                 const ok = have >= r.amount;
                 return `${r.symbol}:${have}/${r.amount}${ok ? '' : '!'}`;
             }).join('  ');
-            this._d(this.add.text(leftX + 6, my + 33, recipeStr, {
-                fontSize: '12px', color: '#556655', fontFamily: 'monospace'
+            this._d(this.add.text(leftX + 6, my + 38, recipeStr, {
+                fontSize: '13px', color: '#556655', fontFamily: 'monospace'
             }));
 
             // Effect preview
-            this._d(this.add.text(leftX + colW - 8, my + 36, m.desc.length > 35 ? m.desc.slice(0, 33) + '…' : m.desc, {
+            this._d(this.add.text(leftX + colW - 8, my + 40, m.desc.length > 32 ? m.desc.slice(0, 30) + '…' : m.desc, {
                 fontSize: '12px', color: '#445544', fontFamily: 'monospace'
             }).setOrigin(1, 0));
 
             if (can) {
-                const btn = this._d(this.add.text(leftX + colW - 50, my + 10, '[ Lag ]', {
-                    fontSize: '13px', color: '#33dd88', fontFamily: 'monospace', fontStyle: 'bold'
+                const btn = this._d(this.add.text(leftX + colW - 56, my + 10, '[ Lag ]', {
+                    fontSize: '15px', color: '#33dd88', fontFamily: 'monospace', fontStyle: 'bold'
                 }).setInteractive({ useHandCursor: true }));
                 btn.on('pointerover', () => btn.setColor('#66ffaa'));
                 btn.on('pointerout', () => btn.setColor('#33dd88'));
@@ -235,7 +292,10 @@ class ChemLabScene extends Phaser.Scene {
 
         // Right side: element inventory
         const elemY = this.contentY;
-        this._drawElementCounts(rightX, elemY, colW - 20);
+        this._drawElementCounts(rightX, elemY, 150);
+
+        // End-of-content for scrollbar
+        this._contentEndY = y + allMols.length * rowStep;
     }
 
     _doSynthesize(moleculeId) {
@@ -262,29 +322,29 @@ class ChemLabScene extends Phaser.Scene {
 
     _drawElementCounts(x, y, w) {
         this._d(this.add.text(x, y, 'GRUNNSTOFFER:', {
-            fontSize: '13px', color: '#556655', fontFamily: 'monospace', fontStyle: 'bold'
+            fontSize: '14px', color: '#556655', fontFamily: 'monospace', fontStyle: 'bold'
         }));
 
         const collected = this.heroRef.elementTracker.collected;
         const entries = Object.entries(collected).filter(([, v]) => v > 0);
         if (entries.length === 0) {
-            this._d(this.add.text(x, y + 14, 'Ingen lagret.', {
-                fontSize: '13px', color: '#334433', fontFamily: 'monospace'
+            this._d(this.add.text(x, y + 18, 'Ingen lagret.', {
+                fontSize: '14px', color: '#334433', fontFamily: 'monospace'
             }));
             return;
         }
 
-        let bx = x, by = y + 14;
+        let bx = x, by = y + 18;
         for (const [symbol, count] of entries) {
             const elem = typeof ELEMENTS !== 'undefined' ? ELEMENTS[symbol] : null;
             const col = elem ? elem.color : 0xaaaaaa;
             const hexCol = '#' + col.toString(16).padStart(6, '0');
             const badge = this._d(this.add.text(bx, by, `${symbol}:${count}`, {
-                fontSize: '13px', color: hexCol, fontFamily: 'monospace',
+                fontSize: '14px', color: hexCol, fontFamily: 'monospace',
                 backgroundColor: '#081808', padding: { x: 3, y: 1 }
             }));
             bx += badge.width + 6;
-            if (bx > x + w - 30) { bx = x; by += 16; }
+            if (bx > x + w - 30) { bx = x; by += 20; }
         }
     }
 }

--- a/src/scenes/SmelteryScene.js
+++ b/src/scenes/SmelteryScene.js
@@ -21,8 +21,9 @@ class SmelteryScene extends Phaser.Scene {
         this.add.rectangle(cx, cy, W, H, 0x000000, 0.82);
 
         // ── Panel ─────────────────────────────────────────────────────────────
-        this.panelW = W - 20;
-        this.panelH = H - 20;
+        // Shrink from full-canvas so the scene feels lighter and leaves margin.
+        this.panelW = Math.min(W - 80, 1080);
+        this.panelH = Math.min(H - 80, 680);
         this.px = cx - this.panelW / 2;
         this.py = cy - this.panelH / 2;
 
@@ -48,24 +49,24 @@ class SmelteryScene extends Phaser.Scene {
         panel.strokeRoundedRect(this.px, this.py, this.panelW, this.panelH, 8);
 
         // Title
-        this.add.text(cx, this.py + 18, 'SMELTEOVN  –  Leirplass', {
-            fontSize: '14px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
+        this.add.text(cx, this.py + 22, 'SMELTEOVN  –  Leirplass', {
+            fontSize: '18px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
         }).setOrigin(0.5);
 
         // Fuel indicator
         const fuel = this.smelter.calculateFuelEnergy(this.heroRef);
-        this._fuelText = this.add.text(this.px + this.panelW - 20, this.py + 18, `Brensel: ${fuel} energi`, {
-            fontSize: '12px', color: '#886633', fontFamily: 'monospace'
+        this._fuelText = this.add.text(this.px + this.panelW - 20, this.py + 22, `Brensel: ${fuel} energi`, {
+            fontSize: '14px', color: '#886633', fontFamily: 'monospace'
         }).setOrigin(1, 0.5);
 
         // Element counts summary
         const tracker = this.heroRef.elementTracker;
         const elemCount = Object.keys(tracker.collected).length;
-        this._elemText = this.add.text(this.px + 20, this.py + 18, `Grunnstoffer: ${elemCount}`, {
-            fontSize: '12px', color: '#887766', fontFamily: 'monospace'
+        this._elemText = this.add.text(this.px + 20, this.py + 22, `Grunnstoffer: ${elemCount}`, {
+            fontSize: '14px', color: '#887766', fontFamily: 'monospace'
         }).setOrigin(0, 0.5);
 
-        this.add.rectangle(cx, this.py + 34, this.panelW - 20, 1, 0x332200);
+        this.add.rectangle(cx, this.py + 42, this.panelW - 20, 1, 0x332200);
 
         // ── Tab buttons ───────────────────────────────────────────────────────
         this._tabBtns = [];
@@ -75,24 +76,24 @@ class SmelteryScene extends Phaser.Scene {
             { id: 'alloy', label: 'Legering' },
             { id: 'forge', label: 'Smi' },
         ];
-        const tabW = 110;
-        const tabY = this.py + 50;
+        const tabW = 130;
+        const tabY = this.py + 62;
         tabs.forEach((tab, i) => {
             const tx = this.px + 30 + i * (tabW + 10) + tabW / 2;
             const active = this._tab === tab.id;
             const btn = this.add.text(tx, tabY, tab.label, {
-                fontSize: '13px', color: active ? '#ff7722' : '#554433',
+                fontSize: '16px', color: active ? '#ff7722' : '#554433',
                 fontFamily: 'monospace', fontStyle: active ? 'bold' : 'normal'
             }).setOrigin(0.5).setInteractive({ useHandCursor: true });
             btn.on('pointerdown', () => { this._tab = tab.id; this._refresh(); });
             this._tabBtns.push(btn);
         });
 
-        this.add.rectangle(cx, tabY + 14, this.panelW - 20, 1, 0x221100);
+        this.add.rectangle(cx, tabY + 18, this.panelW - 20, 1, 0x221100);
 
         // ── Close button ──────────────────────────────────────────────────────
-        const closeBtn = this.add.text(this.px + this.panelW - 20, this.py + 8, '✕', {
-            fontSize: '18px', color: '#886644', fontFamily: 'monospace'
+        const closeBtn = this.add.text(this.px + this.panelW - 20, this.py + 10, '✕', {
+            fontSize: '22px', color: '#886644', fontFamily: 'monospace'
         }).setOrigin(0.5).setInteractive({ useHandCursor: true });
         closeBtn.on('pointerdown', () => this.scene.stop());
 
@@ -100,17 +101,49 @@ class SmelteryScene extends Phaser.Scene {
         this.input.keyboard.on('keydown-V', () => this.scene.stop());
 
         // ── Content area ──────────────────────────────────────────────────────
-        this.contentY = tabY + 24;
+        this.contentY = tabY + 30;
         this._scrollOffsets = { stash: 0, smelt: 0, alloy: 0, forge: 0 };
+        this._maxScrolls = { stash: 0, smelt: 0, alloy: 0, forge: 0 };
         this._elementFilter = null; // null = show all, or element symbol string
 
         // Mouse wheel scrolling (per-tab offset)
         this.input.on('wheel', (pointer, gameObjects, deltaX, deltaY) => {
-            this._scrollOffsets[this._tab] = Math.max(0, this._scrollOffsets[this._tab] + deltaY * 0.5);
+            this._scrollOffsets[this._tab] = this._clampScroll(this._scrollOffsets[this._tab] + deltaY * 0.5);
             this._refresh();
         });
 
+        // Touch / mouse-drag scrolling. Only engages after a small movement
+        // threshold so that short clicks still trigger interactive buttons.
+        this._dragState = { active: false, startY: 0, startOffset: 0, engaged: false };
+        this.input.on('pointerdown', (pointer) => {
+            this._dragState.active = true;
+            this._dragState.engaged = false;
+            this._dragState.startY = pointer.y;
+            this._dragState.startOffset = this._scrollOffsets[this._tab] || 0;
+        });
+        this.input.on('pointermove', (pointer) => {
+            if (!this._dragState.active || !pointer.isDown) return;
+            const dy = pointer.y - this._dragState.startY;
+            if (!this._dragState.engaged && Math.abs(dy) < 8) return;
+            this._dragState.engaged = true;
+            this._scrollOffsets[this._tab] = this._clampScroll(this._dragState.startOffset - dy);
+            this._refresh();
+        });
+        this.input.on('pointerup', () => { this._dragState.active = false; });
+        this.input.on('pointerupoutside', () => { this._dragState.active = false; });
+
         this._refresh();
+    }
+
+    /** Clamp a scroll offset against the current tab's known max. */
+    _clampScroll(v) {
+        const max = this._maxScrolls[this._tab] || 0;
+        return Math.max(0, Math.min(v, max));
+    }
+
+    /** Viewport height available for scrolling content in a tab. */
+    _viewportHeight() {
+        return this.panelH - (this.contentY - this.py) - 30;
     }
 
     _refresh() {
@@ -147,17 +180,38 @@ class SmelteryScene extends Phaser.Scene {
                 break;
         }
 
-        // Scroll indicators
+        // Compute max scroll for this tab from the captured end-of-content Y.
+        const viewportH = this._viewportHeight();
+        const contentSpan = Math.max(0, (this._contentEndY || 0) - this.contentY);
+        this._maxScrolls[this._tab] = Math.max(0, contentSpan - viewportH);
+        // Re-clamp in case content shrank (e.g. item used up).
+        this._scrollOffsets[this._tab] = this._clampScroll(this._scrollOffsets[this._tab] || 0);
+
+        // Scroll indicators + thumb
         const scrollOff = this._scrollOffsets[this._tab] || 0;
+        const maxScroll = this._maxScrolls[this._tab] || 0;
         if (scrollOff > 0) {
             this._d(this.add.text(this.px + this.panelW / 2, this.contentY - 2, '▲ mer ▲', {
-                fontSize: '10px', color: '#665544', fontFamily: 'monospace'
+                fontSize: '12px', color: '#665544', fontFamily: 'monospace'
             }).setOrigin(0.5, 1));
         }
-        if (this._lastContentOverflow) {
+        if (maxScroll > 0 && scrollOff < maxScroll - 1) {
             this._d(this.add.text(this.px + this.panelW / 2, this.py + this.panelH - 14, '▼ mer ▼', {
-                fontSize: '10px', color: '#665544', fontFamily: 'monospace'
+                fontSize: '12px', color: '#665544', fontFamily: 'monospace'
             }).setOrigin(0.5));
+        }
+        // Scrollbar thumb on right edge
+        if (maxScroll > 0) {
+            const trackX = this.px + this.panelW - 10;
+            const trackY = this.contentY;
+            const trackH = viewportH;
+            const thumbH = Math.max(24, trackH * (trackH / (trackH + maxScroll)));
+            const thumbY = trackY + (trackH - thumbH) * (scrollOff / maxScroll);
+            const bar = this._d(this.add.graphics());
+            bar.fillStyle(0x332200, 0.6);
+            bar.fillRoundedRect(trackX, trackY, 4, trackH, 2);
+            bar.fillStyle(0xff7722, 0.7);
+            bar.fillRoundedRect(trackX, thumbY, 4, thumbH, 2);
         }
     }
 
@@ -176,16 +230,17 @@ class SmelteryScene extends Phaser.Scene {
     _drawLockedTab() {
         const cx = this.px + this.panelW / 2;
         const cy = this.contentY + (this.panelH - (this.contentY - this.py)) / 2 - 40;
-        this._d(this.add.text(cx, cy, '🔒', { fontSize: '32px' }).setOrigin(0.5));
-        this._d(this.add.text(cx, cy + 30, 'Krever Metallurg-skill!', {
-            fontSize: '14px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
+        this._d(this.add.text(cx, cy, '🔒', { fontSize: '36px' }).setOrigin(0.5));
+        this._d(this.add.text(cx, cy + 34, 'Krever Metallurg-skill!', {
+            fontSize: '16px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
         }).setOrigin(0.5));
         const hint = this._hasGeologSkill()
             ? 'Lær Rask smelting i skilltreet\nfor å bruke smelteovnen.'
             : 'Du trenger Geolog-skill først,\nderetter Metallurg-skill.';
-        this._d(this.add.text(cx, cy + 50, hint, {
-            fontSize: '12px', color: '#665544', fontFamily: 'monospace', align: 'center'
+        this._d(this.add.text(cx, cy + 58, hint, {
+            fontSize: '14px', color: '#665544', fontFamily: 'monospace', align: 'center'
         }).setOrigin(0.5));
+        this._contentEndY = this.contentY;
     }
 
     _d(obj) { this._dyn.push(obj); return obj; }
@@ -196,22 +251,21 @@ class SmelteryScene extends Phaser.Scene {
         const hero = this.heroRef;
         const cx = this.px + this.panelW / 2;
         let y = this.contentY;
-        const colW = Math.min(420, this.panelW / 2 - 30);
+        const colW = Math.min(460, this.panelW / 2 - 30);
         const leftX = this.px + 20;
         const rightX = cx + 10;
         const scrollOff = this._scrollOffsets.stash || 0;
         const visTop = this.contentY - 10;
         const visBot = this.py + this.panelH - 40;
-        this._lastContentOverflow = false;
 
         // ── Left side: Backpack (deposit from) ──────────────────────────────
         const hdrLeftY = y - scrollOff;
         if (hdrLeftY >= visTop && hdrLeftY <= visBot) {
             this._d(this.add.text(leftX, hdrLeftY, 'RYGGSEKK → Lager', {
-                fontSize: '12px', color: '#887766', fontFamily: 'monospace', fontStyle: 'bold'
+                fontSize: '14px', color: '#887766', fontFamily: 'monospace', fontStyle: 'bold'
             }));
         }
-        y += 16;
+        y += 20;
 
         let bpY = y;
         let hasDepositable = false;
@@ -224,8 +278,8 @@ class SmelteryScene extends Phaser.Scene {
             hasDepositable = true;
 
             const adjY = bpY - scrollOff;
-            bpY += 20;
-            if (adjY > visBot) { this._lastContentOverflow = true; continue; }
+            bpY += 22;
+            if (adjY > visBot) { continue; }
             if (adjY < visTop) continue;
 
             const col = def.color || 0xaaaaaa;
@@ -234,11 +288,11 @@ class SmelteryScene extends Phaser.Scene {
             const stashDepName = (def.type === 'mineral' && typeof getMineralDisplayName !== 'undefined')
                 ? getMineralDisplayName(def, hero) : def.name;
             this._d(this.add.text(leftX + 4, adjY, `${stashDepName} ×${entry.count}`, {
-                fontSize: '12px', color: hexCol, fontFamily: 'monospace'
+                fontSize: '14px', color: hexCol, fontFamily: 'monospace'
             }));
 
             const btn = this._d(this.add.text(leftX + colW - 10, adjY, '→', {
-                fontSize: '12px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
+                fontSize: '16px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
             }).setOrigin(1, 0).setInteractive({ useHandCursor: true }));
             const slotIdx = i;
             btn.on('pointerover', () => btn.setColor('#ffaa44'));
@@ -249,7 +303,7 @@ class SmelteryScene extends Phaser.Scene {
             const adjY = y - scrollOff;
             if (adjY >= visTop && adjY <= visBot) {
                 this._d(this.add.text(leftX + 4, adjY, 'Ingen mineraler/brensel', {
-                    fontSize: '13px', color: '#444433', fontFamily: 'monospace'
+                    fontSize: '14px', color: '#444433', fontFamily: 'monospace'
                 }));
             }
         }
@@ -259,27 +313,28 @@ class SmelteryScene extends Phaser.Scene {
         const hdrRightY = sBaseY - scrollOff;
         if (hdrRightY >= visTop && hdrRightY <= visBot) {
             this._d(this.add.text(rightX, hdrRightY, 'LAGER → Ryggsekk', {
-                fontSize: '12px', color: '#887766', fontFamily: 'monospace', fontStyle: 'bold'
+                fontSize: '14px', color: '#887766', fontFamily: 'monospace', fontStyle: 'bold'
             }));
         }
-        sBaseY += 16;
+        sBaseY += 20;
 
+        let sY = sBaseY;
         if (hero.campStash.length === 0) {
             const adjY = sBaseY - scrollOff;
             if (adjY >= visTop && adjY <= visBot) {
                 this._d(this.add.text(rightX + 4, adjY, 'Lageret er tomt.', {
-                    fontSize: '13px', color: '#444433', fontFamily: 'monospace'
+                    fontSize: '14px', color: '#444433', fontFamily: 'monospace'
                 }));
             }
+            sY = sBaseY + 22;
         } else {
-            let sY = sBaseY;
             for (let si = 0; si < hero.campStash.length; si++) {
                 const stashEntry = hero.campStash[si];
                 if (!stashEntry || stashEntry.count <= 0) continue;
 
                 const adjY = sY - scrollOff;
-                sY += 20;
-                if (adjY > visBot) { this._lastContentOverflow = true; continue; }
+                sY += 22;
+                if (adjY > visBot) { continue; }
                 if (adjY < visTop) continue;
 
                 const def = this._getStashItemDef(stashEntry.id);
@@ -290,11 +345,11 @@ class SmelteryScene extends Phaser.Scene {
                 const hexCol = '#' + col.toString(16).padStart(6, '0');
 
                 this._d(this.add.text(rightX + 4, adjY, `${stName} ×${stashEntry.count}`, {
-                    fontSize: '12px', color: hexCol, fontFamily: 'monospace'
+                    fontSize: '14px', color: hexCol, fontFamily: 'monospace'
                 }));
 
                 const btn = this._d(this.add.text(rightX + colW - 10, adjY, '←', {
-                    fontSize: '12px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
+                    fontSize: '16px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
                 }).setOrigin(1, 0).setInteractive({ useHandCursor: true }));
                 const idx = si;
                 btn.on('pointerover', () => btn.setColor('#ffaa44'));
@@ -303,10 +358,13 @@ class SmelteryScene extends Phaser.Scene {
             }
         }
 
+        // Content end = bottom of the longer column
+        this._contentEndY = Math.max(bpY, sY);
+
         // Stash capacity label
         const totalStashed = hero.campStash.reduce((s, e) => s + (e.count || 0), 0);
         this._d(this.add.text(cx, this.py + this.panelH - 24, `Lagret: ${totalStashed} gjenstander  |  Klikk → for å lagre, ← for å hente`, {
-            fontSize: '13px', color: '#665544', fontFamily: 'monospace'
+            fontSize: '14px', color: '#665544', fontFamily: 'monospace'
         }).setOrigin(0.5));
     }
 
@@ -369,27 +427,26 @@ class SmelteryScene extends Phaser.Scene {
         const scrollOff = this._scrollOffsets.smelt || 0;
         const visTop = this.contentY - 10;
         const visBot = this.py + this.panelH - 40;
-        this._lastContentOverflow = false;
 
         this._d(this.add.text(cx, y, 'Velg et mineral å smelte (ryggsekk + lager):', {
-            fontSize: '12px', color: '#887766', fontFamily: 'monospace'
+            fontSize: '14px', color: '#887766', fontFamily: 'monospace'
         }).setOrigin(0.5));
-        y += 18;
+        y += 22;
 
         // Element filter indicator
         if (this._elementFilter) {
             const filterElem = typeof ELEMENTS !== 'undefined' ? ELEMENTS[this._elementFilter] : null;
             const fCol = filterElem ? '#' + filterElem.color.toString(16).padStart(6, '0') : '#ff7722';
             this._d(this.add.text(this.px + 20, y, `Filter: ${this._elementFilter}`, {
-                fontSize: '12px', color: fCol, fontFamily: 'monospace', fontStyle: 'bold'
+                fontSize: '14px', color: fCol, fontFamily: 'monospace', fontStyle: 'bold'
             }));
-            const clearBtn = this._d(this.add.text(this.px + 100, y, '✕ Fjern filter', {
-                fontSize: '12px', color: '#886644', fontFamily: 'monospace'
+            const clearBtn = this._d(this.add.text(this.px + 110, y, '✕ Fjern filter', {
+                fontSize: '14px', color: '#886644', fontFamily: 'monospace'
             }).setInteractive({ useHandCursor: true }));
             clearBtn.on('pointerover', () => clearBtn.setColor('#ffaa44'));
             clearBtn.on('pointerout', () => clearBtn.setColor('#886644'));
             clearBtn.on('pointerdown', () => { this._elementFilter = null; this._scrollOffsets.smelt = 0; this._refresh(); });
-            y += 16;
+            y += 20;
         }
 
         // List minerals in backpack
@@ -423,22 +480,24 @@ class SmelteryScene extends Phaser.Scene {
                 ? `Ingen mineraler gir ${this._elementFilter}.`
                 : 'Ingen mineraler i ryggsekk eller lager.';
             this._d(this.add.text(cx, y + 30, msg, {
-                fontSize: '13px', color: '#444433', fontFamily: 'monospace'
+                fontSize: '14px', color: '#444433', fontFamily: 'monospace'
             }).setOrigin(0.5));
             // Still show element inventory
-            this._drawElementInventory(this.px + 20, y + 60, Math.min(500, this.panelW - 40));
+            this._drawElementInventory(this.px + 20, y + 60, Math.min(560, this.panelW - 40));
+            this._contentEndY = y + 60 + 120;
             return;
         }
 
         const fuel = this.smelter.calculateFuelEnergy(hero);
-        const colW = Math.min(500, this.panelW - 40);
+        const colW = Math.min(560, this.panelW - 40);
         const startX = this.px + 20;
+        const rowStep = 54;
 
         filtered.forEach((m, idx) => {
-            const baseY = y + idx * 52;
+            const baseY = y + idx * rowStep;
             const my = baseY - scrollOff;
-            if (my > visBot) { this._lastContentOverflow = true; return; }
-            if (my < visTop - 46) return;
+            if (my > visBot) { return; }
+            if (my < visTop - 50) return;
             const check = this.smelter.canSmelt(m.def, fuel, hero);
             const col = check.canSmelt ? 0xff7722 : 0x443322;
             const hexCol = '#' + col.toString(16).padStart(6, '0');
@@ -446,9 +505,9 @@ class SmelteryScene extends Phaser.Scene {
             // Background
             const bg = this._d(this.add.graphics());
             bg.fillStyle(col, 0.08);
-            bg.fillRoundedRect(startX, my, colW, 46, 4);
+            bg.fillRoundedRect(startX, my, colW, 48, 4);
             bg.lineStyle(1, col, 0.3);
-            bg.strokeRoundedRect(startX, my, colW, 46, 4);
+            bg.strokeRoundedRect(startX, my, colW, 48, 4);
 
             // Source label
             const srcLabel = m.source === 'stash' ? ' [lager]' : '';
@@ -459,40 +518,40 @@ class SmelteryScene extends Phaser.Scene {
                 ? getMineralDisplayName(m.def, hero) : m.def.name;
             const mName = rawName.length > 28 ? rawName.slice(0, 27) + '…' : rawName;
             this._d(this.add.text(startX + 8, my + 6, `${mName} (×${m.count})${srcLabel}`, {
-                fontSize: '13px', color: hexCol, fontFamily: 'monospace', fontStyle: 'bold'
+                fontSize: '15px', color: hexCol, fontFamily: 'monospace', fontStyle: 'bold'
             }));
 
             // Yield preview – hide element details if not identified
             // Highlight the filtered element
             if (canId) {
                 let yieldX = startX + 8;
-                this._d(this.add.text(yieldX, my + 22, '→ ', {
-                    fontSize: '13px', color: '#776655', fontFamily: 'monospace'
+                this._d(this.add.text(yieldX, my + 26, '→ ', {
+                    fontSize: '14px', color: '#776655', fontFamily: 'monospace'
                 }));
-                yieldX += 20;
+                yieldX += 22;
                 m.def.yields.forEach((yld, yi) => {
                     const isMatch = this._elementFilter && yld.symbol === this._elementFilter;
                     const yCol = isMatch ? '#ffcc44' : '#776655';
                     const txt = `${yld.symbol}×${yld.amount}${yi < m.def.yields.length - 1 ? ', ' : ''}`;
-                    const t = this._d(this.add.text(yieldX, my + 22, txt, {
-                        fontSize: '13px', color: yCol, fontFamily: 'monospace',
+                    const t = this._d(this.add.text(yieldX, my + 26, txt, {
+                        fontSize: '14px', color: yCol, fontFamily: 'monospace',
                         fontStyle: isMatch ? 'bold' : 'normal'
                     }));
                     yieldX += t.width;
                 });
-                this._d(this.add.text(yieldX + 4, my + 22, `|  Energi: ${check.energyCost}`, {
-                    fontSize: '13px', color: '#776655', fontFamily: 'monospace'
+                this._d(this.add.text(yieldX + 4, my + 26, `|  Energi: ${check.energyCost}`, {
+                    fontSize: '14px', color: '#776655', fontFamily: 'monospace'
                 }));
             } else {
-                this._d(this.add.text(startX + 8, my + 22, `→ ???  |  Energi: ${check.energyCost}`, {
-                    fontSize: '13px', color: '#776655', fontFamily: 'monospace'
+                this._d(this.add.text(startX + 8, my + 26, `→ ???  |  Energi: ${check.energyCost}`, {
+                    fontSize: '14px', color: '#776655', fontFamily: 'monospace'
                 }));
             }
 
             // Smelt button
             if (check.canSmelt) {
-                const btn = this._d(this.add.text(startX + colW - 60, my + 12, '[ Smelt ]', {
-                    fontSize: '13px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
+                const btn = this._d(this.add.text(startX + colW - 70, my + 14, '[ Smelt ]', {
+                    fontSize: '15px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
                 }).setInteractive({ useHandCursor: true }));
                 btn.on('pointerover', () => btn.setColor('#ffaa44'));
                 btn.on('pointerout', () => btn.setColor('#ff7722'));
@@ -502,18 +561,19 @@ class SmelteryScene extends Phaser.Scene {
                     btn.on('pointerdown', () => this._doSmelt(m.slot, m.def));
                 }
             } else {
-                this._d(this.add.text(startX + colW - 70, my + 12, 'Lite brensel', {
-                    fontSize: '13px', color: '#443322', fontFamily: 'monospace'
+                this._d(this.add.text(startX + colW - 80, my + 14, 'Lite brensel', {
+                    fontSize: '14px', color: '#443322', fontFamily: 'monospace'
                 }));
             }
         });
 
         // Element inventory display
-        const elemBaseY = y + filtered.length * 52 + 10;
+        const elemBaseY = y + filtered.length * rowStep + 10;
         const elemY = elemBaseY - scrollOff;
         if (elemY <= visBot) {
             this._drawElementInventory(startX, Math.max(elemY, visTop), colW);
         }
+        this._contentEndY = elemBaseY + 120;
     }
 
     _doSmelt(slotIndex, mineralDef) {
@@ -569,44 +629,45 @@ class SmelteryScene extends Phaser.Scene {
         const scrollOff = this._scrollOffsets.alloy || 0;
         const visTop = this.contentY - 10;
         const visBot = this.py + this.panelH - 40;
-        this._lastContentOverflow = false;
 
         this._d(this.add.text(cx, y, 'Kombiner grunnstoffer til legeringer:', {
-            fontSize: '12px', color: '#887766', fontFamily: 'monospace'
+            fontSize: '14px', color: '#887766', fontFamily: 'monospace'
         }).setOrigin(0.5));
-        y += 18;
+        y += 22;
 
         const fuel = this.smelter.calculateFuelEnergy(hero);
         const alloys = this.smelter.getAvailableAlloys(hero, fuel);
-        const colW = Math.min(500, this.panelW - 40);
+        const colW = Math.min(560, this.panelW - 40);
         const startX = this.px + 20;
+        const rowStep = 60;
 
         if (alloys.length === 0) {
             this._d(this.add.text(cx, y + 30, 'Ingen legeringer tilgjengelig.', {
-                fontSize: '13px', color: '#444433', fontFamily: 'monospace'
+                fontSize: '14px', color: '#444433', fontFamily: 'monospace'
             }).setOrigin(0.5));
             this._drawElementInventory(startX, y + 60, colW);
+            this._contentEndY = y + 60 + 120;
             return;
         }
 
         alloys.forEach((entry, idx) => {
-            const baseY = y + idx * 56;
+            const baseY = y + idx * rowStep;
             const ay = baseY - scrollOff;
-            if (ay > visBot) { this._lastContentOverflow = true; return; }
-            if (ay < visTop - 50) return;
+            if (ay > visBot) { return; }
+            if (ay < visTop - 54) return;
             const a = entry.alloy;
             const col = entry.canCraft ? 0xff7722 : 0x443322;
             const hexCol = '#' + col.toString(16).padStart(6, '0');
 
             const bg = this._d(this.add.graphics());
             bg.fillStyle(col, 0.08);
-            bg.fillRoundedRect(startX, ay, colW, 50, 4);
+            bg.fillRoundedRect(startX, ay, colW, 54, 4);
             bg.lineStyle(1, col, 0.3);
-            bg.strokeRoundedRect(startX, ay, colW, 50, 4);
+            bg.strokeRoundedRect(startX, ay, colW, 54, 4);
 
             // Alloy name + formula
             this._d(this.add.text(startX + 8, ay + 6, `${a.name} (${a.formula})`, {
-                fontSize: '13px', color: hexCol, fontFamily: 'monospace', fontStyle: 'bold'
+                fontSize: '15px', color: hexCol, fontFamily: 'monospace', fontStyle: 'bold'
             }));
 
             // Recipe
@@ -615,20 +676,20 @@ class SmelteryScene extends Phaser.Scene {
                 const ok = have >= r.amount;
                 return `${r.symbol}: ${have}/${r.amount}${ok ? '' : '!'}`;
             }).join('  ');
-            this._d(this.add.text(startX + 8, ay + 22, recipeStr, {
-                fontSize: '13px', color: '#776655', fontFamily: 'monospace'
+            this._d(this.add.text(startX + 8, ay + 24, recipeStr, {
+                fontSize: '14px', color: '#776655', fontFamily: 'monospace'
             }));
 
             // Stats preview
             const stats = a.statBonuses;
             const statStr = Object.entries(stats).map(([k, v]) => `+${v} ${k}`).join(', ');
-            this._d(this.add.text(startX + 8, ay + 34, `Stats: ${statStr}  |  Energi: ${entry.energyCost}`, {
-                fontSize: '12px', color: '#665544', fontFamily: 'monospace'
+            this._d(this.add.text(startX + 8, ay + 38, `Stats: ${statStr}  |  Energi: ${entry.energyCost}`, {
+                fontSize: '13px', color: '#665544', fontFamily: 'monospace'
             }));
 
             if (entry.canCraft) {
-                const btn = this._d(this.add.text(startX + colW - 50, ay + 14, '[ Lag ]', {
-                    fontSize: '13px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
+                const btn = this._d(this.add.text(startX + colW - 60, ay + 16, '[ Lag ]', {
+                    fontSize: '15px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
                 }).setInteractive({ useHandCursor: true }));
                 btn.on('pointerover', () => btn.setColor('#ffaa44'));
                 btn.on('pointerout', () => btn.setColor('#ff7722'));
@@ -637,11 +698,12 @@ class SmelteryScene extends Phaser.Scene {
         });
 
         // Element inventory
-        const elemBaseY = y + alloys.length * 56 + 10;
+        const elemBaseY = y + alloys.length * rowStep + 10;
         const elemY = elemBaseY - scrollOff;
         if (elemY <= visBot) {
             this._drawElementInventory(startX, Math.max(elemY, visTop), colW);
         }
+        this._contentEndY = elemBaseY + 120;
     }
 
     _doCraftAlloy(alloyId) {
@@ -670,23 +732,23 @@ class SmelteryScene extends Phaser.Scene {
         const scrollOff = this._scrollOffsets.forge || 0;
         const visTop = this.contentY - 10;
         const visBot = this.py + this.panelH - 40;
-        this._lastContentOverflow = false;
 
         this._d(this.add.text(cx, y, 'Smi utstyr fra legeringer:', {
-            fontSize: '12px', color: '#887766', fontFamily: 'monospace'
+            fontSize: '14px', color: '#887766', fontFamily: 'monospace'
         }).setOrigin(0.5));
-        y += 18;
+        y += 22;
 
         // List available alloys the player has
         const alloyInv = hero.alloyInventory || {};
         const available = Object.entries(alloyInv).filter(([, count]) => count > 0);
-        const colW = Math.min(500, this.panelW - 40);
+        const colW = Math.min(560, this.panelW - 40);
         const startX = this.px + 20;
 
         if (available.length === 0) {
-            this._d(this.add.text(cx, y + 30, 'Ingen legeringer å smi med.\nLag legeringer i "Lag legering"-fanen først.', {
-                fontSize: '12px', color: '#444433', fontFamily: 'monospace', align: 'center'
+            this._d(this.add.text(cx, y + 30, 'Ingen legeringer å smi med.\nLag legeringer i "Legering"-fanen først.', {
+                fontSize: '14px', color: '#444433', fontFamily: 'monospace', align: 'center'
             }).setOrigin(0.5));
+            this._contentEndY = y + 80;
             return;
         }
 
@@ -698,41 +760,42 @@ class SmelteryScene extends Phaser.Scene {
             const adjHdr = rowY - scrollOff;
             if (adjHdr >= visTop && adjHdr <= visBot) {
                 this._d(this.add.text(startX, adjHdr, `${alloy.name} (×${count}):`, {
-                    fontSize: '13px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
+                    fontSize: '15px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
                 }));
             }
-            rowY += 18;
+            rowY += 22;
 
             const equipment = this.smelter.getForgeableEquipment(alloyId);
             equipment.forEach(equip => {
                 const adjY = rowY - scrollOff;
-                rowY += 40;
-                if (adjY > visBot) { this._lastContentOverflow = true; return; }
-                if (adjY < visTop - 36) return;
+                rowY += 44;
+                if (adjY > visBot) { return; }
+                if (adjY < visTop - 40) return;
 
                 const hexCol = '#' + (equip.color || 0xaabbcc).toString(16).padStart(6, '0');
 
                 const bg = this._d(this.add.graphics());
                 bg.fillStyle(equip.color || 0xaabbcc, 0.08);
-                bg.fillRoundedRect(startX + 10, adjY, colW - 20, 36, 3);
+                bg.fillRoundedRect(startX + 10, adjY, colW - 20, 40, 3);
 
                 this._d(this.add.text(startX + 18, adjY + 6, `${equip.name} (${equip.type === 'weapon' ? 'Våpen' : 'Rustning'})`, {
-                    fontSize: '12px', color: hexCol, fontFamily: 'monospace'
+                    fontSize: '14px', color: hexCol, fontFamily: 'monospace'
                 }));
-                this._d(this.add.text(startX + 18, adjY + 20, equip.desc, {
-                    fontSize: '11px', color: '#776655', fontFamily: 'monospace',
-                    wordWrap: { width: colW - 100 }
+                this._d(this.add.text(startX + 18, adjY + 22, equip.desc, {
+                    fontSize: '13px', color: '#776655', fontFamily: 'monospace',
+                    wordWrap: { width: colW - 120 }
                 }));
 
-                const btn = this._d(this.add.text(startX + colW - 60, adjY + 10, '[ Smi ]', {
-                    fontSize: '12px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
+                const btn = this._d(this.add.text(startX + colW - 70, adjY + 12, '[ Smi ]', {
+                    fontSize: '14px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
                 }).setInteractive({ useHandCursor: true }));
                 btn.on('pointerover', () => btn.setColor('#ffaa44'));
                 btn.on('pointerout', () => btn.setColor('#ff7722'));
                 btn.on('pointerdown', () => this._doForge(alloyId, equip.id));
             });
-            rowY += 6;
+            rowY += 8;
         }
+        this._contentEndY = rowY;
     }
 
     _doForge(alloyId, equipmentId) {
@@ -782,9 +845,9 @@ class SmelteryScene extends Phaser.Scene {
         if (entries.length === 0) return;
 
         this._d(this.add.text(startX, y, 'Lagrede grunnstoffer (klikk for å filtrere):', {
-            fontSize: '12px', color: '#665544', fontFamily: 'monospace'
+            fontSize: '14px', color: '#665544', fontFamily: 'monospace'
         }));
-        y += 16;
+        y += 20;
 
         const sources = this._getElementMineralSources();
 
@@ -797,7 +860,7 @@ class SmelteryScene extends Phaser.Scene {
             const isActive = this._elementFilter === symbol;
 
             const badge = this._d(this.add.text(bx, by, `${symbol}:${count}`, {
-                fontSize: '13px', color: isActive ? '#ffffff' : hexCol, fontFamily: 'monospace',
+                fontSize: '14px', color: isActive ? '#ffffff' : hexCol, fontFamily: 'monospace',
                 backgroundColor: isActive ? '#442200' : '#0a0818',
                 padding: { x: 4, y: 2 }
             }).setInteractive({ useHandCursor: true }));
@@ -808,8 +871,8 @@ class SmelteryScene extends Phaser.Scene {
                 // Show mineral sources as tooltip-style text
                 const srcList = sources[sym];
                 if (srcList && srcList.length > 0) {
-                    this._tooltipText = this._d(this.add.text(startX, by + 22, `${sym} ← ${srcList.join(', ')}`, {
-                        fontSize: '11px', color: '#998877', fontFamily: 'monospace',
+                    this._tooltipText = this._d(this.add.text(startX, by + 24, `${sym} ← ${srcList.join(', ')}`, {
+                        fontSize: '12px', color: '#998877', fontFamily: 'monospace',
                         backgroundColor: '#0a0608', padding: { x: 4, y: 2 }
                     }));
                 }
@@ -832,7 +895,7 @@ class SmelteryScene extends Phaser.Scene {
             bx += badge.width + 6;
             if (bx > startX + colW - 50) {
                 bx = startX;
-                by += 22;
+                by += 24;
             }
         }
     }


### PR DESCRIPTION
SmelteryScene and ChemLabScene were cramped: ~97% of canvas with 12-14px
fonts, and no touch scrolling. Shrink SmelteryScene to a centered panel
(max 1080x680), raise ChemLabScene cap to 760x600, bump title/tab/body
fonts to 14-18px, and add pointer-drag scrolling that coexists with the
wheel handler. A small 8px drag threshold lets short clicks still trigger
interactive buttons. Scroll offsets are now clamped to content height
and a thin scrollbar thumb shows current position.

Updates CHANGELOG (v0.39) and GDD accordingly.