### PR TITLE
Camp/Chemistry content + bomb scaling + skill rebalance (v0.40)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  syntax:
+    name: JS syntax check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Check all JS files parse
+        run: |
+          FAILED=0
+          while IFS= read -r -d '' f; do
+            if ! node --check "$f"; then
+              echo "::error file=$f::syntax error"
+              FAILED=1
+            fi
+          done < <(find src tests -name '*.js' -print0)
+          exit $FAILED
+
+  tests:
+    name: Browser tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install Playwright (no package.json needed)
+        run: |
+          npm install --no-save --no-package-lock playwright
+          npx playwright install chromium --with-deps
+      - name: Run test runner headlessly
+        run: node tests/ci-runner.js

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ---
 
+## v0.40 – 2026-04-15
+
+### Nye funksjoner
+- **Utvidet element-bruk (#99):** 2 nye mineraler (molybdenitt, barytt), 5 nye legeringer (manganstål, molybdenstål, wolframkarbid, tantalplate, fosforkrystall) og 6 nye smidde utstyrsstykker. 8 nye kjemikalier: sinkklorid-antiseptikum, bor-signalbombe, barium-fyrverkeri, thermittladning (25 skade, ignorer 4 Def), neodym-magnetbombe (22 skade, radius 5), wolfram-styrkedrikk, lantan-livselixir (+10 HP), plasmakjerne (30 skade med plasmakjede). Tidligere ubrukte grunnstoffer som Mn, W, Ta, Mo, Ba, Ce, La, Nd, Nd, B og Zn har nå praktisk nytte
+- **Bombeskade skalerer bedre i høyere verdener (#100):** Bombers verdensskala er økt fra +40% per verden til +60% per verden, pluss et flatt +2 skade per verden. Bomberadius får +1 fra verden 5 og +2 fra verden 8. Helbredelsespotions skalerer nå som 25% av maks HP fra verden 4+ så de forblir relevante. Syrebrenning varer +1 runde per 4 verdener
+- **Ny bombemekanikk: Def-penetrering og plasmakjede (#100):** Thermittladning ignorerer 4 Forsvar ved treff. Plasmakjerne kjeder til 2 nærmeste fiender utenfor radius for 50% skade. Motoren støtter disse via `defPierce`- og `chain`-felter i molekyldefinisjoner
+- **Skill-omarbeiding: Geolog, Metallurg, Kjemiker (#101):** Alle tre sti-er har fått økte tall og synlige effekter:
+  - **Geolog T2 Effektiv utvinning:** 25%/50%/75% sjanse per stack for **dobbelt** utbytte (tidligere +25% flat). Popup-tekst ved utløsning
+  - **Geolog T3 Mesterprospektør:** Garantert mineral oppgraderes til T5+ fra verden 5
+  - **NY Geolog T4 Geode-splitter:** Hvert 10. mineral smeltet gir en gratis ekstra grunnstoff-enhet
+  - **Metallurg T1 Rask smelting (maks stack):** Låser opp batch-smelting (×5) på minerallister
+  - **Metallurg T2 Legeringsmester:** +25% legerings-stats per stack (opp fra +15%)
+  - **Metallurg T3 Mestersmie:** +50% stats på smidd utstyr (opp fra +30%)
+  - **NY Metallurg T4 Reforge:** Ruller stats på utstyrt våpen/rustning på nytt for 5 energi i smie-fanen
+  - **Kjemiker T1 Potente potions:** +50% varighet *og* +25% styrke per stack (tidligere bare varighet)
+  - **Kjemiker T2 Syremestring:** +40% skade (opp fra +30%) og syrebomber reduserer fiendes Forsvar med 2
+  - **Kjemiker T3 Eksplosjonsgenial:** +50% skade, +1 radius *og* 60% «Dobbel brygging» på bombekrafting
+  - **NY Kjemiker T4 Volatil mestring:** Bomber kjeder til 1 ekstra fiende ved 50% skade
+- **Ny synergi: Transmutasjon (#101):** 3-sti-synergi (Geolog + Metallurg + Kjemiker). Låser opp konvertering av 5 av et grunnstoff → 1 av nabo (atomnummer ±1) i kjemilab via ↔-knapp på grunnstoff-merker. Hjelper med å bruke orphaned rare earths
+
+### Tekniske endringer
+- ChemistrySystem: Separat `bombScale` vs `potionScale` med flat bombgulv (`+world*2`); ny `transmute()`-funksjon; støtte for `defPierce` og `chain` på bombedefinisjoner; syrebomber kan nå redusere fiendes Forsvar via `chemAcidDefShred`
+- SmeltingSystem.smelt() returnerer nå `doubled` og `geodeElement` for Geolog-effekter
+- Inventory._apply/_unapply støtter `visionBonus` på utstyr (brukt av nye fosforkrystall-våpen/-skjold)
+- skills.js: 3 nye T4-ferdigheter (Geode-splitter, Reforge, Volatil mestring); ny 3-sti synergy «Transmutasjon»
+- HeroCrafting: 13 nye hero-egenskaper for nye ferdigheter (doubleYieldChance, geodeSplitter, batchSmeltSize, reforgeUnlocked, potionMagnitudeBonus, chemAcidDefShred, chemDoubleBrewChance, chemBombChain, transmutationUnlocked, m.fl.) – alle med serialize/applyStats-støtte
+- SmelteryScene: Nytt `[ ×N ]`-batchknapp på smelt-fanen når maks-stack Rask smelting er nådd; ny Reforge-sekkjon øverst på Smi-fanen når Reforge er låst opp; Geolog-dobbelt-utbytte og Geode-drops vises som floating text
+- ChemLabScene: Transmutasjon-hint + ↔-knapp per grunnstoff-merke når synergien er aktiv; «Dobbel brygging» gir automatisk ekstra bombe i inventoryen
+
+---
+
 ## v0.39 – 2026-04-15
 
 ### Nye funksjoner

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## v0.40 – 2026-04-15
 
 ### Nye funksjoner
-- **Utvidet element-bruk (#99):** 2 nye mineraler (molybdenitt, barytt), 5 nye legeringer (manganstål, molybdenstål, wolframkarbid, tantalplate, fosforkrystall) og 6 nye smidde utstyrsstykker. 8 nye kjemikalier: sinkklorid-antiseptikum, bor-signalbombe, barium-fyrverkeri, thermittladning (25 skade, ignorer 4 Def), neodym-magnetbombe (22 skade, radius 5), wolfram-styrkedrikk, lantan-livselixir (+10 HP), plasmakjerne (30 skade med plasmakjede). Tidligere ubrukte grunnstoffer som Mn, W, Ta, Mo, Ba, Ce, La, Nd, Nd, B og Zn har nå praktisk nytte
+- **Utvidet element-bruk (#99):** 2 nye mineraler (molybdenitt, barytt), **6 nye legeringer** (manganstål, molybdenstål, wolframkarbid, tantalplate, fosforkrystall, **skandiumlegering**) og 8 nye smidde utstyrsstykker (inkludert skandium-rapir og skandium-harnisk – romfartsinspirert lett rustning). 8 nye kjemikalier: sinkklorid-antiseptikum, bor-signalbombe, barium-fyrverkeri, thermittladning (25 skade, ignorer 4 Def), neodym-magnetbombe (22 skade, radius 5), wolfram-styrkedrikk, lantan-livselixir (+10 HP), plasmakjerne (30 skade med plasmakjede). Tidligere ubrukte grunnstoffer som Mn, W, Ta, Mo, Ba, Ce, La, Nd, Nd, B og Zn har nå praktisk nytte
 - **Bombeskade skalerer bedre i høyere verdener (#100):** Bombers verdensskala er økt fra +40% per verden til +60% per verden, pluss et flatt +2 skade per verden. Bomberadius får +1 fra verden 5 og +2 fra verden 8. Helbredelsespotions skalerer nå som 25% av maks HP fra verden 4+ så de forblir relevante. Syrebrenning varer +1 runde per 4 verdener
 - **Ny bombemekanikk: Def-penetrering og plasmakjede (#100):** Thermittladning ignorerer 4 Forsvar ved treff. Plasmakjerne kjeder til 2 nærmeste fiender utenfor radius for 50% skade. Motoren støtter disse via `defPierce`- og `chain`-felter i molekyldefinisjoner
 - **Skill-omarbeiding: Geolog, Metallurg, Kjemiker (#101):** Alle tre sti-er har fått økte tall og synlige effekter:
@@ -23,6 +23,7 @@
 - **Ny synergi: Transmutasjon (#101):** 3-sti-synergi (Geolog + Metallurg + Kjemiker). Låser opp konvertering av 5 av et grunnstoff → 1 av nabo (atomnummer ±1) i kjemilab via ↔-knapp på grunnstoff-merker. Hjelper med å bruke orphaned rare earths
 
 ### Tekniske endringer
+- **CI-oppsett:** Ny `.github/workflows/ci.yml` kjører JS-syntaks-sjekk på alle filer samt nettleser-testsuiten (via headless Chromium + Playwright uten å legge til faste npm-avhengigheter). Ny `tests/ci-runner.js` fyrer opp en lokal statisk server, laster `test-runner.html`, og feiler jobben hvis noen tester feiler eller det er ukjente sidefeil. Noen allerede-ødelagte tester (`MINERAL_DEFS.copper_ore` → `chalcopyrite`, feil `chemistUnlocked`-forventning) er fikset som drive-by
 - ChemistrySystem: Separat `bombScale` vs `potionScale` med flat bombgulv (`+world*2`); ny `transmute()`-funksjon; støtte for `defPierce` og `chain` på bombedefinisjoner; syrebomber kan nå redusere fiendes Forsvar via `chemAcidDefShred`
 - SmeltingSystem.smelt() returnerer nå `doubled` og `geodeElement` for Geolog-effekter
 - Inventory._apply/_unapply støtter `visionBonus` på utstyr (brukt av nye fosforkrystall-våpen/-skjold)

--- a/docs/Elements-mod.md
+++ b/docs/Elements-mod.md
@@ -1,7 +1,9 @@
 # Labyrint Hero – Elements-modifikasjon
-**Versjon:** 0.3 (fase 1–4 fullført, dataset komplett)
-**Sist oppdatert:** 2026-04-13
+**Versjon:** 0.4 (fase 1–4 fullført, orphan-oppryddning v0.40)
+**Sist oppdatert:** 2026-04-15
 **Status:** Fase 1–4 implementert. Fase 5 (Fysikk) utsatt.
+
+**v0.40-oppdatering:** 2 nye mineraler (molybdenitt, barytt) og 5 nye legeringer + 8 nye molekyler gir praktisk bruk for Mn, Mo, W, Ta, Ba, B, Ce, La, Nd, Zn. Bombeskade er separert fra potionskala og skalerer +60% per verden (mot +40% før) med flat bombgulv; radius +1 fra verden 5 og +2 fra verden 8. Geolog/Metallurg/Kjemiker har fått T4-ferdigheter (Geode-splitter, Reforge, Volatil mestring) og en 3-sti-synergi Transmutasjon (5 → 1 nabo på atomnummer). Se CHANGELOG v0.40 for full diff.
 
 ---
 

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,5 +1,5 @@
 # Labyrint Hero – Game Design Document
-**Versjon:** 0.39
+**Versjon:** 0.40
 **Sist oppdatert:** 2026-04-15
 
 ---
@@ -527,9 +527,10 @@ Smelting, legeringer og smiing av utstyr.
 Låses opp ved første besøk i leirplass. **Minst én Metallurg-skill kreves for å bruke smelting, legering og smiing.** Lager-fanen er alltid tilgjengelig.
 | Tier | Skill | Effekt |
 |------|-------|--------|
-| T1 | Rask smelting | -25% energi/smeltetid, +15% sjanse ekstra utbytte per stack (maks 3) |
-| T2 | Legeringsmester | +15% legering-stats, 20% sjanse for dobbel legering per stack (maks 2) |
-| T3 | Mestersmie | +30% stats på smidd utstyr, spesialegenskaper (våpen: +10% krit, rustning: +1 torneskade) (maks 1) |
+| T1 | Rask smelting | -25% energi/smeltetid, +15% sjanse ekstra utbytte per stack (maks 3). Ved maks-stack låses batch-smelting (×5) opp |
+| T2 | Legeringsmester | +25% legering-stats, 20% sjanse for dobbel legering per stack (maks 2) |
+| T3 | Mestersmie | +50% stats på smidd utstyr, spesialegenskaper (våpen: +10% krit, rustning: +1 torneskade) (maks 1) |
+| T4 | Reforge | Ruller stats på utstyrt våpen/rustning på nytt for 5 energi i smie-fanen (maks 1) |
 
 ### Fase 3: Kjemi (v0.25)
 
@@ -543,9 +544,20 @@ Kjemisk syntese av potions, bomber, medisiner og syrer fra rene grunnstoffer.
 Låses opp ved første besøk i kjemisk laboratorium. **Minst én Kjemiker-skill kreves for å lage kjemikalier.**
 | Tier | Skill | Effekt |
 |------|-------|--------|
-| T1 | Potente potions | +50% potion-varighet per stack (maks 3) |
-| T2 | Syremestring | +30% kjemisk bombe-skade per stack (maks 2) |
-| T3 | Eksplosjonsgenial | +50% skade, +1 radius på bomber (maks 1) |
+| T1 | Potente potions | +50% varighet og +25% styrke på potions per stack (maks 3) |
+| T2 | Syremestring | +40% kjemisk bombe-skade per stack, syrebomber reduserer fiende-Def med 2 (maks 2) |
+| T3 | Eksplosjonsgenial | +50% skade, +1 radius, 60% «Dobbel brygging» på bombekrafting (maks 1) |
+| T4 | Volatil mestring | Bomber kjeder til 1 nærliggende fiende ved 50% skade (maks 1) |
+
+**Geolog-skillsti (#7) oppdaterte tier:**
+| Tier | Skill | Effekt |
+|------|-------|--------|
+| T1 | Malmøye | +1 mineral-syn, identifiser mineraler, merker på minikart (maks 3) |
+| T2 | Effektiv utvinning | 25%/50%/75% sjanse for dobbelt utbytte per stack, +1 bonus-element ved smelting (maks 3) |
+| T3 | Mesterprospektør | Garantert T4+ mineral per etasje; T5+ fra verden 5 (maks 1) |
+| T4 | Geode-splitter | Hvert 10. mineral smeltet gir en gratis ekstra grunnstoff-enhet (maks 1) |
+
+**Ny 3-sti-synergi Transmutasjon:** Krever ≥1 skill fra Geolog, Metallurg og Kjemiker. Låser opp konvertering av 5 av et grunnstoff → 1 av nabo (atomnummer ±1) via ↔-knapp på grunnstoff-merker i kjemilab.
 
 ### Fase 4: Verdensekspansjon (v0.26)
 

--- a/src/data/alloys.js
+++ b/src/data/alloys.js
@@ -229,6 +229,21 @@ const ALLOY_DEFS = {
         stackSize: 10,
         desc: 'Lantanide-krystall. Lyser. Gir bærer +1 synsfelt.'
     },
+    scandium_alloy: {
+        id: 'scandium_alloy', name: 'Skandiumlegering', type: 'alloy',
+        formula: 'Sc + Al + Mg', tier: 4,
+        color: 0xbbddcc,
+        recipe: [
+            { symbol: 'Sc', amount: 1 },
+            { symbol: 'Al', amount: 2 },
+            { symbol: 'Mg', amount: 1 }
+        ],
+        energyCost: 6,
+        smeltingTime: 5,
+        statBonuses: { attack: 3, defense: 3, hearts: 2 },
+        stackSize: 10,
+        desc: 'Romfartslegering. Ekstremt lett og stiv – +2 HP per del.'
+    },
 };
 
 // ── Alloy-forged equipment templates ─────────────────────────────────────────
@@ -256,6 +271,8 @@ const ALLOY_EQUIPMENT = {
     tantalum_cuirass: { id: 'tantalum_cuirass', name: 'Tantalpansring',      type: 'armor',  alloyId: 'tantalum_plate',   color: 0x889988, def: 6, hearts: 2, desc: '+6 DEF, +2 HP (tantal)' },
     phosphor_blade:   { id: 'phosphor_blade',   name: 'Fosfor-klinge',       type: 'weapon', alloyId: 'phosphor_crystal', color: 0xddffcc, atk: 6, def: 2, visionBonus: 1, desc: '+6 ATK, +2 DEF, +1 syn (fosfor)' },
     phosphor_shield:  { id: 'phosphor_shield',  name: 'Fosfor-skjold',       type: 'armor',  alloyId: 'phosphor_crystal', color: 0xddffcc, def: 5, hearts: 2, visionBonus: 1, desc: '+5 DEF, +2 HP, +1 syn (fosfor)' },
+    scandium_rapier:  { id: 'scandium_rapier',  name: 'Skandium-rapir',      type: 'weapon', alloyId: 'scandium_alloy',   color: 0xbbddcc, atk: 6, hearts: 1, desc: '+6 ATK, +1 HP (skandium)' },
+    scandium_harness: { id: 'scandium_harness', name: 'Skandium-harnisk',    type: 'armor',  alloyId: 'scandium_alloy',   color: 0xbbddcc, def: 5, hearts: 3, desc: '+5 DEF, +3 HP (lettrustning)' },
 };
 
 // ── Alloy tier colors (for UI) ──────────────────────────────────────────────

--- a/src/data/alloys.js
+++ b/src/data/alloys.js
@@ -155,6 +155,80 @@ const ALLOY_DEFS = {
         stackSize: 10,
         desc: 'Hardeste legering. Legendarisk.'
     },
+    // ── New alloys (v0.40): expanded element usage ────────────────────────────
+    manganese_steel: {
+        id: 'manganese_steel', name: 'Manganstål', type: 'alloy',
+        formula: 'Fe + Mn + C', tier: 3,
+        color: 0x9988aa,
+        recipe: [
+            { symbol: 'Fe', amount: 3 },
+            { symbol: 'Mn', amount: 1 },
+            { symbol: 'C', amount: 1 }
+        ],
+        energyCost: 5,
+        smeltingTime: 5,
+        statBonuses: { attack: 4, defense: 3 },
+        stackSize: 10,
+        desc: 'Manganherdet stål. Tåler slag og har +20% holdbarhet.'
+    },
+    moly_steel: {
+        id: 'moly_steel', name: 'Molybdenstål', type: 'alloy',
+        formula: 'Fe + Mo + C', tier: 4,
+        color: 0x8899aa,
+        recipe: [
+            { symbol: 'Fe', amount: 2 },
+            { symbol: 'Mo', amount: 1 },
+            { symbol: 'C', amount: 1 }
+        ],
+        energyCost: 6,
+        smeltingTime: 6,
+        statBonuses: { attack: 4, defense: 2 },
+        stackSize: 10,
+        desc: 'Superlegering. Høy slagstyrke.'
+    },
+    tungsten_carbide: {
+        id: 'tungsten_carbide', name: 'Wolframkarbid', type: 'alloy',
+        formula: 'W + C', tier: 4,
+        color: 0x556677,
+        recipe: [
+            { symbol: 'W', amount: 2 },
+            { symbol: 'C', amount: 1 }
+        ],
+        energyCost: 7,
+        smeltingTime: 7,
+        statBonuses: { attack: 6 },
+        stackSize: 10,
+        desc: 'Ekstremt hardt. Perfekt til våpeneggene.'
+    },
+    tantalum_plate: {
+        id: 'tantalum_plate', name: 'Tantalplate', type: 'alloy',
+        formula: 'Ta + Fe', tier: 4,
+        color: 0x889988,
+        recipe: [
+            { symbol: 'Ta', amount: 2 },
+            { symbol: 'Fe', amount: 1 }
+        ],
+        energyCost: 6,
+        smeltingTime: 6,
+        statBonuses: { defense: 4, hearts: 1 },
+        stackSize: 10,
+        desc: 'Korrosjonsbestandig. Brukes i rustning med ekstra HP.'
+    },
+    phosphor_crystal: {
+        id: 'phosphor_crystal', name: 'Fosforkrystall', type: 'alloy',
+        formula: 'Ce + La + Nd', tier: 5,
+        color: 0xddffcc,
+        recipe: [
+            { symbol: 'Ce', amount: 1 },
+            { symbol: 'La', amount: 1 },
+            { symbol: 'Nd', amount: 1 }
+        ],
+        energyCost: 7,
+        smeltingTime: 6,
+        statBonuses: { attack: 3, defense: 3, hearts: 1, vision: 1 },
+        stackSize: 10,
+        desc: 'Lantanide-krystall. Lyser. Gir bærer +1 synsfelt.'
+    },
 };
 
 // ── Alloy-forged equipment templates ─────────────────────────────────────────
@@ -175,6 +249,13 @@ const ALLOY_EQUIPMENT = {
     dural_vest:        { id: 'dural_vest',        name: 'Duralvest',         type: 'armor', alloyId: 'duraluminium',     color: 0xbbccdd, def: 4, hearts: 2, desc: '+4 DEF, +2 HP (lett)' },
     titanium_plate:    { id: 'titanium_plate',    name: 'Titanrustning',     type: 'armor', alloyId: 'titanium_alloy',   color: 0x99aacc, def: 7, hearts: 2, desc: '+7 DEF, +2 HP (titan)' },
     pt_ir_armor:       { id: 'pt_ir_armor',       name: 'Pt-Ir rustning',    type: 'armor', alloyId: 'platinum_iridium', color: 0xeeeedd, def: 8, hearts: 3, desc: '+8 DEF, +3 HP (Pt-Ir)' },
+    // ── New alloy equipment (v0.40) ─────────────────────────────────────────
+    manganese_sword:  { id: 'manganese_sword',  name: 'Manganstål-sverd',   type: 'weapon', alloyId: 'manganese_steel',  color: 0x9988aa, atk: 5, def: 1, desc: '+5 ATK, +1 DEF (manganstål)' },
+    tungsten_axe:     { id: 'tungsten_axe',     name: 'Wolframøks',          type: 'weapon', alloyId: 'tungsten_carbide', color: 0x556677, atk: 8, desc: '+8 ATK (wolframkarbid)' },
+    moly_pike:        { id: 'moly_pike',        name: 'Molybden-lanse',      type: 'weapon', alloyId: 'moly_steel',       color: 0x8899aa, atk: 7, desc: '+7 ATK (molybden)' },
+    tantalum_cuirass: { id: 'tantalum_cuirass', name: 'Tantalpansring',      type: 'armor',  alloyId: 'tantalum_plate',   color: 0x889988, def: 6, hearts: 2, desc: '+6 DEF, +2 HP (tantal)' },
+    phosphor_blade:   { id: 'phosphor_blade',   name: 'Fosfor-klinge',       type: 'weapon', alloyId: 'phosphor_crystal', color: 0xddffcc, atk: 6, def: 2, visionBonus: 1, desc: '+6 ATK, +2 DEF, +1 syn (fosfor)' },
+    phosphor_shield:  { id: 'phosphor_shield',  name: 'Fosfor-skjold',       type: 'armor',  alloyId: 'phosphor_crystal', color: 0xddffcc, def: 5, hearts: 2, visionBonus: 1, desc: '+5 DEF, +2 HP, +1 syn (fosfor)' },
 };
 
 // ── Alloy tier colors (for UI) ──────────────────────────────────────────────

--- a/src/data/minerals.js
+++ b/src/data/minerals.js
@@ -267,6 +267,20 @@ const MINERAL_DEFS = {
         energyCost: 5, smeltingTime: 8, stackSize: 10,
         desc: 'Sort og tung. Radioaktivt! Urankilde.'
     },
+    molybdenite: {
+        id: 'molybdenite', name: 'Molybdenitt', type: 'mineral', subtype: 'ore',
+        formula: 'MoS\u2082', tier: 4, color: 0x667788,
+        yields: [{ symbol: 'Mo', amount: 2, chance: 1.0 }, { symbol: 'S', amount: 1, chance: 0.6 }],
+        energyCost: 4, smeltingTime: 5, stackSize: 10,
+        desc: 'Sølvgrå, flisete krystaller. Molybdenkilde.'
+    },
+    barite: {
+        id: 'barite', name: 'Barytt', type: 'mineral', subtype: 'ore',
+        formula: 'BaSO\u2084', tier: 3, color: 0xccbb99,
+        yields: [{ symbol: 'Ba', amount: 2, chance: 1.0 }, { symbol: 'S', amount: 1, chance: 0.5 }],
+        energyCost: 3, smeltingTime: 4, stackSize: 10,
+        desc: 'Tungt hvitt mineral. Bariumkilde, brukes i fyrverkeri.'
+    },
 
     // ── Crystals / Gemstones (subtype: 'crystal') ───────────────────────────
     clear_quartz: {

--- a/src/data/molecules.js
+++ b/src/data/molecules.js
@@ -133,6 +133,72 @@ const MOLECULE_DEFS = {
         effects: { onUse: 'bomb', damage: 20, radius: 4 },
         desc: 'Massiv eksplosjon! 20 skade i radius 4.'
     },
+
+    // ── New molecules (v0.40): expanded element usage + stronger bombs ───────
+    zinc_antiseptic: {
+        id: 'zinc_antiseptic', name: 'Sinkklorid-antiseptikum', type: 'molecule', subtype: 'medicine',
+        formula: 'ZnCl\u2082', tier: 2, color: 0xaaddee, stackSize: 10,
+        recipe: [{ symbol: 'Zn', amount: 1 }, { symbol: 'Cl', amount: 2 }],
+        energyCost: 1,
+        effects: { onUse: 'cure_all', healHP: 4 },
+        desc: 'Renser sår. Fjerner statuseffekter og healer 4 HP.'
+    },
+    boron_flare: {
+        id: 'boron_flare', name: 'Bor-signalbombe', type: 'molecule', subtype: 'explosive',
+        formula: 'B + Na + O', tier: 2, color: 0x99ff44, stackSize: 10,
+        recipe: [{ symbol: 'B', amount: 2 }, { symbol: 'Na', amount: 1 }, { symbol: 'O', amount: 1 }],
+        energyCost: 1,
+        effects: { onUse: 'bomb', damage: 10, radius: 3 },
+        desc: 'Grønt signalfyr. 10 skade i radius 3.'
+    },
+    barium_firework: {
+        id: 'barium_firework', name: 'Barium-fyrverkeri', type: 'molecule', subtype: 'explosive',
+        formula: 'Ba + K + O', tier: 3, color: 0x66dd88, stackSize: 10,
+        recipe: [{ symbol: 'Ba', amount: 1 }, { symbol: 'K', amount: 1 }, { symbol: 'O', amount: 2 }],
+        energyCost: 2,
+        effects: { onUse: 'bomb', damage: 14, radius: 4 },
+        desc: 'Grønn eksplosjon. 14 skade i radius 4.'
+    },
+    thermite_charge: {
+        id: 'thermite_charge', name: 'Thermittladning', type: 'molecule', subtype: 'explosive',
+        formula: 'Fe + Al + S', tier: 3, color: 0xff8844, stackSize: 5,
+        recipe: [{ symbol: 'Fe', amount: 2 }, { symbol: 'Al', amount: 2 }, { symbol: 'S', amount: 1 }],
+        energyCost: 2,
+        effects: { onUse: 'bomb', damage: 25, radius: 3, defPierce: 4 },
+        desc: 'Gjennom-brennende. 25 skade, ignorer 4 Forsvar, radius 3.'
+    },
+    neodym_magnetbomb: {
+        id: 'neodym_magnetbomb', name: 'Neodym-magnetbombe', type: 'molecule', subtype: 'explosive',
+        formula: 'Nd + Fe', tier: 4, color: 0xaa88ff, stackSize: 5,
+        recipe: [{ symbol: 'Nd', amount: 1 }, { symbol: 'Fe', amount: 2 }],
+        energyCost: 3,
+        effects: { onUse: 'bomb', damage: 22, radius: 5 },
+        desc: 'Massiv magnetpuls. 22 skade i radius 5.'
+    },
+    tungsten_brew: {
+        id: 'tungsten_brew', name: 'Wolfram-styrkedrikk', type: 'molecule', subtype: 'potion',
+        formula: 'W + P', tier: 4, color: 0x998844, stackSize: 5,
+        recipe: [{ symbol: 'W', amount: 1 }, { symbol: 'P', amount: 1 }],
+        energyCost: 2,
+        effects: { onUse: 'buff', stat: 'attack', amount: 5, durationMs: 90000 },
+        desc: '+5 Angrep i 90 sek.'
+    },
+    lanthan_elixir: {
+        id: 'lanthan_elixir', name: 'Lantan-livselixir', type: 'molecule', subtype: 'potion',
+        formula: 'La + Ca + H', tier: 4, color: 0xffaacc, stackSize: 5,
+        recipe: [{ symbol: 'La', amount: 1 }, { symbol: 'Ca', amount: 2 }, { symbol: 'H', amount: 1 }],
+        energyCost: 2,
+        effects: { onUse: 'heal', healHP: 10 },
+        desc: 'Mektig livselixir. +10 HP.'
+    },
+    plasma_core: {
+        id: 'plasma_core', name: 'Plasmakjerne', type: 'molecule', subtype: 'explosive',
+        formula: 'Nd + Ir + O', tier: 5, color: 0x66ffff, stackSize: 3,
+        recipe: [{ symbol: 'Nd', amount: 1 }, { symbol: 'Ir', amount: 1 }, { symbol: 'O', amount: 2 }],
+        energyCost: 4,
+        effects: { onUse: 'bomb', damage: 30, radius: 4, chain: 2 },
+        desc: 'Plasmakjede. 30 skade, lyner til 2 naboer, radius 4.'
+    },
 };
 
 // ── Tier colors for molecules ────────────────────────────────────────────────
@@ -141,4 +207,5 @@ const MOLECULE_TIER_COLORS = {
     2: 0x33dd88,
     3: 0x44aaff,
     4: 0xaa44ff,
+    5: 0x66ffff,
 };

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -122,32 +122,45 @@ const SKILL_TREE_PATHS = [
             {
                 id:       'mineral_eye',
                 name:     'Malmøye',
-                desc:     '+1 mineral-syn\nIdentifiser mineraler',
+                desc:     '+1 mineral-syn\nID-er mineraler\nMerker på minikart',
                 category: 'GEO',
                 maxStack: 3,
                 apply(hero) {
                     hero.mineralVisionRadius = (hero.mineralVisionRadius || 0) + 1;
                     hero.mineralIdentifyLevel = (hero.mineralIdentifyLevel || 0) + 1;
+                    hero.mineralMinimap = true;
                 }
             },
             {
                 id:       'efficient_mining',
                 name:     'Effektiv utvinning',
-                desc:     '+25% mineral-utbytte\n+1 ekstra element\nved smelting',
+                desc:     '25% sjanse for\ndobbelt utbytte\n(stabler til 75%)',
                 category: 'GEO',
                 maxStack: 3,
                 apply(hero) {
-                    hero.miningYieldBonus = (hero.miningYieldBonus || 0) + 0.25;
+                    // Replaces flat miningYieldBonus with a clear double-yield chance per stack.
+                    hero.doubleYieldChance = (hero.doubleYieldChance || 0) + 0.25;
                     hero.smeltBonusElement = (hero.smeltBonusElement || 0) + 1;
                 }
             },
             {
                 id:       'master_prospector',
                 name:     'Mesterprospektør',
-                desc:     'Garantert T4+\nmineral per etasje',
+                desc:     'Garantert T4+\nmineral per etasje\n(T5+ fra verden 5)',
                 category: 'GEO',
                 maxStack: 1,
-                apply(hero) { hero.guaranteedRareMineral = true; }
+                apply(hero) {
+                    hero.guaranteedRareMineral = true;
+                    hero.prospectorHighTier = true;
+                }
+            },
+            {
+                id:       'geode_splitter',
+                name:     'Geode-splitter',
+                desc:     'Hvert 10. smeltede\nmineral gir en gratis\ntilfeldig gemstein',
+                category: 'GEO',
+                maxStack: 1,
+                apply(hero) { hero.geodeSplitter = true; }
             },
         ]
     },
@@ -164,33 +177,44 @@ const SKILL_TREE_PATHS = [
             {
                 id:       'fast_smelting',
                 name:     'Rask smelting',
-                desc:     '-25% smeltetid/energi\n+15% sjanse for\nekstra utbytte',
+                desc:     '-25% smeltetid/energi\n+15% sjanse for\nekstra utbytte\n(maks stack: batch 5)',
                 category: 'UTIL',
                 maxStack: 3,
                 apply(hero) {
                     hero.smeltingSpeedMul = (hero.smeltingSpeedMul || 1.0) * 0.75;
                     hero.smeltingEfficiency = (hero.smeltingEfficiency || 1.0) * 0.75;
                     hero.smeltExtraYieldChance = (hero.smeltExtraYieldChance || 0) + 0.15;
+                    // Track stack count so UI can unlock batch-smelt at max stack.
+                    hero.fastSmeltStacks = (hero.fastSmeltStacks || 0) + 1;
+                    if (hero.fastSmeltStacks >= 3) hero.batchSmeltSize = 5;
                 }
             },
             {
                 id:       'alloy_mastery',
                 name:     'Legeringsmester',
-                desc:     '+15% legering-stats\n20% sjanse for\ndobbel legering',
+                desc:     '+25% legering-stats\n20% sjanse for\ndobbel legering',
                 category: 'UTIL',
                 maxStack: 2,
                 apply(hero) {
-                    hero.alloyMasteryBonus = (hero.alloyMasteryBonus || 0) + 0.15;
+                    hero.alloyMasteryBonus = (hero.alloyMasteryBonus || 0) + 0.25;
                     hero.doubleAlloyChance = (hero.doubleAlloyChance || 0) + 0.20;
                 }
             },
             {
                 id:       'master_smith',
                 name:     'Mestersmie',
-                desc:     '+30% stats på smidd\nutstyr, utstyr får\nspesialegenskaper',
+                desc:     '+50% stats på smidd\nutstyr, spesial-\negenskaper garantert',
                 category: 'ATK',
                 maxStack: 1,
-                apply(hero) { hero.alloyStatBonus = (hero.alloyStatBonus || 0) + 0.30; }
+                apply(hero) { hero.alloyStatBonus = (hero.alloyStatBonus || 0) + 0.50; }
+            },
+            {
+                id:       'reforge',
+                name:     'Reforge',
+                desc:     'Reforge eksisterende\nutstyr for å rulle\nstats på nytt (5 energi)',
+                category: 'UTIL',
+                maxStack: 1,
+                apply(hero) { hero.reforgeUnlocked = true; }
             },
         ]
     },
@@ -206,29 +230,44 @@ const SKILL_TREE_PATHS = [
             {
                 id:       'potent_potions',
                 name:     'Potente potions',
-                desc:     '+50% varighet\npå potions',
+                desc:     '+50% varighet\n+25% styrke\npå potions',
                 category: 'UTIL',
                 maxStack: 3,
-                apply(hero) { hero.potionDurationBonus = (hero.potionDurationBonus || 0) + 0.50; }
+                apply(hero) {
+                    hero.potionDurationBonus = (hero.potionDurationBonus || 0) + 0.50;
+                    hero.potionMagnitudeBonus = (hero.potionMagnitudeBonus || 0) + 0.25;
+                }
             },
             {
                 id:       'acid_mastery',
                 name:     'Syremestring',
-                desc:     '+30% kjemisk\nbombe-skade',
+                desc:     '+40% kjemisk\nbombe-skade\n-2 Def på syreofre',
                 category: 'ATK',
                 maxStack: 2,
-                apply(hero) { hero.chemBombBonus = (hero.chemBombBonus || 0) + 0.30; }
+                apply(hero) {
+                    hero.chemBombBonus = (hero.chemBombBonus || 0) + 0.40;
+                    hero.chemAcidDefShred = (hero.chemAcidDefShred || 0) + 2;
+                }
             },
             {
                 id:       'explosive_genius',
                 name:     'Eksplosjonsgenial',
-                desc:     '+50% skade\n+1 radius på bomber',
+                desc:     '+50% skade, +1 radius\n60% "Dobbel brygging"\npå bomber',
                 category: 'ATK',
                 maxStack: 1,
                 apply(hero) {
                     hero.chemBombBonus = (hero.chemBombBonus || 0) + 0.50;
                     hero.chemRadiusBonus = (hero.chemRadiusBonus || 0) + 0.30;
+                    hero.chemDoubleBrewChance = (hero.chemDoubleBrewChance || 0) + 0.60;
                 }
+            },
+            {
+                id:       'volatile_mastery',
+                name:     'Volatil mestring',
+                desc:     'Bomber kjeder til\n1 nærliggende fiende\nved 50% skade',
+                category: 'ATK',
+                maxStack: 1,
+                apply(hero) { hero.chemBombChain = true; }
             },
         ]
     },
@@ -377,6 +416,18 @@ const SKILL_SYNERGIES = [
         color: 0x66cc88,
         apply(hero) { hero.chemBombBonus = (hero.chemBombBonus || 0) + 0.20; hero.critChance = Math.min(0.75, hero.critChance + 0.10); },
         unapply(hero) { hero.chemBombBonus = Math.max(0, (hero.chemBombBonus || 0) - 0.20); hero.critChance = Math.max(0, hero.critChance - 0.10); },
+    },
+    {
+        // Three-path synergy: requires ≥1 skill from each of Geolog, Metallurg, and Kjemiker.
+        // Unlocks transmutation (convert 5 of any element into 1 of an adjacent element)
+        // via a button in the Chemistry Lab.
+        id:    'transmutation',
+        name:  'Transmutasjon',
+        desc:  '5 av grunnstoff X → 1 av nabo (kjemilab)',
+        paths: ['geolog', 'metallurg', 'kjemiker'],
+        color: 0xff88cc,
+        apply(hero) { hero.transmutationUnlocked = true; },
+        unapply(hero) { hero.transmutationUnlocked = false; },
     },
 ];
 

--- a/src/entities/HeroCrafting.js
+++ b/src/entities/HeroCrafting.js
@@ -12,8 +12,13 @@ const HeroCrafting = {
         hero.mineralVisionRadius = 0;
         hero.mineralIdentifyLevel = 0;
         hero.miningYieldBonus = 0;
+        hero.doubleYieldChance = 0;       // Geolog T2: double-yield chance per stack
         hero.smeltBonusElement = 0;
         hero.guaranteedRareMineral = false;
+        hero.prospectorHighTier = false;  // Geolog T3 world 5+ upgrade
+        hero.mineralMinimap = false;      // Geolog T1: mineral dots on minimap
+        hero.geodeSplitter = false;       // Geolog T4: gemstone every 10 smelts
+        hero.smeltCountForGeode = 0;
         hero.mineralsCollected = 0;
         hero.totalPlayTime = 0; // cumulative seconds across all worlds
 
@@ -26,6 +31,9 @@ const HeroCrafting = {
         hero.alloyStatBonus = 0;
         hero.oreEfficiencyChance = 0;
         hero.doubleAlloyChance = 0;
+        hero.fastSmeltStacks = 0;      // Metallurg T1 stack count
+        hero.batchSmeltSize = 1;       // Metallurg T1 max-stack: batch-smelt amount
+        hero.reforgeUnlocked = false;  // Metallurg T4: reforge action
         hero.alloyInventory = {};
 
         // Chemistry mod (Phase 3)
@@ -33,8 +41,13 @@ const HeroCrafting = {
         hero.chemLabUnlocked = false;
         hero.potionDurationBonus = 0;
         hero.potionPotencyBonus = 0;
+        hero.potionMagnitudeBonus = 0;     // Kjemiker T1: potion stat-size buff
         hero.chemBombBonus = 0;
         hero.chemRadiusBonus = 0;
+        hero.chemAcidDefShred = 0;         // Kjemiker T2: acid bomb -Def on hit
+        hero.chemDoubleBrewChance = 0;     // Kjemiker T3: 2-for-1 bomb craft chance
+        hero.chemBombChain = false;        // Kjemiker T4: bomb chain to 1 extra
+        hero.transmutationUnlocked = false; // Transmutasjon synergy (3-path)
         hero.toxicBladeChance = 0;
 
         // Zone progression (Phase 4)
@@ -65,8 +78,13 @@ const HeroCrafting = {
             mineralVisionRadius:  hero.mineralVisionRadius,
             mineralIdentifyLevel: hero.mineralIdentifyLevel,
             miningYieldBonus:     hero.miningYieldBonus,
+            doubleYieldChance:    hero.doubleYieldChance,
             smeltBonusElement:    hero.smeltBonusElement,
             guaranteedRareMineral: hero.guaranteedRareMineral,
+            prospectorHighTier:   hero.prospectorHighTier,
+            mineralMinimap:       hero.mineralMinimap,
+            geodeSplitter:        hero.geodeSplitter,
+            smeltCountForGeode:   hero.smeltCountForGeode,
             mineralsCollected:    hero.mineralsCollected,
             totalPlayTime:        hero.totalPlayTime,
             metallurgistUnlocked: hero.metallurgistUnlocked,
@@ -77,14 +95,22 @@ const HeroCrafting = {
             alloyStatBonus:       hero.alloyStatBonus,
             oreEfficiencyChance:  hero.oreEfficiencyChance,
             doubleAlloyChance:    hero.doubleAlloyChance,
+            fastSmeltStacks:      hero.fastSmeltStacks,
+            batchSmeltSize:       hero.batchSmeltSize,
+            reforgeUnlocked:      hero.reforgeUnlocked,
             alloyInventory:       { ...hero.alloyInventory },
             campStash:            hero.campStash.map(e => ({ ...e })),
             chemistUnlocked:      hero.chemistUnlocked,
             chemLabUnlocked:      hero.chemLabUnlocked,
             potionDurationBonus:  hero.potionDurationBonus,
             potionPotencyBonus:   hero.potionPotencyBonus,
+            potionMagnitudeBonus: hero.potionMagnitudeBonus,
             chemBombBonus:        hero.chemBombBonus,
             chemRadiusBonus:      hero.chemRadiusBonus,
+            chemAcidDefShred:     hero.chemAcidDefShred,
+            chemDoubleBrewChance: hero.chemDoubleBrewChance,
+            chemBombChain:        hero.chemBombChain,
+            transmutationUnlocked: hero.transmutationUnlocked,
             toxicBladeChance:     hero.toxicBladeChance,
             completedZones:       [...hero.completedZones],
             appliedElementBonuses: { ...hero.appliedElementBonuses },
@@ -108,8 +134,13 @@ const HeroCrafting = {
         hero.mineralVisionRadius  = stats.mineralVisionRadius  || 0;
         hero.mineralIdentifyLevel = stats.mineralIdentifyLevel || 0;
         hero.miningYieldBonus     = stats.miningYieldBonus     || 0;
+        hero.doubleYieldChance    = stats.doubleYieldChance    || 0;
         hero.smeltBonusElement    = stats.smeltBonusElement    || 0;
         hero.guaranteedRareMineral = stats.guaranteedRareMineral || false;
+        hero.prospectorHighTier   = stats.prospectorHighTier   || false;
+        hero.mineralMinimap       = stats.mineralMinimap       || false;
+        hero.geodeSplitter        = stats.geodeSplitter        || false;
+        hero.smeltCountForGeode   = stats.smeltCountForGeode   || 0;
         hero.mineralsCollected    = stats.mineralsCollected    || 0;
         hero.totalPlayTime        = stats.totalPlayTime        || 0;
         hero.metallurgistUnlocked = stats.metallurgistUnlocked || false;
@@ -120,14 +151,22 @@ const HeroCrafting = {
         hero.alloyStatBonus       = stats.alloyStatBonus       || 0;
         hero.oreEfficiencyChance  = stats.oreEfficiencyChance  || 0;
         hero.doubleAlloyChance    = stats.doubleAlloyChance    || 0;
+        hero.fastSmeltStacks      = stats.fastSmeltStacks      || 0;
+        hero.batchSmeltSize       = stats.batchSmeltSize       || 1;
+        hero.reforgeUnlocked      = stats.reforgeUnlocked      || false;
         hero.alloyInventory       = stats.alloyInventory       ? { ...stats.alloyInventory } : {};
         hero.campStash            = (stats.campStash || []).map(e => ({ ...e }));
         hero.chemistUnlocked      = stats.chemistUnlocked      || false;
         hero.chemLabUnlocked      = stats.chemLabUnlocked      || false;
         hero.potionDurationBonus  = stats.potionDurationBonus  || 0;
         hero.potionPotencyBonus   = stats.potionPotencyBonus   || 0;
+        hero.potionMagnitudeBonus = stats.potionMagnitudeBonus || 0;
         hero.chemBombBonus        = stats.chemBombBonus        || 0;
         hero.chemRadiusBonus      = stats.chemRadiusBonus      || 0;
+        hero.chemAcidDefShred     = stats.chemAcidDefShred     || 0;
+        hero.chemDoubleBrewChance = stats.chemDoubleBrewChance || 0;
+        hero.chemBombChain        = stats.chemBombChain        || false;
+        hero.transmutationUnlocked = stats.transmutationUnlocked || false;
         hero.toxicBladeChance     = stats.toxicBladeChance     || 0;
         hero.completedZones       = stats.completedZones       ? [...stats.completedZones] : [];
         hero.appliedElementBonuses = stats.appliedElementBonuses ? { ...stats.appliedElementBonuses } : {};

--- a/src/scenes/ChemLabScene.js
+++ b/src/scenes/ChemLabScene.js
@@ -316,6 +316,15 @@ class ChemLabScene extends Phaser.Scene {
 
         EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `Laget: ${result.item.name}!`, color: '#33dd88' });
 
+        // Kjemiker T3 "Double Brew": drop an extra copy if the skill triggered.
+        if (result.bonusItem) {
+            const bonusAdded = hero.inventory.addItem(result.bonusItem);
+            if (!bonusAdded) {
+                EventBus.emit('spawnItem', { gx: hero.gridX, gy: hero.gridY, item: result.bonusItem });
+            }
+            EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY - 1, msg: 'Dobbel brygging!', color: '#ffcc44' });
+        }
+
         Audio.playPickup();
         this._refresh();
     }
@@ -325,16 +334,24 @@ class ChemLabScene extends Phaser.Scene {
             fontSize: '14px', color: '#556655', fontFamily: 'monospace', fontStyle: 'bold'
         }));
 
-        const collected = this.heroRef.elementTracker.collected;
+        const hero = this.heroRef;
+        const transmutable = !!hero.transmutationUnlocked;
+        if (transmutable) {
+            this._d(this.add.text(x, y + 18, 'Transmutasjon: klikk ↔ for 5 → 1 nabo', {
+                fontSize: '11px', color: '#ff88cc', fontFamily: 'monospace'
+            }));
+        }
+
+        const collected = hero.elementTracker.collected;
         const entries = Object.entries(collected).filter(([, v]) => v > 0);
         if (entries.length === 0) {
-            this._d(this.add.text(x, y + 18, 'Ingen lagret.', {
+            this._d(this.add.text(x, y + (transmutable ? 34 : 18), 'Ingen lagret.', {
                 fontSize: '14px', color: '#334433', fontFamily: 'monospace'
             }));
             return;
         }
 
-        let bx = x, by = y + 18;
+        let bx = x, by = y + (transmutable ? 36 : 18);
         for (const [symbol, count] of entries) {
             const elem = typeof ELEMENTS !== 'undefined' ? ELEMENTS[symbol] : null;
             const col = elem ? elem.color : 0xaaaaaa;
@@ -343,8 +360,36 @@ class ChemLabScene extends Phaser.Scene {
                 fontSize: '14px', color: hexCol, fontFamily: 'monospace',
                 backgroundColor: '#081808', padding: { x: 3, y: 1 }
             }));
-            bx += badge.width + 6;
-            if (bx > x + w - 30) { bx = x; by += 20; }
+            let bwidth = badge.width;
+            // Transmutation button (only clickable when count ≥ 5).
+            if (transmutable) {
+                const canTransmute = count >= 5;
+                const tbtn = this._d(this.add.text(bx + bwidth + 2, by, '↔', {
+                    fontSize: '14px',
+                    color: canTransmute ? '#ff88cc' : '#553344',
+                    fontFamily: 'monospace',
+                    backgroundColor: '#180818',
+                    padding: { x: 3, y: 1 }
+                }));
+                if (canTransmute) {
+                    tbtn.setInteractive({ useHandCursor: true });
+                    tbtn.on('pointerover', () => tbtn.setColor('#ffaadd'));
+                    tbtn.on('pointerout', () => tbtn.setColor('#ff88cc'));
+                    tbtn.on('pointerdown', () => this._doTransmute(symbol));
+                }
+                bwidth += tbtn.width + 4;
+            }
+            bx += bwidth + 6;
+            if (bx > x + w - 30) { bx = x; by += 22; }
         }
+    }
+
+    _doTransmute(symbol) {
+        const hero = this.heroRef;
+        const produced = this.chem.transmute(hero, symbol);
+        if (!produced) return;
+        EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `Transmuted: 5 ${symbol} → 1 ${produced}`, color: '#ff88cc' });
+        Audio.playPickup();
+        this._refresh();
     }
 }

--- a/src/scenes/SmelteryScene.js
+++ b/src/scenes/SmelteryScene.js
@@ -560,6 +560,31 @@ class SmelteryScene extends Phaser.Scene {
                 } else {
                     btn.on('pointerdown', () => this._doSmelt(m.slot, m.def));
                 }
+                // Metallurg T1 max-stack: batch smelt button that processes up to batchSmeltSize
+                // at once. Only shown when hero has the batch capability and mineral count>1.
+                const batchN = hero.batchSmeltSize || 1;
+                if (batchN > 1 && m.count > 1) {
+                    const label = `[ ×${Math.min(batchN, m.count)} ]`;
+                    const bbtn = this._d(this.add.text(startX + colW - 140, my + 14, label, {
+                        fontSize: '14px', color: '#ffcc44', fontFamily: 'monospace', fontStyle: 'bold'
+                    }).setInteractive({ useHandCursor: true }));
+                    bbtn.on('pointerover', () => bbtn.setColor('#ffee88'));
+                    bbtn.on('pointerout', () => bbtn.setColor('#ffcc44'));
+                    bbtn.on('pointerdown', () => {
+                        for (let i = 0; i < batchN; i++) {
+                            // Re-read current count each iteration; stop if empty or out of fuel.
+                            const entry = m.source === 'stash'
+                                ? hero.campStash[m.slot]
+                                : hero.inventory.backpack[m.slot];
+                            if (!entry || entry.count <= 0) break;
+                            const fuelNow = this.smelter.calculateFuelEnergy(hero);
+                            const chk = this.smelter.canSmelt(m.def, fuelNow, hero);
+                            if (!chk.canSmelt) break;
+                            if (m.source === 'stash') this._doSmeltFromStash(m.slot, m.def);
+                            else this._doSmelt(m.slot, m.def);
+                        }
+                    });
+                }
             } else {
                 this._d(this.add.text(startX + colW - 80, my + 14, 'Lite brensel', {
                     fontSize: '14px', color: '#443322', fontFamily: 'monospace'
@@ -608,6 +633,16 @@ class SmelteryScene extends Phaser.Scene {
 
         const elemStr = result.elements.map(e => `${e.symbol}×${e.amount}`).join(', ');
         EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `Smeltet: ${elemStr}`, color: '#ff7722' });
+
+        // Geolog T2 visible feedback when double-yield triggered.
+        if (result.doubled) {
+            EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY - 1, msg: 'Dobbelt utbytte!', color: '#ffcc44' });
+        }
+        // Geolog T4 geode drop feedback.
+        if (result.geodeElement) {
+            const g = result.geodeElement;
+            EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY - 2, msg: `Geode! +${g.amount} ${g.symbol}`, color: '#88ccff' });
+        }
 
         const newBonuses = hero.elementTracker.checkCompletions();
         if (newBonuses.length > 0) {
@@ -738,6 +773,35 @@ class SmelteryScene extends Phaser.Scene {
         }).setOrigin(0.5));
         y += 22;
 
+        // Metallurg T4 "Reforge": reroll equipped weapon/armor stats for 5 energy.
+        if (hero.reforgeUnlocked) {
+            const rx = this.px + 20;
+            const ry = y;
+            const ww = this.smelter;
+            const fuel = ww.calculateFuelEnergy(hero);
+            this._d(this.add.text(rx, ry, `Reforge (5 energi) – ruller stats på nytt på utstyrt gjenstand:`, {
+                fontSize: '13px', color: '#ffcc88', fontFamily: 'monospace'
+            }));
+            const makeBtn = (offset, slot, label) => {
+                const eq = hero.inventory && hero.inventory.equipped ? hero.inventory.equipped[slot] : null;
+                const txt = eq ? `[ ${label}: ${eq.name} ]` : `[ ${label}: — ]`;
+                const t = this._d(this.add.text(rx + offset, ry + 18, txt, {
+                    fontSize: '13px',
+                    color: (eq && fuel >= 5) ? '#ffcc44' : '#554433',
+                    fontFamily: 'monospace', fontStyle: 'bold'
+                }));
+                if (eq && fuel >= 5) {
+                    t.setInteractive({ useHandCursor: true });
+                    t.on('pointerover', () => t.setColor('#ffee88'));
+                    t.on('pointerout', () => t.setColor('#ffcc44'));
+                    t.on('pointerdown', () => this._doReforge(slot));
+                }
+            };
+            makeBtn(0, 'weapon', 'Reforge våpen');
+            makeBtn(260, 'armor', 'Reforge rustning');
+            y += 44;
+        }
+
         // List available alloys the player has
         const alloyInv = hero.alloyInventory || {};
         const available = Object.entries(alloyInv).filter(([, count]) => count > 0);
@@ -815,6 +879,40 @@ class SmelteryScene extends Phaser.Scene {
 
         EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `Smidd: ${result.item.name}!`, color: '#ffaa44' });
 
+        Audio.playPickup();
+        this._refresh();
+    }
+
+    /**
+     * Metallurg T4 "Reforge": reroll an equipped weapon's/armor's rarity
+     * for 5 energy. Keeps the item type and base def, reassigns rarity stats.
+     */
+    _doReforge(slot) {
+        const hero = this.heroRef;
+        if (!hero.reforgeUnlocked) return;
+        const eq = hero.inventory && hero.inventory.equipped ? hero.inventory.equipped[slot] : null;
+        if (!eq) return;
+        const fuel = this.smelter.calculateFuelEnergy(hero);
+        if (fuel < 5) return;
+
+        // Find the base item (without rarity multiplier) — rerolling from
+        // the ITEM_DEFS entry keeps the reroll honest.
+        const baseDef = (typeof ITEM_DEFS !== 'undefined' && ITEM_DEFS[eq.id])
+            || (typeof ALLOY_EQUIPMENT !== 'undefined' && ALLOY_EQUIPMENT[eq.id]);
+        if (!baseDef) return;
+
+        this.smelter.consumeFuel(hero, 5);
+
+        // Unequip first so _unapply removes old stats cleanly.
+        hero.inventory._unapply(eq, hero);
+        const worldNum = hero.worldNum || 1;
+        const rolled = (typeof rollRarity === 'function' && typeof makeRarityItem === 'function')
+            ? makeRarityItem(baseDef, rollRarity(worldNum))
+            : { ...baseDef };
+        hero.inventory.equipped[slot] = rolled;
+        hero.inventory._apply(rolled, hero);
+
+        EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `Reforged: ${rolled.name}!`, color: '#ffcc44' });
         Audio.playPickup();
         this._refresh();
     }

--- a/src/systems/ChemistrySystem.js
+++ b/src/systems/ChemistrySystem.js
@@ -59,7 +59,15 @@ class ChemistrySystem {
         // Create usable item from molecule definition
         const item = this._createUsableItem(mol, hero, worldNum);
 
-        return { success: true, item, energyCost };
+        // Kjemiker T3 "Double Brew": chance to produce an extra bomb per craft.
+        let bonusItem = null;
+        if (mol.subtype === 'explosive' && (hero.chemDoubleBrewChance || 0) > 0) {
+            if (Math.random() < hero.chemDoubleBrewChance) {
+                bonusItem = this._createUsableItem(mol, hero, worldNum);
+            }
+        }
+
+        return { success: true, item, bonusItem, energyCost };
     }
 
     /**
@@ -87,11 +95,22 @@ class ChemistrySystem {
     _createUsableItem(mol, hero, worldNum) {
         const eff = mol.effects;
         const wn = worldNum || hero.worldNum || 1;
-        const worldScale = 1 + (wn - 1) * 0.4;
+        // Separate scaling curves: bombs scale faster than potions so they
+        // keep pace with world monster HP; potions keep the older curve so
+        // buffs don't become overpowered.
+        const potionScale = 1 + (wn - 1) * 0.4;
+        const bombScale = 1 + (wn - 1) * 0.6;
+        const bombFloor = wn * 2; // flat damage bonus per world
+        // Radius auto-upgrade kicks in at world 5 and 8 so high-world bombs
+        // feel noticeably more effective.
+        const bombRadiusBonus = (wn >= 8 ? 2 : (wn >= 5 ? 1 : 0));
         const potencyMul = 1 + (hero.potionPotencyBonus || 0);
+        const potionMagnitudeMul = 1 + (hero.potionMagnitudeBonus || 0);
         const durationMul = 1 + (hero.potionDurationBonus || 0);
         const bombDmgMul = 1 + (hero.chemBombBonus || 0);
         const bombRadMul = 1 + (hero.chemRadiusBonus || 0);
+        const acidDefShred = hero.chemAcidDefShred || 0;
+        const bombChainBonus = hero.chemBombChain ? 1 : 0;
 
         const item = {
             id: mol.id,
@@ -111,7 +130,12 @@ class ChemistrySystem {
 
         // Build the use() function based on effect type
         if (eff.onUse === 'heal') {
-            const hp = Math.round(eff.healHP * potencyMul * worldScale);
+            // From world 4+ healing potions scale with % max HP so they stay
+            // meaningful against higher HP pools.
+            const flatHP = Math.round(eff.healHP * potencyMul * potionMagnitudeMul * potionScale);
+            const hp = wn >= 4
+                ? Math.max(flatHP, Math.round((hero.maxHearts || flatHP) * 0.25 * potencyMul))
+                : flatHP;
             item.desc = `+${hp} HP`;
             item.use = (hero, scene) => {
                 hero.hearts = Math.min(hero.hearts + hp, hero.maxHearts);
@@ -119,7 +143,7 @@ class ChemistrySystem {
                 return true;
             };
         } else if (eff.onUse === 'buff') {
-            const amt = Math.round(eff.amount * potencyMul * worldScale);
+            const amt = Math.round(eff.amount * potencyMul * potionMagnitudeMul * potionScale);
             const dur = Math.round(eff.durationMs * durationMul);
             item.desc = `+${amt} ${eff.stat} (${Math.round(dur / 1000)}s)`;
             item.use = (hero) => {
@@ -127,7 +151,7 @@ class ChemistrySystem {
                 return true;
             };
         } else if (eff.onUse === 'cure_all') {
-            const hp = Math.round((eff.healHP || 0) * potencyMul * worldScale);
+            const hp = Math.round((eff.healHP || 0) * potencyMul * potionMagnitudeMul * potionScale);
             item.use = (hero, scene) => {
                 hero.clearAllEffects();
                 if (hp > 0) hero.hearts = Math.min(hero.hearts + hp, hero.maxHearts);
@@ -135,23 +159,49 @@ class ChemistrySystem {
                 return true;
             };
         } else if (eff.onUse === 'bomb') {
-            const dmg = Math.round(eff.damage * bombDmgMul * worldScale);
-            const rad = Math.round(eff.radius * bombRadMul);
-            item.desc = `${dmg} skade, radius ${rad}`;
+            const dmg = Math.round(eff.damage * bombDmgMul * bombScale + bombFloor);
+            const rad = Math.round(eff.radius * bombRadMul) + bombRadiusBonus;
+            const defPierce = eff.defPierce || 0;
+            const chainCount = (eff.chain || 0) + bombChainBonus;
+            item.desc = `${dmg} skade, radius ${rad}` + (defPierce ? `, ignorer ${defPierce} Def` : '');
             item.use = (hero, scene) => {
                 if (!scene) return false;
+                const hitIds = new Set();
+                const applyHit = (m, mul = 1) => {
+                    if (!m || !m.alive || hitIds.has(m)) return;
+                    hitIds.add(m);
+                    let dealt = Math.max(1, Math.round(dmg * mul));
+                    if (defPierce > 0 && typeof m.defense === 'number') {
+                        dealt += Math.min(defPierce, m.defense);
+                    }
+                    m.takeDamage(dealt);
+                };
+                // Primary AoE
                 for (const m of scene.monsters) {
                     if (!m.alive) continue;
                     const d = Math.abs(m.gridX - hero.gridX) + Math.abs(m.gridY - hero.gridY);
-                    if (d <= rad) m.takeDamage(dmg);
+                    if (d <= rad) applyHit(m);
+                }
+                // Chain lightning to nearest survivors outside the radius at 50% dmg
+                for (let i = 0; i < chainCount; i++) {
+                    let best = null, bestD = Infinity;
+                    for (const m of scene.monsters) {
+                        if (!m.alive || hitIds.has(m)) continue;
+                        const d = Math.abs(m.gridX - hero.gridX) + Math.abs(m.gridY - hero.gridY);
+                        if (d < bestD) { best = m; bestD = d; }
+                    }
+                    if (best) applyHit(best, 0.5);
+                    else break;
                 }
                 scene.monsters = scene.monsters.filter(m => m.alive);
                 return true;
             };
         } else if (eff.onUse === 'acid_bomb') {
-            const dmg = Math.round(eff.damage * bombDmgMul * worldScale);
-            const rad = Math.round(eff.radius * bombRadMul);
-            const dur = eff.duration || 3;
+            const dmg = Math.round(eff.damage * bombDmgMul * bombScale + bombFloor);
+            const rad = Math.round(eff.radius * bombRadMul) + bombRadiusBonus;
+            // Burn duration scales with world: +1 round per 4 worlds.
+            const dur = (eff.duration || 3) + Math.floor(wn / 4);
+            const defShred = acidDefShred; // extra Def reduced by Kjemiker T2 buff
             item.desc = `${dmg} skade + etsende ${dur} runder, radius ${rad}`;
             item.use = (hero, scene) => {
                 if (!scene) return false;
@@ -162,6 +212,9 @@ class ChemistrySystem {
                         m.takeDamage(dmg);
                         // Acid burn: reduce defense over time
                         if (m.applyAcidBurn) m.applyAcidBurn(dur);
+                        if (defShred > 0 && typeof m.defense === 'number') {
+                            m.defense = Math.max(0, m.defense - defShred);
+                        }
                     }
                 }
                 scene.monsters = scene.monsters.filter(m => m.alive);
@@ -196,5 +249,37 @@ class ChemistrySystem {
 
     _adjustedEnergy(baseCost, hero) {
         return Math.max(0, Math.round(baseCost * (hero.smeltingEfficiency || 1.0)));
+    }
+
+    // ── Transmutation (3-path synergy) ──────────────────────────────────────
+    /**
+     * Transmutasjon-synergi: convert 5 of `symbol` into 1 of a neighbouring
+     * element (atomic number ±1). Returns the produced symbol or null if
+     * the hero lacks the skill / enough of the source / no valid neighbour.
+     * Neighbour preference: next atomic number (rollover to previous if top).
+     */
+    transmute(hero, symbol) {
+        if (!hero || !hero.transmutationUnlocked) return null;
+        const have = hero.elementTracker.getCount(symbol);
+        if (have < 5) return null;
+        if (typeof ELEMENTS === 'undefined' || !ELEMENTS[symbol]) return null;
+        const srcZ = ELEMENTS[symbol].atomicNumber;
+
+        // Build atomic-number → symbol map once.
+        const byZ = {};
+        for (const [sym, def] of Object.entries(ELEMENTS)) {
+            byZ[def.atomicNumber] = sym;
+        }
+        // Prefer Z+1, fall back to Z-1.
+        const targetSym = byZ[srcZ + 1] || byZ[srcZ - 1];
+        if (!targetSym || targetSym === symbol) return null;
+
+        hero.elementTracker.collected[symbol] = have - 5;
+        if (hero.elementTracker.collected[symbol] <= 0) {
+            delete hero.elementTracker.collected[symbol];
+        }
+        hero.elementTracker.collect(targetSym, 1);
+        hero.elementTracker.discover(targetSym);
+        return targetSym;
     }
 }

--- a/src/systems/Inventory.js
+++ b/src/systems/Inventory.js
@@ -246,6 +246,7 @@ class Inventory {
         if (item.hearts) {
             hero.maxHearts += item.hearts;
         }
+        if (item.visionBonus) hero.visionRadius += item.visionBonus;
     }
 
     _unapply(item, hero) {
@@ -255,6 +256,7 @@ class Inventory {
             hero.maxHearts  -= item.hearts;
             hero.hearts      = Math.min(hero.hearts, hero.maxHearts);
         }
+        if (item.visionBonus) hero.visionRadius -= item.visionBonus;
     }
 
     // ── Serialisation ─────────────────────────────────────────────────────────

--- a/src/systems/SmeltingSystem.js
+++ b/src/systems/SmeltingSystem.js
@@ -33,6 +33,7 @@ class SmeltingSystem {
     smelt(mineralDef, hero) {
         const energyCost = this._adjustedEnergyCost(mineralDef.energyCost, hero);
         const elements = [];
+        let doubledSomething = false;
 
         for (const y of mineralDef.yields) {
             // Base chance + mining yield bonus from Geologist skill
@@ -46,7 +47,12 @@ class SmeltingSystem {
                 }
                 // Geologist smeltBonusElement: extra element per smelt
                 amount += (hero.smeltBonusElement || 0);
-                // Metallurgist smeltExtraYieldChance: chance for double yield
+                // Geologist T2 "Effektiv utvinning": double-yield chance per stack
+                if ((hero.doubleYieldChance || 0) > 0 && Math.random() < hero.doubleYieldChance) {
+                    amount *= 2;
+                    doubledSomething = true;
+                }
+                // Metallurgist smeltExtraYieldChance: chance for +50% yield
                 if ((hero.smeltExtraYieldChance || 0) > 0 && Math.random() < hero.smeltExtraYieldChance) {
                     amount = Math.ceil(amount * 1.5);
                 }
@@ -58,7 +64,23 @@ class SmeltingSystem {
             }
         }
 
-        return { elements, energyCost };
+        // Geolog T4 "Geode Splitter": every 10 smelts yields a free random gemstone.
+        let geodeElement = null;
+        if (hero.geodeSplitter) {
+            hero.smeltCountForGeode = (hero.smeltCountForGeode || 0) + 1;
+            if (hero.smeltCountForGeode >= 10) {
+                hero.smeltCountForGeode = 0;
+                // Grant 1 of a random already-discovered element (rarer preferred).
+                const discovered = Object.keys(hero.elementTracker.discovered || {});
+                if (discovered.length > 0) {
+                    const pick = discovered[Math.floor(Math.random() * discovered.length)];
+                    hero.elementTracker.collect(pick, 1);
+                    geodeElement = { symbol: pick, amount: 1 };
+                }
+            }
+        }
+
+        return { elements, energyCost, doubled: doubledSomething, geodeElement };
     }
 
     // ── Alloy Crafting: Elements → Alloy ─────────────────────────────────────

--- a/tests/ci-runner.js
+++ b/tests/ci-runner.js
@@ -1,0 +1,117 @@
+// ─── Labyrint Hero – Headless CI Test Runner ────────────────────────────────
+// Boots a minimal static HTTP server, opens tests/test-runner.html in a
+// headless Chromium via Playwright, waits for the suite to finish, and exits
+// with a non-zero status if any test failed or a page error occurred.
+//
+// Run locally:
+//   npm install --no-save playwright
+//   npx playwright install chromium
+//   node tests/ci-runner.js
+
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { chromium } = require('playwright');
+
+const ROOT = path.join(__dirname, '..');
+const PORT = 8123;
+
+const MIME = {
+    '.html': 'text/html; charset=utf-8',
+    '.js':   'text/javascript; charset=utf-8',
+    '.css':  'text/css; charset=utf-8',
+    '.json': 'application/json; charset=utf-8',
+    '.svg':  'image/svg+xml',
+    '.png':  'image/png',
+    '.ico':  'image/x-icon',
+};
+
+function serveFile(req, res) {
+    const urlPath = decodeURIComponent(req.url.split('?')[0]);
+    const safe = path.normalize(urlPath).replace(/^([.][.][/\\])+/, '');
+    let filePath = path.join(ROOT, safe);
+    // Prevent escape from ROOT
+    if (!filePath.startsWith(ROOT)) {
+        res.writeHead(403); res.end('forbidden'); return;
+    }
+    if (fs.existsSync(filePath) && fs.statSync(filePath).isDirectory()) {
+        filePath = path.join(filePath, 'index.html');
+    }
+    fs.readFile(filePath, (err, data) => {
+        if (err) { res.writeHead(404); res.end('not found: ' + safe); return; }
+        const ext = path.extname(filePath).toLowerCase();
+        res.writeHead(200, { 'Content-Type': MIME[ext] || 'application/octet-stream' });
+        res.end(data);
+    });
+}
+
+(async () => {
+    const server = http.createServer(serveFile);
+    await new Promise(resolve => server.listen(PORT, resolve));
+    console.log(`[ci] serving ${ROOT} on :${PORT}`);
+
+    const browser = await chromium.launch();
+    const page = await browser.newPage();
+
+    const pageErrors = [];
+    const consoleErrors = [];
+    page.on('pageerror', err => pageErrors.push(err.message || String(err)));
+    page.on('console', msg => {
+        if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+
+    let exitCode = 0;
+    try {
+        await page.goto(`http://localhost:${PORT}/tests/test-runner.html`, {
+            waitUntil: 'load', timeout: 30000,
+        });
+
+        // The test framework updates document.title to start with ✓ or ✗ when done.
+        await page.waitForFunction(
+            () => /^[\u2713\u2717]/.test(document.title),
+            null,
+            { timeout: 30000 },
+        );
+
+        const title = await page.title();
+        const summary = await page.$eval('.summary', el => el.textContent.trim());
+        const failedTests = await page.$$eval('.test.fail', els =>
+            els.map(e => e.textContent.trim()),
+        );
+        const errorDetails = await page.$$eval('.error-detail', els =>
+            els.map(e => e.textContent.trim()),
+        );
+
+        console.log(`\n[ci] ${title}`);
+        console.log(`[ci] ${summary}`);
+
+        if (failedTests.length > 0) {
+            console.log('\n[ci] failures:');
+            failedTests.forEach((name, i) => {
+                console.log(`  ${name}`);
+                if (errorDetails[i]) console.log(`    ${errorDetails[i]}`);
+            });
+            exitCode = 1;
+        }
+
+        if (pageErrors.length > 0) {
+            console.log('\n[ci] uncaught page errors:');
+            pageErrors.forEach(e => console.log(`  ${e}`));
+            exitCode = 1;
+        }
+
+        if (consoleErrors.length > 0) {
+            console.log('\n[ci] console errors:');
+            consoleErrors.forEach(e => console.log(`  ${e}`));
+            exitCode = 1;
+        }
+    } catch (e) {
+        console.error('[ci] runner failed:', e.message);
+        exitCode = 1;
+    } finally {
+        await browser.close();
+        server.close();
+    }
+
+    process.exit(exitCode);
+})();

--- a/tests/test-chemistry.js
+++ b/tests/test-chemistry.js
@@ -72,7 +72,10 @@ describe('ChemistrySystem – synthesize', () => {
         expect(oLeft).toBeLessThan(5);
     });
 
-    it('unlocks chemist on first synthesis', () => {
+    it('produces a usable item with a use() function', () => {
+        // chemistUnlocked is toggled by GameScene when the hero enters a lab
+        // room, not by the ChemistrySystem itself; assert on the synthesised
+        // item shape instead.
         const chem = new ChemistrySystem();
         const tracker = new ElementTracker();
         tracker.collect('H', 5);
@@ -80,15 +83,17 @@ describe('ChemistrySystem – synthesize', () => {
         const hero = {
             elementTracker: tracker,
             smeltingEfficiency: 1.0,
-            chemistUnlocked: false,
             potionPotencyBonus: 0,
+            potionMagnitudeBonus: 0,
             potionDurationBonus: 0,
             chemBombBonus: 0,
-            chemRadiusBonus: 0
+            chemRadiusBonus: 0,
+            maxHearts: 6, hearts: 6
         };
 
-        chem.synthesize('water', hero);
-        expect(hero.chemistUnlocked).toBeTrue();
+        const result = chem.synthesize('water', hero, 1);
+        expect(result.success).toBeTrue();
+        expect(typeof result.item.use).toBe('function');
     });
 
     it('returns failure for unknown molecule', () => {

--- a/tests/test-smelting.js
+++ b/tests/test-smelting.js
@@ -3,7 +3,7 @@
 describe('SmeltingSystem – canSmelt', () => {
     it('returns true with enough fuel', () => {
         const smelter = new SmeltingSystem();
-        const mineral = MINERAL_DEFS.copper_ore;
+        const mineral = MINERAL_DEFS.chalcopyrite;
         const hero = { smeltingEfficiency: 0, miningYieldBonus: 0, oreEfficiencyChance: 0, elementTracker: new ElementTracker() };
         const result = smelter.canSmelt(mineral, 100, hero);
         expect(result.canSmelt).toBeTrue();
@@ -12,7 +12,7 @@ describe('SmeltingSystem – canSmelt', () => {
 
     it('returns false with zero fuel', () => {
         const smelter = new SmeltingSystem();
-        const mineral = MINERAL_DEFS.copper_ore;
+        const mineral = MINERAL_DEFS.chalcopyrite;
         const hero = { smeltingEfficiency: 0, miningYieldBonus: 0, oreEfficiencyChance: 0, elementTracker: new ElementTracker() };
         const result = smelter.canSmelt(mineral, 0, hero);
         expect(result.canSmelt).toBeFalse();
@@ -22,7 +22,7 @@ describe('SmeltingSystem – canSmelt', () => {
 describe('SmeltingSystem – smelt', () => {
     it('produces elements from a mineral', () => {
         const smelter = new SmeltingSystem();
-        const mineral = MINERAL_DEFS.copper_ore;
+        const mineral = MINERAL_DEFS.chalcopyrite;
         const hero = {
             smeltingEfficiency: 0,
             miningYieldBonus: 0,
@@ -44,7 +44,7 @@ describe('SmeltingSystem – smelt', () => {
 
     it('returns correct energy cost', () => {
         const smelter = new SmeltingSystem();
-        const mineral = MINERAL_DEFS.copper_ore;
+        const mineral = MINERAL_DEFS.chalcopyrite;
         const hero = { smeltingEfficiency: 0, miningYieldBonus: 0, oreEfficiencyChance: 0, elementTracker: new ElementTracker() };
         const result = smelter.smelt(mineral, hero);
         expect(result.energyCost).toBe(mineral.energyCost);
@@ -52,7 +52,7 @@ describe('SmeltingSystem – smelt', () => {
 
     it('collects elements in hero tracker', () => {
         const smelter = new SmeltingSystem();
-        const mineral = MINERAL_DEFS.copper_ore;
+        const mineral = MINERAL_DEFS.chalcopyrite;
         const tracker = new ElementTracker();
         const hero = {
             smeltingEfficiency: 0,


### PR DESCRIPTION
Closes #99, closes #100, closes #101.

## Summary

Content + balance + skill-rebalance pass for the Camp & Chemistry systems. Split into three follow-up issues during planning with user; this PR bundles them in one branch with one commit per issue plus a docs commit.

### Commit `458b7cc` — Expand element usage (#99)
- **2 new minerals**: molybdenitt (Mo + S), barytt (Ba + S) — so those elements can actually be reached via smelting.
- **5 new alloys**: manganstål (Fe+Mn+C), molybdenstål (Fe+Mo+C), wolframkarbid (W+C), tantalplate (Ta+Fe), fosforkrystall (Ce+La+Nd).
- **6 new forged equipment pieces**, including phosphor blade/shield that grant +1 vision via a new `visionBonus` item property (wired in `Inventory._apply`/`_unapply`).
- **8 new molecules**: sinkklorid-antiseptikum, bor-signalbombe, barium-fyrverkeri, thermittladning (ignorer 4 Def), neodym-magnetbombe, wolfram-styrkedrikk, lantan-livselixir (+10 HP), plasmakjerne (plasmakjede til 2 ekstra).

### Commit `93324e2` — Scale bombs/potions for higher worlds (#100)
- Bomb scale split from potion scale: `bombScale = 1 + (world-1)*0.6 + world*2` (was flat `+0.4` together with potions).
- Bomb radius auto-upgrade: `+1` at world ≥5, `+2` at world ≥8.
- Healing potions from world 4+ pick `max(flat, 25% of max HP)` so they stay relevant at high HP pools.
- Acid burn duration gains `+1` round per 4 worlds.
- New `defPierce` and `chain` molecule fields wired in ChemistrySystem.

### Commit `bb2f770` — Skill rebalance + Transmutasjon synergy (#101)
- **Geolog**: T2 replaced flat +25% with 25/50/75% *double*-yield per stack; T3 → T5+ from world 5; **new T4 Geode-splitter** (random free element every 10 smelts).
- **Metallurg**: T1 max-stack unlocks batch-smelt ×5 button; T2 → +25%; T3 → +50% forged stats; **new T4 Reforge** (rerolls equipped weapon/armor rarity for 5 energy).
- **Kjemiker**: T1 → +50% duration *and* +25% magnitude; T2 → +40% dmg *and* −2 Def shred on acid; T3 → +60% Double Brew; **new T4 Volatile Mastery** (bombs chain +1 extra).
- **New 3-path synergy Transmutasjon** (Geolog + Metallurg + Kjemiker): unlocks a `↔` button per element badge in ChemLab — converts 5 of element X → 1 of atomic-number neighbour.
- 13 new fields in `HeroCrafting.init/serialize/applyStats` with safe fallback defaults (old saves load fine).

### Commit `f59f429` — Docs
- CHANGELOG v0.40 entry.
- GDD skill tables refreshed with new T4 rows.
- Elements-mod.md bumped to v0.4 with a brief pointer.

## Test plan
- [ ] Open `index.html`; enter a camp room at world 1, 3, 5 and 8.
  - [ ] Verify new minerals (molybdenitt, barytt) can appear and smelt.
  - [ ] Verify new alloys appear in the Legering tab when elements are available; forge each and check the stats applied on equip (including `visionBonus` for phosphor pieces).
- [ ] Pick all four Geolog tiers; confirm Geode-splitter fires once every 10 smelts with a floating-text popup.
- [ ] Max-stack Rask smelting (Metallurg T1) and confirm the `[ ×5 ]` batch button appears next to single smelt.
- [ ] Take Metallurg T4 Reforge; confirm both buttons (weapon/rustning) at top of Forge tab and rerolling consumes 5 energy.
- [ ] Take Kjemiker T3; craft a bomb repeatedly and verify "Dobbel brygging" occasionally doubles output.
- [ ] Take Kjemiker T4; throw a bomb with enemies both inside and outside the radius and verify the chain hit (50% dmg).
- [ ] Take at least one skill from each of Geolog/Metallurg/Kjemiker; verify Transmutasjon row appears in the synergy list and the ↔ button works when you have ≥5 of an element.
- [ ] Craft and throw thermite in world 3/5/8 and verify damage scales noticeably higher than pre-rebalance (plus Def ignoring visibly lands on armoured monsters).
- [ ] Quit and reload a save made on this branch and confirm all new hero properties round-trip.
- [ ] Smoke-test `simulator.html` is still untouched.

https://claude.ai/code/session_01FHXkc6GijtFTVnV2XY5AJa