### PR TITLE
Pet enhancements: more HP, equipment, chemistry integration (#41)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ---
 
+## v0.41 – 2026-04-16
+
+### Nye funksjoner
+- **Forbedrede kjæledyr (#41):** Kjæledyrene har fått 60-80% mer basis-HP (Rev 8→14, Katt/Ugle 6→12, Drage 10→18) slik at de overlever lengre i kamp. Når kjæledyret dør øker eggsjansen på neste nivå fra 35% til 50% for å gjøre det lettere å få en ny kompanjong
+- **Kjæledyr-utstyr (#41):** Kjæledyrene har nå to utstyrsplasser (klo/våpen + rustning/halsbånd). 8 nye smidde gjenstander fra eksisterende legeringer: bronsekløer, ståltenner, wolframkløer, fosfortenner, bronsehalsbånd, stålsele, skandiumvest og titansele. Forges i Smi-fanen og utstyres automatisk på kjæledyret. Utstyr vises og håndteres i inventoret
+- **Kjæledyr-kjemi (#41):** 2 nye kjemiske oppskrifter for permanente kjæledyr-oppgraderinger: Kjæledyr-vitalitet (Ca+Fe+Mg) gir +3 permanent maks HP, og Vekst-elixir (La+Ca+P) gir +1 permanent angrep. Krever elements-mod-materialer
+- **Kjæledyr-utstyrspanel:** InventoryScene viser nå kjæledyrets utstyrsplasser med klo- og rustningsikon, samt utvidet stat-visning (inkludert DEF fra utstyr). Klikk for å fjerne utstyr tilbake til ryggsekken
+
+### Tekniske endringer
+- Pet.js: Ny `equipped` objekt med `weapon`/`armor` plasser; `effectiveAttack`/`effectiveMaxHp`/`effectiveDef` inkluderer utstyrsbonuser (`petAtk`/`petDef`/`petHp`). Nye `equipItem()`/`unequipItem()`-metoder. Serialisering/deserialisering inkluderer utstyr via PET_EQUIPMENT oppslag
+- alloys.js: Ny `PET_EQUIPMENT` konstant med 8 kjæledyr-gjenstander knyttes til eksisterende legeringer (bronse, stål, wolfram, fosfor, skandium, titan)
+- molecules.js: 2 nye kjæledyr-medisinoppskrifter (`pet_vitality`, `pet_growth`) med nye `onUse`-typer
+- ChemistrySystem: Nye `pet_permanent_hp` og `pet_permanent_atk` effekthandlere i `_createUsableItem()`
+- SmeltingSystem.getForgeableEquipment(): Returnerer nå PET_EQUIPMENT i tillegg til ALLOY_EQUIPMENT
+- SmelteryScene: Ny `_doPetForge()` – smir kjæledyr-utstyr og utstyrer det automatisk. Smi-fanen viser 🐾-merke på kjæledyr-gjenstander
+- InventoryScene: Ny `_makePetEquipSlot()` for utstyrsplasser; panelhøyde utvidet; stat-visning inkluderer DEF
+- ItemSpawner: Eggsjanse ved kjæledyr-død økt fra 35% til 50%
+
+---
+
 ## v0.40 – 2026-04-15
 
 ### Nye funksjoner

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,6 +1,6 @@
 # Labyrint Hero – Game Design Document
-**Versjon:** 0.40
-**Sist oppdatert:** 2026-04-15
+**Versjon:** 0.41
+**Sist oppdatert:** 2026-04-16
 
 ---
 

--- a/src/data/alloys.js
+++ b/src/data/alloys.js
@@ -275,6 +275,22 @@ const ALLOY_EQUIPMENT = {
     scandium_harness: { id: 'scandium_harness', name: 'Skandium-harnisk',    type: 'armor',  alloyId: 'scandium_alloy',   color: 0xbbddcc, def: 5, hearts: 3, desc: '+5 DEF, +3 HP (lettrustning)' },
 };
 
+// ── Pet equipment (forged from alloys at the Smeltery) ──────────────────────
+// petSlot: 'weapon' or 'armor'. petAtk/petDef/petHp are additive bonuses.
+
+const PET_EQUIPMENT = {
+    // Pet weapons (claws / fangs)
+    bronze_claws:    { id: 'bronze_claws',    name: 'Bronsekløer',       petSlot: 'weapon', alloyId: 'bronze',           color: 0xcc8844, petAtk: 2,              desc: '+2 ATK (kjæledyr)' },
+    steel_fangs:     { id: 'steel_fangs',     name: 'Ståltenner',        petSlot: 'weapon', alloyId: 'steel',            color: 0xaabbcc, petAtk: 3,              desc: '+3 ATK (kjæledyr)' },
+    tungsten_claws:  { id: 'tungsten_claws',  name: 'Wolframkløer',      petSlot: 'weapon', alloyId: 'tungsten_carbide', color: 0x556677, petAtk: 5,              desc: '+5 ATK (kjæledyr)' },
+    phosphor_fangs:  { id: 'phosphor_fangs',  name: 'Fosfortenner',      petSlot: 'weapon', alloyId: 'phosphor_crystal', color: 0xddffcc, petAtk: 4, petHp: 2,    desc: '+4 ATK, +2 HP (kjæledyr)' },
+    // Pet armor (collars / harnesses)
+    bronze_collar:   { id: 'bronze_collar',   name: 'Bronsehalsbånd',    petSlot: 'armor',  alloyId: 'bronze',           color: 0xcc8844, petDef: 1, petHp: 3,    desc: '+1 DEF, +3 HP (kjæledyr)' },
+    steel_harness:   { id: 'steel_harness',   name: 'Stålsele',          petSlot: 'armor',  alloyId: 'steel',            color: 0xaabbcc, petDef: 2, petHp: 4,    desc: '+2 DEF, +4 HP (kjæledyr)' },
+    scandium_vest:   { id: 'scandium_vest',   name: 'Skandiumvest',      petSlot: 'armor',  alloyId: 'scandium_alloy',   color: 0xbbddcc, petDef: 3, petHp: 6,    desc: '+3 DEF, +6 HP (kjæledyr)' },
+    titanium_harness:{ id: 'titanium_harness', name: 'Titansele',        petSlot: 'armor',  alloyId: 'titanium_alloy',   color: 0x99aacc, petDef: 4, petHp: 8,    desc: '+4 DEF, +8 HP (kjæledyr)' },
+};
+
 // ── Alloy tier colors (for UI) ──────────────────────────────────────────────
 
 const ALLOY_TIER_COLORS = {

--- a/src/data/molecules.js
+++ b/src/data/molecules.js
@@ -199,6 +199,24 @@ const MOLECULE_DEFS = {
         effects: { onUse: 'bomb', damage: 30, radius: 4, chain: 2 },
         desc: 'Plasmakjede. 30 skade, lyner til 2 naboer, radius 4.'
     },
+
+    // ── Pet-specific chemistry items ─────────────────────────────────────────
+    pet_vitality: {
+        id: 'pet_vitality', name: 'Kjæledyr-vitalitet', type: 'molecule', subtype: 'medicine',
+        formula: 'Ca + Fe + Mg', tier: 2, color: 0xffaadd, stackSize: 5,
+        recipe: [{ symbol: 'Ca', amount: 2 }, { symbol: 'Fe', amount: 1 }, { symbol: 'Mg', amount: 1 }],
+        energyCost: 1,
+        effects: { onUse: 'pet_permanent_hp', amount: 3 },
+        desc: 'Gir kjæledyr +3 permanent maks HP.'
+    },
+    pet_growth: {
+        id: 'pet_growth', name: 'Vekst-elixir', type: 'molecule', subtype: 'medicine',
+        formula: 'La + Ca + P', tier: 3, color: 0xddaaff, stackSize: 5,
+        recipe: [{ symbol: 'La', amount: 1 }, { symbol: 'Ca', amount: 1 }, { symbol: 'P', amount: 1 }],
+        energyCost: 2,
+        effects: { onUse: 'pet_permanent_atk', amount: 1 },
+        desc: 'Gir kjæledyr +1 permanent angrep.'
+    },
 };
 
 // ── Tier colors for molecules ────────────────────────────────────────────────

--- a/src/entities/Pet.js
+++ b/src/entities/Pet.js
@@ -2,10 +2,10 @@
 // A companion that follows the hero, assists in combat, and persists across worlds.
 
 const PET_TYPES = {
-    fox:    { name: 'Rev',      color: 0xff8833, attack: 1, maxHp: 8,  desc: 'Rask og lojal' },
-    cat:    { name: 'Katt',     color: 0xccaa66, attack: 1, maxHp: 6,  desc: 'Stille og presis' },
-    dragon: { name: 'Drage',    color: 0xff4466, attack: 2, maxHp: 10, desc: 'Liten men farlig' },
-    owl:    { name: 'Ugle',     color: 0x88aacc, attack: 1, maxHp: 6,  desc: 'Klok og skarpsynt' },
+    fox:    { name: 'Rev',      color: 0xff8833, attack: 1, maxHp: 14, desc: 'Rask og lojal' },
+    cat:    { name: 'Katt',     color: 0xccaa66, attack: 1, maxHp: 12, desc: 'Stille og presis' },
+    dragon: { name: 'Drage',    color: 0xff4466, attack: 2, maxHp: 18, desc: 'Liten men farlig' },
+    owl:    { name: 'Ugle',     color: 0x88aacc, attack: 1, maxHp: 12, desc: 'Klok og skarpsynt' },
 };
 
 class Pet {
@@ -25,6 +25,9 @@ class Pet {
 
         // Pet backpack (4 slots for carrying items)
         this.backpack = new Array(4).fill(null);
+
+        // Pet equipment (craftable at the Smeltery / Chemistry Lab)
+        this.equipped = { weapon: null, armor: null };
 
         this.graphics = scene.add.graphics();
         this.graphics.setDepth(4);
@@ -292,9 +295,35 @@ class Pet {
         };
     }
 
-    get effectiveAttack() { return this.attack + this._heroBonuses().atk; }
-    get effectiveMaxHp()  { return this.maxHp  + this._heroBonuses().hp; }
-    get effectiveDef()    { return this._heroBonuses().def; }
+    get effectiveAttack() {
+        const eq = this.equipped.weapon;
+        return this.attack + this._heroBonuses().atk + (eq ? (eq.petAtk || 0) : 0);
+    }
+    get effectiveMaxHp() {
+        const eqW = this.equipped.weapon, eqA = this.equipped.armor;
+        return this.maxHp + this._heroBonuses().hp
+            + (eqW ? (eqW.petHp || 0) : 0) + (eqA ? (eqA.petHp || 0) : 0);
+    }
+    get effectiveDef() {
+        const eq = this.equipped.armor;
+        return this._heroBonuses().def + (eq ? (eq.petDef || 0) : 0);
+    }
+
+    /** Equip a pet item. Returns the previously equipped item or null. */
+    equipItem(item) {
+        const slot = item.petSlot; // 'weapon' or 'armor'
+        if (!slot) return null;
+        const old = this.equipped[slot];
+        this.equipped[slot] = item;
+        return old;
+    }
+
+    /** Unequip an item from the given slot. Returns the item or null. */
+    unequipItem(slot) {
+        const old = this.equipped[slot];
+        this.equipped[slot] = null;
+        return old;
+    }
 
     // ── Combat ────────────────────────────────────────────────────────────────
 
@@ -435,18 +464,23 @@ class Pet {
     // ── Serialisation ─────────────────────────────────────────────────────────
 
     serialize() {
+        const serializeSlot = (entry) => {
+            if (!entry) return null;
+            if (entry.count !== undefined) return { id: entry.id, count: entry.count };
+            if (entry.rarity && entry.rarity !== 'common') return { id: entry.id, rarity: entry.rarity };
+            return entry.id || null;
+        };
         return {
             typeId:   this.typeId,
             hp:       this.hp,
             maxHp:    this.maxHp,
             attack:   this.attack,
             alive:    this.alive,
-            backpack: this.backpack.map(entry => {
-                if (!entry) return null;
-                if (entry.count !== undefined) return { id: entry.id, count: entry.count };
-                if (entry.rarity && entry.rarity !== 'common') return { id: entry.id, rarity: entry.rarity };
-                return entry.id || null;
-            }),
+            equipped: {
+                weapon: this.equipped.weapon ? this.equipped.weapon.id : null,
+                armor:  this.equipped.armor  ? this.equipped.armor.id  : null,
+            },
+            backpack: this.backpack.map(serializeSlot),
         };
     }
 
@@ -459,6 +493,16 @@ class Pet {
         pet.alive  = data.alive !== false;
         if (!pet.alive) {
             pet.graphics.setVisible(false);
+        }
+        // Restore pet equipment
+        if (data.equipped) {
+            const petItems = typeof PET_EQUIPMENT !== 'undefined' ? PET_EQUIPMENT : {};
+            if (data.equipped.weapon && petItems[data.equipped.weapon]) {
+                pet.equipped.weapon = petItems[data.equipped.weapon];
+            }
+            if (data.equipped.armor && petItems[data.equipped.armor]) {
+                pet.equipped.armor = petItems[data.equipped.armor];
+            }
         }
         // Restore pet backpack
         if (data.backpack) {

--- a/src/scenes/InventoryScene.js
+++ b/src/scenes/InventoryScene.js
@@ -24,7 +24,7 @@ class InventoryScene extends Phaser.Scene {
         const bpCount = this.inv.backpack.length;
         const bpRows = Math.ceil(bpCount / 5);
         const extraBpSpace = Math.max(0, (bpRows - 2) * 60);
-        const panelH = (hasPet ? 500 : 420) + extraBpSpace;
+        const panelH = (hasPet ? 560 : 420) + extraBpSpace;
         const panelY = cy;
         this.add.rectangle(cx, panelY, panelW, panelH, 0x0d0b1e).setStrokeStyle(2, 0x334466);
 
@@ -104,7 +104,7 @@ class InventoryScene extends Phaser.Scene {
         const bpCount = this.inv.backpack.length;
         const bpRows = Math.ceil(bpCount / 5);
         const extraBpSpace = Math.max(0, (bpRows - 2) * 60);
-        const panelH = (hasPet ? 500 : 420) + extraBpSpace;
+        const panelH = (hasPet ? 560 : 420) + extraBpSpace;
         const panelY = cy;
 
         // Update stats line
@@ -430,7 +430,8 @@ class InventoryScene extends Phaser.Scene {
 
         // Pet label with name and HP (to the right of portrait)
         const labelX = petPortX + petPortSize + 12;
-        const hpText = `${pet.petName}  HP: ${pet.hp}/${pet.effectiveMaxHp}  ATK: ${pet.effectiveAttack}`;
+        const defStr = pet.effectiveDef > 0 ? `  DEF: ${pet.effectiveDef}` : '';
+        const hpText = `${pet.petName}  HP: ${pet.hp}/${pet.effectiveMaxHp}  ATK: ${pet.effectiveAttack}${defStr}`;
         this._d(this.add.text(labelX, baseY, `KJÆLEDYR  ·  ${hpText}`, {
             fontSize: '13px', color: '#ffaadd', fontFamily: 'monospace'
         }));
@@ -439,11 +440,20 @@ class InventoryScene extends Phaser.Scene {
             fontSize: '13px', color: '#334455', fontFamily: 'monospace'
         }).setOrigin(1, 0));
 
+        // Pet equipment slots (weapon + armor)
+        const eqY = baseY + 18;
+        this._d(this.add.text(labelX, eqY, 'Utstyr:', {
+            fontSize: '12px', color: '#886688', fontFamily: 'monospace'
+        }));
+        const eqSlotSize = 42;
+        this._makePetEquipSlot(labelX + 54, eqY + eqSlotSize / 2 + 2, eqSlotSize, 'weapon', pet);
+        this._makePetEquipSlot(labelX + 54 + eqSlotSize + 8, eqY + eqSlotSize / 2 + 2, eqSlotSize, 'armor', pet);
+
         // Pet backpack slots (4 slots in a row, to the right of portrait)
         const slotSize = 52, gap = 8;
         const totalW = 4 * slotSize + 3 * gap;
         const startX = labelX;
-        const slotsY = baseY + 20;
+        const slotsY = eqY + eqSlotSize + 12;
 
         for (let i = 0; i < 4; i++) {
             const sx = startX + i * (slotSize + gap) + slotSize / 2;
@@ -529,6 +539,42 @@ class InventoryScene extends Phaser.Scene {
             bg.setInteractive({ useHandCursor: true });
             bg.on('pointerover', () => bg.setFillStyle(0x1a1830));
             bg.on('pointerout',  () => bg.setFillStyle(0x120a18));
+        }
+    }
+
+    /** Draw a pet equipment slot (weapon or armor). Tap to unequip back to hero backpack. */
+    _makePetEquipSlot(x, y, size, slot, pet) {
+        const item = pet.equipped[slot];
+        const label = slot === 'weapon' ? 'Klo' : 'Rust';
+        const col = item ? (item.color || 0xffaadd) : 0x1a0a1a;
+
+        const bg = this._d(this.add.rectangle(x, y, size, size, 0x1a0a1a).setStrokeStyle(1, col));
+        if (item) {
+            this._drawItemIcon(x, y, item, size - 8);
+            this._d(this.add.text(x, y + size / 2 - 2, item.name.length > 8 ? item.name.slice(0, 7) + '…' : item.name, {
+                fontSize: '10px', color: '#ffaadd', fontFamily: 'monospace'
+            }).setOrigin(0.5, 1));
+            bg.setInteractive({ useHandCursor: true });
+            bg.on('pointerover', () => {
+                bg.setFillStyle(0x2a1a2a);
+                this._showTooltip(x, y - size / 2 - 4, item);
+            });
+            bg.on('pointerout', () => { bg.setFillStyle(0x1a0a1a); this._hideTooltip(); });
+            bg.on('pointerdown', () => {
+                this._hideTooltip();
+                const removed = pet.unequipItem(slot);
+                if (removed) {
+                    // Try to put in hero inventory, otherwise drop on ground.
+                    if (!this.inv.addItem(removed)) {
+                        EventBus.emit('spawnItem', { gx: this.hero.gridX, gy: this.hero.gridY, item: removed });
+                    }
+                }
+                this._refresh();
+            });
+        } else {
+            this._d(this.add.text(x, y, label, {
+                fontSize: '11px', color: '#443344', fontFamily: 'monospace'
+            }).setOrigin(0.5));
         }
     }
 

--- a/src/scenes/SmelteryScene.js
+++ b/src/scenes/SmelteryScene.js
@@ -836,13 +836,17 @@ class SmelteryScene extends Phaser.Scene {
                 if (adjY > visBot) { return; }
                 if (adjY < visTop - 40) return;
 
+                const isPet = !!equip.petSlot;
                 const hexCol = '#' + (equip.color || 0xaabbcc).toString(16).padStart(6, '0');
+                const typeLabel = isPet
+                    ? (equip.petSlot === 'weapon' ? '🐾 Kjæledyr-klo' : '🐾 Kjæledyr-rust')
+                    : (equip.type === 'weapon' ? 'Våpen' : 'Rustning');
 
                 const bg = this._d(this.add.graphics());
                 bg.fillStyle(equip.color || 0xaabbcc, 0.08);
                 bg.fillRoundedRect(startX + 10, adjY, colW - 20, 40, 3);
 
-                this._d(this.add.text(startX + 18, adjY + 6, `${equip.name} (${equip.type === 'weapon' ? 'Våpen' : 'Rustning'})`, {
+                this._d(this.add.text(startX + 18, adjY + 6, `${equip.name} (${typeLabel})`, {
                     fontSize: '14px', color: hexCol, fontFamily: 'monospace'
                 }));
                 this._d(this.add.text(startX + 18, adjY + 22, equip.desc, {
@@ -851,11 +855,11 @@ class SmelteryScene extends Phaser.Scene {
                 }));
 
                 const btn = this._d(this.add.text(startX + colW - 70, adjY + 12, '[ Smi ]', {
-                    fontSize: '14px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
+                    fontSize: '14px', color: isPet ? '#ffaadd' : '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
                 }).setInteractive({ useHandCursor: true }));
-                btn.on('pointerover', () => btn.setColor('#ffaa44'));
-                btn.on('pointerout', () => btn.setColor('#ff7722'));
-                btn.on('pointerdown', () => this._doForge(alloyId, equip.id));
+                btn.on('pointerover', () => btn.setColor(isPet ? '#ffccee' : '#ffaa44'));
+                btn.on('pointerout', () => btn.setColor(isPet ? '#ffaadd' : '#ff7722'));
+                btn.on('pointerdown', () => isPet ? this._doPetForge(alloyId, equip) : this._doForge(alloyId, equip.id));
             });
             rowY += 8;
         }
@@ -878,6 +882,38 @@ class SmelteryScene extends Phaser.Scene {
         }
 
         EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `Smidd: ${result.item.name}!`, color: '#ffaa44' });
+
+        Audio.playPickup();
+        this._refresh();
+    }
+
+    /** Forge a pet equipment piece (claws / collar / harness). */
+    _doPetForge(alloyId, petEquipDef) {
+        const hero = this.heroRef;
+        if (!hero.alloyInventory || (hero.alloyInventory[alloyId] || 0) < 1) return;
+
+        hero.alloyInventory[alloyId]--;
+        if (hero.alloyInventory[alloyId] <= 0) delete hero.alloyInventory[alloyId];
+
+        // Try to equip directly on the pet (auto-swap with old item to hero backpack).
+        const gs = this.scene.get('GameScene');
+        const pet = gs && gs.pet && gs.pet.alive ? gs.pet : null;
+        if (pet) {
+            const old = pet.equipItem(petEquipDef);
+            if (old) {
+                // Unequipped previous item → put in hero backpack or drop.
+                if (!hero.inventory.addItem(old)) {
+                    EventBus.emit('spawnItem', { gx: hero.gridX, gy: hero.gridY, item: old });
+                }
+            }
+            EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `${pet.petName}: ${petEquipDef.name}!`, color: '#ffaadd' });
+        } else {
+            // No living pet: put the item in hero's backpack for later.
+            if (!hero.inventory.addItem(petEquipDef)) {
+                EventBus.emit('spawnItem', { gx: hero.gridX, gy: hero.gridY, item: petEquipDef });
+            }
+            EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `Smidd: ${petEquipDef.name}`, color: '#ffaadd' });
+        }
 
         Audio.playPickup();
         this._refresh();

--- a/src/systems/ChemistrySystem.js
+++ b/src/systems/ChemistrySystem.js
@@ -242,6 +242,23 @@ class ChemistrySystem {
                 hero.addTempBuff('invisible', 1, dur);
                 return true;
             };
+        } else if (eff.onUse === 'pet_permanent_hp') {
+            const amt = eff.amount || 2;
+            item.desc = `Kjæledyr +${amt} permanent maks HP`;
+            item.use = (hero, scene) => {
+                if (!scene || !scene.pet || !scene.pet.alive) return false;
+                scene.pet.maxHp += amt;
+                scene.pet.hp = Math.min(scene.pet.hp + amt, scene.pet.effectiveMaxHp);
+                return true;
+            };
+        } else if (eff.onUse === 'pet_permanent_atk') {
+            const amt = eff.amount || 1;
+            item.desc = `Kjæledyr +${amt} permanent angrep`;
+            item.use = (hero, scene) => {
+                if (!scene || !scene.pet || !scene.pet.alive) return false;
+                scene.pet.attack += amt;
+                return true;
+            };
         }
 
         return item;

--- a/src/systems/ItemSpawner.js
+++ b/src/systems/ItemSpawner.js
@@ -27,9 +27,12 @@ class ItemSpawner {
 
         // 3. Pet egg (one per world, if hero has no pet or pet is dead)
         if (!scene.pet || !scene.pet.alive) {
+            // Track whether the hero had a pet that died so we can bump spawn rate.
+            const hadPetDie = !!(scene.pet && !scene.pet.alive);
             // Clear dead pet so a new one can be hatched
             if (scene.pet && !scene.pet.alive) scene.pet = null;
-            const eggChance = scene.worldNum === 1 ? 0.8 : 0.35;
+            // 80% on world 1, 50% if previous pet died, 35% otherwise.
+            const eggChance = scene.worldNum === 1 ? 0.8 : (hadPetDie ? 0.50 : 0.35);
             if (Math.random() < eggChance) {
                 // Find a free floor tile not used by chests or items
                 const eggTile = eligible.find(t =>

--- a/src/systems/SmeltingSystem.js
+++ b/src/systems/SmeltingSystem.js
@@ -162,13 +162,19 @@ class SmeltingSystem {
     // ── Forging: Alloy → Equipment ───────────────────────────────────────────
 
     /**
-     * Get equipment that can be forged from a given alloy.
+     * Get equipment that can be forged from a given alloy (hero + pet items).
      * @param {string} alloyId
-     * @returns {Array<object>} Array of ALLOY_EQUIPMENT items
+     * @returns {Array<object>} Array of ALLOY_EQUIPMENT + PET_EQUIPMENT items
      */
     getForgeableEquipment(alloyId) {
-        if (typeof ALLOY_EQUIPMENT === 'undefined') return [];
-        return Object.values(ALLOY_EQUIPMENT).filter(e => e.alloyId === alloyId);
+        const items = [];
+        if (typeof ALLOY_EQUIPMENT !== 'undefined') {
+            items.push(...Object.values(ALLOY_EQUIPMENT).filter(e => e.alloyId === alloyId));
+        }
+        if (typeof PET_EQUIPMENT !== 'undefined') {
+            items.push(...Object.values(PET_EQUIPMENT).filter(e => e.alloyId === alloyId));
+        }
+        return items;
     }
 
     /**


### PR DESCRIPTION
Closes #41.

## Summary

- **Pet HP buff**: Fox 8→14, Cat/Owl 6→12, Dragon 10→18 (~70% more). Pets no longer die on first hit from mid-game monsters.
- **Egg respawn boost**: When pet dies, next-level egg chance rises from 35% to 50% so the player doesn't spend many levels without a companion.
- **Pet equipment system**: Two new slots (weapon + armor) on Pet. 8 craftable items forged from existing elements-mod alloys at the Smeltery: bronze claws (+2 ATK), steel fangs (+3), tungsten claws (+5), phosphor fangs (+4 ATK/+2 HP), bronze collar (+1 DEF/+3 HP), steel harness (+2 DEF/+4 HP), scandium vest (+3 DEF/+6 HP), titanium harness (+4 DEF/+8 HP). Auto-equips on living pet on forge, with old item swapped to hero backpack.
- **Pet chemistry**: 2 new molecules using elements-mod materials — Pet Vitality (Ca+Fe+Mg → +3 permanent max HP) and Growth Elixir (La+Ca+P → +1 permanent ATK).
- **UI**: InventoryScene shows pet equipment slots with unequip-on-tap. SmelteryScene forge tab labels pet items with 🐾 in pink. Pet stat line now includes DEF.

## Test plan
- [ ] Open `index.html`; hatch a pet egg in world 1 (80% chance) — verify base HP is higher (Fox should show 14 HP, etc.)
- [ ] Let the pet die; advance to next level — verify egg spawns more reliably (50% vs 35%)
- [ ] At a camp room with bronze alloy: forge bronze claws and bronze collar. Verify 🐾 label in forge tab and auto-equip on pet.
- [ ] Open inventory (I key): verify pet section shows two equipment slots (Klo/Rust) with items. Tap to unequip back to hero backpack.
- [ ] In chem lab with Ca+Fe+Mg: craft Pet Vitality potion. Use it from inventory while pet is alive — verify pet max HP goes up by 3.
- [ ] Save and reload — verify pet equipment round-trips correctly.
- [ ] Kill the pet, try to use pet_vitality or pet_growth → should fail silently (returns false, item not consumed).

https://claude.ai/code/session_01FHXkc6GijtFTVnV2XY5AJa