### PR TITLE
Phase 5: Physicist skill path, 118 elements, transuranic synthesis (v0.42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,46 @@ Et 2D topp-ned labyrint-RPG i nettleseren. Naviger prosedyregenererte labyrinter
 
 ## Funksjoner
 
-- Prosedyregenererte labyrinter med 5 tematiske verdener (skog, grotte, is, vulkan, tempel)
+### Kjerne
+- Prosedyregenererte labyrinter med 25 etasjer fordelt på 5 geologiske soner (overflatelag → jordens kjerne)
 - Rute-for-rute bevegelse med nærkamp og bueangrep
 - 4 spillbare raser med unike bonuser
-- 12 passive evner fordelt på 4 spesialiseringsveier + kryssvei-synergier
-- 27 gjenstander: våpen, rustning, forbruksgjenstander og verktøy med sjeldenhetsystem
-- Bosser med fase 2-mekanikk
+- Bosser med fase 2-mekanikk, sonebosser vokter inngangen til nye soner
 - Kjøpmann-NPC, kister, feller, låste dører og hemmelige passasjer
+- Kjæledyr-system med 4 dyretyper (rev, katt, drage, ugle) – utstyrsplasser, ryggsekk og kampstøtte
+- Tre vanskelighetsgrader, lagring via localStorage, lokal + global ledertavle
+
+### Elements-modifikasjon (det periodiske system)
+- **118 grunnstoffer** – alle fra hydrogen til oganesson, basert på ekte kjemi og geokjemi
+- **50+ mineraler** å finne, smelte og utvinne grunnstoffer fra
+- **Legeringer og smiing** – 13+ legeringer (bronse → Pt-Ir, skandium, wolframkarbid, fosforkrystall) smidd til våpen og rustning
+- **Kjemisk laboratorium** – 20+ oppskrifter: potions, bomber, medisiner, syrer. Thermittladning, plasmakjerne, neodym-magnetbombe m.m.
+- **Partikkelakselerator** – 28 realistiske transuranske synteseoppskrifter basert på ekte kjernefysikk (nøytronbombardering, alfa-bombardering, tungione-kollisjoner, Ca-48 varmfusjon)
+- **Fisjon/fusjon-energi** – uran og thorium driver fisjon, hydrogen + litium driver D-T-fusjon
+- **Endgame** – samle alle 118 grunnstoffer for «Guds periodiske system»-belønning
+
+### Ferdighetssystem
+- **6 skill-stier** med 3–4 tiers hver + kryssvei-synergier:
+  - Kriger (kamp/forsvar), Villmarksjeger (syn/presisjon/kjæledyr)
+  - Geolog (mineralfunn), Metallurg (smelting/smiing), Kjemiker (potions/bomber)
+  - Fysiker (halvledere/fisjon/fusjon – endgame)
+- 12 kryssvei-synergier inkludert Transmutasjon (3-sti) og Atomsmedja (fysiker+metallurg)
+
+### Grafikk og lyd
 - Prosedyregrafikk og prosedyremusikk – ingen eksterne assets
-- Lagring via localStorage, ledertavle med tidssporing
-- Tre vanskelighetsgrader: lett, normal, vanskelig
+- Touch-støtte med D-pad og handlingsknapper for mobil/nettbrett
 
 ## Hurtigstart
 
 Åpne `index.html` i en nettleser – ingen bygging eller installasjon nødvendig.
 
 For balansetesting, bruk `simulator.html`.
+
+## CI
+
+GitHub Actions kjører automatisk på push og PR:
+- **JS syntax check** – `node --check` på alle kildefiler
+- **Browser tests** – headless Chromium via Playwright kjører `tests/test-runner.html`
 
 ## Teknologi
 
@@ -31,46 +55,76 @@ For balansetesting, bruk `simulator.html`.
 ## Mappestruktur
 ```
 src/
-  constants.js                – konstanter og verdens-temaer
-  maze.js                     – labyrintgenerator (DFS + ekstra passasjer)
+  constants.js                – konstanter, soner og verdens-temaer
+  maze.js                     – labyrintgenerator (DFS + spesialrom)
   main.js                     – Phaser-oppstart
   utils/
     SaveManager.js            – localStorage-lagring
-    Leaderboard.js            – ledertavle
+    Leaderboard.js            – lokal ledertavle
+    GlobalLeaderboard.js      – global ledertavle (Cloudflare Worker)
+    UIHelper.js               – felles UI-hjelpefunksjoner
+    EventBus.js               – event-system
   data/
-    skills.js                 – 12 evner + synergier
-    items.js                  – 27 gjenstander + sjeldenhet
+    skills.js                 – 6 skill-stier + synergier
+    elements.js               – 118 grunnstoffer + transuranske oppskrifter
+    minerals.js               – 50+ mineraler og krystaller
+    alloys.js                 – legeringer, brensel, utstyr, kjæledyr-utstyr
+    molecules.js              – kjemiske oppskrifter (potions, bomber, medisin)
+    items.js                  – våpen, rustning, forbruk + sjeldenhetssystem
+    musicPieces.js            – prosedyremusikk-definisjoner
   graphics/
-    CharacterSprite.js        – prosedyrekaraktertegning
+    CharacterSprite.js        – prosedyre-karaktertegning
+    DetailedCharacterSprite.js – detaljert portrett
+    SceneBackgrounds.js       – tematiske bakgrunner for overlay-scener
+    ItemGraphics.js           – gjenstandsgrafikk
+    MonsterGraphics.js        – monstergrafikk
   systems/
+    ElementTracker.js         – element-samling og gruppebonuser
+    SmeltingSystem.js         – smelting, legeringer, smiing, fisjon/fusjon-energi
+    ChemistrySystem.js        – kjemisk syntese + transmutasjon
     Inventory.js              – utstyr + ryggsekk
     AudioManager.js           – prosedyremusikk og SFX
     TouchControls.js          – mobilkontroller
-    MapRenderer.js            – kartrendering, tåke, portal
-    ItemSpawner.js            – kister, verktøy, gjenstander, kjøpmann
+    MapRenderer.js            – kartrendering, tåke, mineral-syn
+    ItemSpawner.js            – kister, mineraler, kjøpmann, kjæledyr-egg
     MonsterManager.js         – monsterplassering, AI, statuseffekter
     CombatManager.js          – kamp, bue, skadeberegning
     InputHandler.js           – tastatur/touch, bevegelse, zoom
   entities/
     Hero.js                   – spillerkarakter
+    HeroCrafting.js           – crafting-state (elementer, metallurgi, kjemi, fysikk)
     Monster.js                – fiender med unike sprites
+    Pet.js                    – kjæledyr-følgesvenn med utstyr og ryggsekk
   scenes/
     MenuScene.js              – hovedmeny
-    CharacterCreatorScene.js  – karakterskaper
+    CharacterCreatorScene.js  – karakterskaper med 4 raser
     GameScene.js              – orkestrator-scene
-    UIScene.js                – HUD-overlay
-    SkillScene.js             – evnevalg ved nivå-opp
-    InventoryScene.js         – inventar-overlay
+    UIScene.js                – HUD-overlay med minikart
+    SkillScene.js             – ferdighetstreet
+    InventoryScene.js         – inventar + kjæledyr-utstyr
     MerchantScene.js          – kjøpmann-overlay
+    SmelteryScene.js          – smelteovn / leirplass (4 faner)
+    ChemLabScene.js           – kjemisk laboratorium
+    AcceleratorScene.js       – partikkelakselerator (transuransk syntese)
+    ElementBookScene.js       – periodisk system / elementbok
     SettingsScene.js          – lydinnstillinger
-    LeaderboardScene.js       – ledertavle
+    LeaderboardScene.js       – lokal + global ledertavle
     GameOverScene.js          – død/seier-skjerm
+backend/
+  worker.js                   – Cloudflare Worker for global ledertavle
+tests/
+  test-runner.html            – nettleserbasert testsuiteCI
+  ci-runner.js                – headless Playwright-runner for CI
+  framework.js                – minimalt testrammeverk
+  test-*.js                   – testsuiter
 docs/
   GDD.md                      – Game Design Document
   CHANGELOG.md                – endringslogg
+  Elements-mod.md             – Elements-modifikasjon designdokument
 ```
 
 ## Dokumentasjon
 
 - [Game Design Document](docs/GDD.md) – Full spillbeskrivelse og regler
 - [Endringslogg](docs/CHANGELOG.md) – Versjonshistorikk
+- [Elements-modifikasjon](docs/Elements-mod.md) – Det periodiske system i spillet

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@
 - **Partikkelakselerator-rom:** Dukker opp fra verden 13 (20% sjanse), garantert fra verden 15. Åpnes med P-tast. Komplett UI med scrollbar, energikostnad og tier-gating
 - **Realistisk transuran syntese:** Hver oppskrift gjenspeiler ekte kjernefysikk – nøytronbombardering for Np/Pu, alfa-bombardering for Cm, tungione-bombardering for transaktinider, Ca-48 varmfusjon for supertunge (Fl-Og). Krever tilhørende input-grunnstoffer som forbrukes
 - **Fysiker-skillsti (6. sti):** T1 Halvledergrunnlag (halvledercrafting + mineraltiltrekning), T2 Strålingsshield (immunitet mot stråling + loot-bonus), T3 Fisjonsbeherskelse (2× energi fra U/Th, låser tier 1-3 syntetiske), T4 Fusjonspioner (5× energi fra He, låser alle syntetiske)
-- **Fisjon/fusjon-energi:** U gir 50 virtuell energi (×2 med Fisjon T3), Th gir 40. He gir 200 (×5 med Fusjon T4). Gjør endgame-syntese gjennomførbar
+- **Fisjon/fusjon-energi:** U gir 50 virtuell energi (×2 med Fisjon T3), Th gir 40. Fusjon bruker D-T-reaksjonen: H (deuterium, 80 energi) + Li (tritiumkilde via Li-6+nøytron, 150 energi), ×5 med Fusjon T4. He er biprodukt, ikke brensel. Gjør endgame-syntese gjennomførbar
 - **15 nye mineraler:** Vanadinitt (V – fikser uraftbar titanleger.), bromargyryt (Br), jodyritt (I), germanitt (Ge), stibnitt (Sb), gallitt (Ga), xenotim (Y+Dy+Er+Yb), samarskitt (Sm+Gd+Pr), celestin (Sr), pollucitt (Cs+Rb), calaveritt (Te+Au), inditt (In), thoritt (Th). PGM-malm gir nå også Pt, Ir og Os
 - **Edelgass-samling:** Gasslommer (verden 10+) gir nå 1-2 tilfeldige edelgasser (Ar/Kr/Xe/Ne/He) direkte i elementtrakeren
 - **Endgame: Guds periodiske system:** Samle alle 118 grunnstoffer gir +10 ATK, +10 DEF, +5 hjerter, +3 syn og tittelen «Guds periodiske system»

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ---
 
+## v0.42 – 2026-04-16
+
+### Nye funksjoner
+- **Fase 5: Fysikk og transurane grunnstoffer** – Alle 118 grunnstoffer er nå i spillet. 28 syntetiske elementer (Tc, Pm, Np-Og) må produseres i partikkelakseleratoren
+- **Partikkelakselerator-rom:** Dukker opp fra verden 13 (20% sjanse), garantert fra verden 15. Åpnes med P-tast. Komplett UI med scrollbar, energikostnad og tier-gating
+- **Realistisk transuran syntese:** Hver oppskrift gjenspeiler ekte kjernefysikk – nøytronbombardering for Np/Pu, alfa-bombardering for Cm, tungione-bombardering for transaktinider, Ca-48 varmfusjon for supertunge (Fl-Og). Krever tilhørende input-grunnstoffer som forbrukes
+- **Fysiker-skillsti (6. sti):** T1 Halvledergrunnlag (halvledercrafting + mineraltiltrekning), T2 Strålingsshield (immunitet mot stråling + loot-bonus), T3 Fisjonsbeherskelse (2× energi fra U/Th, låser tier 1-3 syntetiske), T4 Fusjonspioner (5× energi fra He, låser alle syntetiske)
+- **Fisjon/fusjon-energi:** U gir 50 virtuell energi (×2 med Fisjon T3), Th gir 40. He gir 200 (×5 med Fusjon T4). Gjør endgame-syntese gjennomførbar
+- **15 nye mineraler:** Vanadinitt (V – fikser uraftbar titanleger.), bromargyryt (Br), jodyritt (I), germanitt (Ge), stibnitt (Sb), gallitt (Ga), xenotim (Y+Dy+Er+Yb), samarskitt (Sm+Gd+Pr), celestin (Sr), pollucitt (Cs+Rb), calaveritt (Te+Au), inditt (In), thoritt (Th). PGM-malm gir nå også Pt, Ir og Os
+- **Edelgass-samling:** Gasslommer (verden 10+) gir nå 1-2 tilfeldige edelgasser (Ar/Kr/Xe/Ne/He) direkte i elementtrakeren
+- **Endgame: Guds periodiske system:** Samle alle 118 grunnstoffer gir +10 ATK, +10 DEF, +5 hjerter, +3 syn og tittelen «Guds periodiske system»
+- **Nye synergier:** Atomsmedja (Fysiker+Metallurg: +3 ATK, −25% akselerator-energi) og Kvantekjemi (Fysiker+Kjemiker: +30% potion, +20% bomberadius)
+
+### Feilrettinger
+- **Handelsmann NaN-pris:** Brenselprisen brukte `fuel.energy` (undefined) i stedet for `fuel.energyValue`. Naturgass viste «NaNg»
+
+### Tekniske endringer
+- elements.js: 118 elementer (90 naturlige + 28 syntetiske med `synthetic: true`). TRANSURANIC_RECIPES med 28 oppskrifter. Ny TOTAL_ALL_ELEMENTS-konstant. `all_92_natural`-bonus filtrerer nå ut syntetiske
+- minerals.js: 15 nye mineraler i MINERAL_DEFS og MINERAL_POOL
+- skills.js: Ny `fysiker`-sti med 4 tiers + `accelerator_found` unlockCondition + 2 nye synergier
+- AcceleratorScene.js: Komplett overlay-scene med scrolling, tier-gating, element-forbruk og energikostnad
+- SmeltingSystem: `calculateFuelEnergy()` legger nå til virtuell energi fra U/Th (fisjon) og He (fusjon)
+- ElementTracker: `applyBonusRewards()` støtter nå `godMode`-belønning
+- GameScene: Ny `_checkAccelerator()` + P-tast for å åpne akseleratoren
+- maze.js: Ny `accelerator`-romtype fra verden 13+
+- HeroCrafting: 10 nye hero-egenskaper for fysikerstate
+- ItemSpawner: Edelgass-samling fra gasslommer, fikset `fuel.energyValue`
+
+---
+
 ## v0.41 – 2026-04-16
 
 ### Nye funksjoner

--- a/docs/Elements-mod.md
+++ b/docs/Elements-mod.md
@@ -1,7 +1,7 @@
 # Labyrint Hero – Elements-modifikasjon
-**Versjon:** 0.4 (fase 1–4 fullført, orphan-oppryddning v0.40)
-**Sist oppdatert:** 2026-04-15
-**Status:** Fase 1–4 implementert. Fase 5 (Fysikk) utsatt.
+**Versjon:** 0.5 (fase 1–5 implementert)
+**Sist oppdatert:** 2026-04-16
+**Status:** Alle 5 faser implementert. 118 grunnstoffer, 28 transuranske synteseoppskrifter, partikkelakselerator, fysiker-skillsti, fisjon/fusjon-energi og «Guds periodiske system»-endgame.
 
 **v0.40-oppdatering:** 2 nye mineraler (molybdenitt, barytt) og 5 nye legeringer + 8 nye molekyler gir praktisk bruk for Mn, Mo, W, Ta, Ba, B, Ce, La, Nd, Zn. Bombeskade er separert fra potionskala og skalerer +60% per verden (mot +40% før) med flat bombgulv; radius +1 fra verden 5 og +2 fra verden 8. Geolog/Metallurg/Kjemiker har fått T4-ferdigheter (Geode-splitter, Reforge, Volatil mestring) og en 3-sti-synergi Transmutasjon (5 → 1 nabo på atomnummer). Se CHANGELOG v0.40 for full diff.
 
@@ -477,14 +477,18 @@ Med en dypere verden trenger spilleren bedre kartlegging:
 - [x] Hurtigreise mellom fullførte soner (v0.37 – knapp på seiersskjerm)
 - [x] Utvidet minikart med Geolog-skills (v0.37 – mineraler vises som fargede prikker)
 
-### Fase 5 – Fysikk og endgame (Issue-prioritet: Lav)
-- [ ] Halvleder-crafting (Si, Ge, GaAs)
-- [ ] Fisjon-reaktor og U-235 beriker
-- [ ] Jordens kjerne-sone (etasje 19–25)
-- [ ] Fusjonsteknologi
-- [ ] Fysiker-sti i skill tree (låses opp via elementbok)
-- [ ] Syntetiske grunnstoffer (Tc, Pm, alle > 92)
-- [ ] Endgame: Alle 92/118 grunnstoffer samlet
+### Fase 5 – Fysikk og transurane grunnstoffer ✅ (v0.42)
+- [x] 28 syntetiske grunnstoffer (Tc, Pm, Np-Og) med `synthetic: true`-flagg
+- [x] TRANSURANIC_RECIPES: 28 oppskrifter som gjenspeiler ekte kjernefysikk (nøytron, alfa, tungioner, Ca-48 varmfusjon)
+- [x] Partikkelakselerator-rom (verden 13+, P-tast) med komplett AcceleratorScene UI
+- [x] Fysiker-skillsti: T1 Halvleder, T2 Strålingsskjold, T3 Fisjon (2× U/Th-energi), T4 Fusjon (5× He-energi)
+- [x] Fisjon/fusjon-energi: U=50, Th=40, He=200 virtuell energi i calculateFuelEnergy()
+- [x] 15 nye mineraler (V, Br, I, Ge, Sb, Ga, Y, Dy, Er, Yb, Sm, Gd, Pr, Sr, Cs, Rb, Te, In, Th) + PGM-malm med Pt/Ir/Os
+- [x] Edelgass-samling fra gasslommer (verden 10+)
+- [x] Endgame «Guds periodiske system»: +10/+10/+5/+3 for alle 118
+- [x] 2 nye synergier (Atomsmedja, Kvantekjemi)
+- [ ] Halvleder-crafting items (Si-wafer, Ge-crystal, GaAs) – fremtidig
+- [ ] Jordens kjerne-sone visuelt tema – fremtidig
 
 ---
 

--- a/docs/Elements-mod.md
+++ b/docs/Elements-mod.md
@@ -81,7 +81,7 @@ Ekstremt sjeldne – endgame.
 | U | Uran | 92 | Aktinide | Uraninitt (blendens) | Muliggjør fisjon |
 | Th | Thorium | 90 | Aktinide | Monazitt | Alternativ fisjon |
 | Ra | Radium | 88 | Aktinide | Uranmalm (biprodukt) | Magisk glød, boost |
-| He | Helium | 2 | Edelgass | Gasslommer i berg | Muliggjør fusjon |
+| He | Helium | 2 | Edelgass | Gasslommer i berg | Biprodukt av fusjon. Samles fra gasslommer (v10+) |
 | Ir | Iridium | 77 | PGM | Ekstremt sjelden malm | Hardeste legering |
 
 ---
@@ -234,8 +234,8 @@ Energi er en ressurs som kreves for smelteprosesser og avansert teknologi. Spill
 | Trekull | 1 | 2 | Ingen | Laget av tre i begrenset luft |
 | Olje (råolje) | 2 | 8 | Bore-skill | Finnes i dype lag |
 | Naturgass | 2 | 10 | Bore-skill | Finnes med olje |
-| Fisjon (U-235) | 3 | 1000 | U + reaktor | Uran må berikes |
-| Fusjon (D-T) | 4 | 10000 | He-3 + fusjonsteknologi | Endgame |
+| Fisjon (U/Th) | 3 | 50/40 per enhet | Fysiker T3 | U og Th gir virtuell energi (×2 med skill) |
+| Fusjon (D-T) | 4 | H:80, Li:150 | Fysiker T4 | Deuterium + Li (tritiumkilde), ×5 med skill |
 
 ### 7.2 Energiteknologi-tre
 

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,5 +1,5 @@
 # Labyrint Hero – Game Design Document
-**Versjon:** 0.41
+**Versjon:** 0.42
 **Sist oppdatert:** 2026-04-16
 
 ---

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -576,8 +576,44 @@ Spillet utvides fra 7 verdener til 25 etasjer fordelt på 5 geologiske soner.
 
 **Nye spesialrom:** Malmkammer (5+), Hydrotermalkilde (8+), Gasslomme (10+), Magmakammer (18+).
 
-### Fremtidige faser (ikke implementert)
-- Fase 5: Fysikk og endgame (halvledere, fisjon, fusjon)
+### Fase 5: Fysikk og transurane grunnstoffer (v0.42)
+
+Avansert kjernefysikk, syntetiske grunnstoffer og endgame-mål.
+
+**Alle 118 grunnstoffer:** 90 naturlige finnes via mineraler og gasslommer. 28 syntetiske (Tc, Pm, Np–Og) må produseres i partikkelakseleratoren. Oppskriftene gjenspeiler ekte kjernefysikk.
+
+**Partikkelakselerator:** Spesialrom fra verden 13+ (garantert verden 15+). Åpnes med P-tast. Scrollbart UI med alle 28 transuranske synteseoppskrifter. Forbruker mål-element + prosjektil-element + energi. Tier-gating: tier 1–3 krever Fisjon-skill, tier 4–6 krever Fusjon-skill.
+
+**Transuransk syntese (28 oppskrifter):**
+| Metode | Eksempel | Tier |
+|--------|----------|------|
+| Nøytronbombardering | U + nøytron → Np, Pu | 1 |
+| Alfa-bombardering (He-4) | Pu + He → Cm | 2–3 |
+| Tungione-kollisjoner | Bi + Cr → Bh, Pb + Fe → Hs | 4–5 |
+| Ca-48 varmfusjon | Cf + Ca → Og (2000 energi!) | 6 |
+
+**Fisjon/fusjon-energi:**
+- Fisjon: Hvert U i elementtrakeren gir 50 virtuell energi (×2 med Fysiker T3), Th gir 40.
+- Fusjon (D-T): H (deuterium) gir 80 energi, Li (tritiumkilde via Li-6 + nøytron → tritium) gir 150 energi, ×5 med Fysiker T4. He er biprodukt, ikke brensel.
+
+**Fysiker-skillsti:**
+Låses opp ved første besøk i partikkelakselerator. Krever ≥1 Kjemiker-skill.
+| Tier | Skill | Effekt |
+|------|-------|--------|
+| T1 | Halvledergrunnlag | Halvleder-crafting, +1 mineral-tiltrekningsradius per stack (maks 3) |
+| T2 | Strålingsshield | Radioaktive gir ikke HP-tap, +1 min loot-tier per stack (maks 2) |
+| T3 | Fisjonsbeherskelse | 2× reaktor-energi fra U/Th, låser tier 1–3 syntetiske (maks 1) |
+| T4 | Fusjonspioner | 5× fusjonsenergi fra H+Li, låser ALLE syntetiske inkl. supertunge (maks 1) |
+
+**Nye synergier:**
+| Synergi | Stier | Effekt |
+|---------|-------|--------|
+| Atomsmedja | Fysiker + Metallurg | +3 ATK, −25% akselerator-energi |
+| Kvantekjemi | Fysiker + Kjemiker | +30% potion-styrke, +20% bomberadius |
+
+**Edelgass-samling:** Gasslommer (verden 10+) gir 1–2 tilfeldige edelgasser (Ar, Kr, Xe, Ne, He) direkte i elementtrakeren.
+
+**Endgame:** Samle alle 118 grunnstoffer utløser «Guds periodiske system» – +10 ATK, +10 DEF, +5 hjerter, +3 synsfelt.
 
 Se `docs/Elements-mod.md` for fullstendig designdokument.
 

--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
 <script src="src/scenes/ElementBookScene.js"></script>
 <script src="src/scenes/SmelteryScene.js"></script>
 <script src="src/scenes/ChemLabScene.js"></script>
+<script src="src/scenes/AcceleratorScene.js"></script>
 
 <!-- Boot -->
 <script src="src/main.js"></script>

--- a/src/data/elements.js
+++ b/src/data/elements.js
@@ -105,6 +105,36 @@ const ELEMENTS = {
     Er: { symbol: 'Er', name: 'Erbium',     atomicNumber: 68, category: 'lanthanide',  period: 6, group: 3,  tier: 4, color: 0xddbbcc, foundNative: false, stackSize: 99, description: 'Rosa lantanide. Brukes i fiberoptikk.' },
     Yb: { symbol: 'Yb', name: 'Ytterbium',  atomicNumber: 70, category: 'lanthanide',  period: 6, group: 3,  tier: 4, color: 0xccccbb, foundNative: false, stackSize: 99, description: 'Sjelden jordart. Brukes i lasere og atomklokker.' },
     Ce: { symbol: 'Ce', name: 'Cerium',     atomicNumber: 58, category: 'lanthanide',  period: 6, group: 3,  tier: 2, color: 0xddddaa, foundNative: false, stackSize: 99, description: 'Vanligste lantanide. Brukes i katalysatorer og lighter-flint.' },
+
+    // ── Synthetic elements (produced in particle accelerator / reactor) ──────
+    Tc: { symbol: 'Tc', name: 'Technetium', atomicNumber: 43, category: 'metal',     period: 5, group: 7,  tier: 6, color: 0x88aacc, foundNative: false, synthetic: true, stackSize: 99, description: 'Første syntetiske grunnstoff. Nøytronbombardering av Mo.' },
+    Pm: { symbol: 'Pm', name: 'Promethium', atomicNumber: 61, category: 'lanthanide', period: 6, group: 3,  tier: 6, color: 0xccddaa, foundNative: false, synthetic: true, stackSize: 99, description: 'Syntetisk lantanide. Brukes i atomdrevne batterier.' },
+    Np: { symbol: 'Np', name: 'Neptunium',  atomicNumber: 93, category: 'actinide',   period: 7, group: 3,  tier: 6, color: 0x44bb88, foundNative: false, synthetic: true, stackSize: 99, description: 'Biprodukt fra uranreaktorer. Nøytronbombardering av U-238.' },
+    Pu: { symbol: 'Pu', name: 'Plutonium',  atomicNumber: 94, category: 'actinide',   period: 7, group: 3,  tier: 6, color: 0x44aa77, foundNative: false, synthetic: true, stackSize: 99, description: 'Fissilt materiale. Nøytronbombardering av U → Np → Pu.' },
+    Am: { symbol: 'Am', name: 'Americium',   atomicNumber: 95, category: 'actinide',   period: 7, group: 3,  tier: 6, color: 0x55bb99, foundNative: false, synthetic: true, stackSize: 99, description: 'Brukes i røykvarslere. Nøytronbombardering av Pu.' },
+    Cm: { symbol: 'Cm', name: 'Curium',      atomicNumber: 96, category: 'actinide',   period: 7, group: 3,  tier: 6, color: 0x66ccaa, foundNative: false, synthetic: true, stackSize: 99, description: 'Oppkalt etter Marie Curie. He + Pu i syklotron.' },
+    Bk: { symbol: 'Bk', name: 'Berkelium',   atomicNumber: 97, category: 'actinide',   period: 7, group: 3,  tier: 6, color: 0x55bb88, foundNative: false, synthetic: true, stackSize: 99, description: 'Ekstremt sjeldent. He-bombardering av Am.' },
+    Cf: { symbol: 'Cf', name: 'Californium', atomicNumber: 98, category: 'actinide',   period: 7, group: 3,  tier: 6, color: 0x66cc99, foundNative: false, synthetic: true, stackSize: 99, description: 'Sterk nøytronkilde. He-bombardering av Cm.' },
+    Es: { symbol: 'Es', name: 'Einsteinium', atomicNumber: 99, category: 'actinide',   period: 7, group: 3,  tier: 6, color: 0x77ddaa, foundNative: false, synthetic: true, stackSize: 99, description: 'Oppdaget i rester fra H-bombe-test. Intensiv nøytronfangst.' },
+    Fm: { symbol: 'Fm', name: 'Fermium',     atomicNumber: 100, category: 'actinide',  period: 7, group: 3,  tier: 6, color: 0x88eebb, foundNative: false, synthetic: true, stackSize: 99, description: 'Oppdaget sammen med einsteinium. Slutt for nøytronmetoden.' },
+    Md: { symbol: 'Md', name: 'Mendelevium', atomicNumber: 101, category: 'actinide',  period: 7, group: 3,  tier: 6, color: 0x77ddbb, foundNative: false, synthetic: true, stackSize: 99, description: 'He-bombardering av Es. Oppkalt etter Mendelejev.' },
+    No: { symbol: 'No', name: 'Nobelium',    atomicNumber: 102, category: 'actinide',  period: 7, group: 3,  tier: 6, color: 0x88eecc, foundNative: false, synthetic: true, stackSize: 99, description: 'C-bombardering av Cm. Oppkalt etter Alfred Nobel.' },
+    Lr: { symbol: 'Lr', name: 'Lawrencium',  atomicNumber: 103, category: 'actinide',  period: 7, group: 3,  tier: 6, color: 0x99ffdd, foundNative: false, synthetic: true, stackSize: 99, description: 'Siste aktinide. B-bombardering av Cf i syklotron.' },
+    Rf: { symbol: 'Rf', name: 'Rutherfordium', atomicNumber: 104, category: 'metal',   period: 7, group: 4,  tier: 6, color: 0xaaddcc, foundNative: false, synthetic: true, stackSize: 99, description: 'Første transaktinide. C-bombardering av Cf.' },
+    Db: { symbol: 'Db', name: 'Dubnium',     atomicNumber: 105, category: 'metal',     period: 7, group: 5,  tier: 6, color: 0xbbddcc, foundNative: false, synthetic: true, stackSize: 99, description: 'N-bombardering av Am. Oppkalt etter Dubna, Russland.' },
+    Sg: { symbol: 'Sg', name: 'Seaborgium',  atomicNumber: 106, category: 'metal',     period: 7, group: 6,  tier: 6, color: 0xccddcc, foundNative: false, synthetic: true, stackSize: 99, description: 'O-bombardering av Cf. Oppkalt etter Glenn Seaborg.' },
+    Bh: { symbol: 'Bh', name: 'Bohrium',     atomicNumber: 107, category: 'metal',     period: 7, group: 7,  tier: 6, color: 0xaaccbb, foundNative: false, synthetic: true, stackSize: 99, description: 'Cr-bombardering av Bi. Lever bare millisekunder.' },
+    Hs: { symbol: 'Hs', name: 'Hassium',     atomicNumber: 108, category: 'metal',     period: 7, group: 8,  tier: 6, color: 0xbbccbb, foundNative: false, synthetic: true, stackSize: 99, description: 'Fe-bombardering av Pb. Oppkalt etter Hessen.' },
+    Mt: { symbol: 'Mt', name: 'Meitnerium',  atomicNumber: 109, category: 'metal',     period: 7, group: 9,  tier: 6, color: 0xccccbb, foundNative: false, synthetic: true, stackSize: 99, description: 'Fe-bombardering av Bi. Oppkalt etter Lise Meitner.' },
+    Ds: { symbol: 'Ds', name: 'Darmstadtium', atomicNumber: 110, category: 'metal',    period: 7, group: 10, tier: 6, color: 0xddccbb, foundNative: false, synthetic: true, stackSize: 99, description: 'Ni-bombardering av Pb. Lever bare mikrosekunder.' },
+    Rg: { symbol: 'Rg', name: 'Roentgenium', atomicNumber: 111, category: 'metal',     period: 7, group: 11, tier: 6, color: 0xeeddcc, foundNative: false, synthetic: true, stackSize: 99, description: 'Ni-bombardering av Bi. Oppkalt etter Röntgen.' },
+    Cn: { symbol: 'Cn', name: 'Copernicium', atomicNumber: 112, category: 'metal',     period: 7, group: 12, tier: 6, color: 0xddddbb, foundNative: false, synthetic: true, stackSize: 99, description: 'Zn-bombardering av Pb. Oppkalt etter Kopernikus.' },
+    Nh: { symbol: 'Nh', name: 'Nihonium',    atomicNumber: 113, category: 'metal',     period: 7, group: 13, tier: 6, color: 0xccddaa, foundNative: false, synthetic: true, stackSize: 99, description: 'Zn-bombardering av Bi. Oppdaget i Japan (Nihon).' },
+    Fl: { symbol: 'Fl', name: 'Flerovium',   atomicNumber: 114, category: 'metal',     period: 7, group: 14, tier: 6, color: 0xbbcc99, foundNative: false, synthetic: true, stackSize: 99, description: 'Ca-bombardering av Pu. Nær «stabilitetsøya».' },
+    Mc: { symbol: 'Mc', name: 'Moscovium',   atomicNumber: 115, category: 'metal',     period: 7, group: 15, tier: 6, color: 0xaabb88, foundNative: false, synthetic: true, stackSize: 99, description: 'Ca-bombardering av Am. Oppkalt etter Moskva.' },
+    Lv: { symbol: 'Lv', name: 'Livermorium', atomicNumber: 116, category: 'metal',     period: 7, group: 16, tier: 6, color: 0x99aa77, foundNative: false, synthetic: true, stackSize: 99, description: 'Ca-bombardering av Cm. Oppkalt etter Livermore-laboratoriet.' },
+    Ts: { symbol: 'Ts', name: 'Tennessine',  atomicNumber: 117, category: 'nonmetal',  period: 7, group: 17, tier: 6, color: 0x88aa88, foundNative: false, synthetic: true, stackSize: 99, description: 'Ca-bombardering av Bk. Nest tyngste grunnstoff.' },
+    Og: { symbol: 'Og', name: 'Oganesson',   atomicNumber: 118, category: 'noble',     period: 7, group: 18, tier: 6, color: 0xddddff, foundNative: false, synthetic: true, stackSize: 99, description: 'Tyngste grunnstoff. Ca-bombardering av Cf. Edelgass?' },
 };
 
 // ── Periodic table layout (standard 18-column, rows 1–7 + lanthanides/actinides) ─
@@ -210,6 +240,37 @@ const PERIODIC_TABLE_LAYOUT = [
     { symbol: 'Th', row: 8, col: 3 },
     { symbol: 'Pa', row: 8, col: 4 },
     { symbol: 'U',  row: 8, col: 5 },
+    // Synthetic actinides (row 8 continued)
+    { symbol: 'Np', row: 8, col: 6 },
+    { symbol: 'Pu', row: 8, col: 7 },
+    { symbol: 'Am', row: 8, col: 8 },
+    { symbol: 'Cm', row: 8, col: 9 },
+    { symbol: 'Bk', row: 8, col: 10 },
+    { symbol: 'Cf', row: 8, col: 11 },
+    { symbol: 'Es', row: 8, col: 12 },
+    { symbol: 'Fm', row: 8, col: 13 },
+    { symbol: 'Md', row: 8, col: 14 },
+    { symbol: 'No', row: 8, col: 15 },
+    { symbol: 'Lr', row: 8, col: 16 },
+    // Tc in period 5, Pm in lanthanide row
+    { symbol: 'Tc', row: 4, col: 6 },
+    { symbol: 'Pm', row: 7, col: 6 },
+    // Period 7 transactinides
+    { symbol: 'Rf', row: 6, col: 3 },
+    { symbol: 'Db', row: 6, col: 4 },
+    { symbol: 'Sg', row: 6, col: 5 },
+    { symbol: 'Bh', row: 6, col: 6 },
+    { symbol: 'Hs', row: 6, col: 7 },
+    { symbol: 'Mt', row: 6, col: 8 },
+    { symbol: 'Ds', row: 6, col: 9 },
+    { symbol: 'Rg', row: 6, col: 10 },
+    { symbol: 'Cn', row: 6, col: 11 },
+    { symbol: 'Nh', row: 6, col: 12 },
+    { symbol: 'Fl', row: 6, col: 13 },
+    { symbol: 'Mc', row: 6, col: 14 },
+    { symbol: 'Lv', row: 6, col: 15 },
+    { symbol: 'Ts', row: 6, col: 16 },
+    { symbol: 'Og', row: 6, col: 17 },
 ];
 
 // ── Collection bonuses (group/period/category completions) ──────────────────
@@ -229,7 +290,8 @@ const ELEMENT_BONUSES = [
     { id: 'period_4',       name: 'Periode 4',       desc: '«Industrialist»-tittel', symbols: ['K', 'Ca', 'Sc', 'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni', 'Cu', 'Zn', 'Ga', 'Ge', 'As', 'Se', 'Br', 'Kr'], reward: { title: 'Industrialist' } },
     { id: 'all_nonmetals',  name: 'Alle ikke-metaller', desc: '2× potionsstyrke', symbols: ['H', 'C', 'N', 'O', 'F', 'P', 'S', 'Cl', 'Se'], reward: { potionStrengthMul: 2.0 } },
     { id: 'all_lanthanides', name: 'Alle lantanider', desc: 'Magisk AoE-angrep',  symbols: ['La', 'Ce', 'Pr', 'Nd', 'Sm', 'Eu', 'Gd', 'Tb', 'Dy', 'Ho', 'Er', 'Tm', 'Yb', 'Lu'], reward: { magicAoe: true } },
-    { id: 'all_92_natural', name: 'Elementmester',   desc: 'Legendarisk tittel + unik gjenstand', symbols: Object.keys(typeof ELEMENTS !== 'undefined' ? ELEMENTS : {}), reward: { title: 'Elementmester', legendaryItem: true } },
+    { id: 'all_92_natural', name: 'Elementmester',   desc: 'Legendarisk tittel + unik gjenstand', symbols: Object.keys(typeof ELEMENTS !== 'undefined' ? ELEMENTS : {}).filter(s => !(ELEMENTS[s] || {}).synthetic), reward: { title: 'Elementmester', legendaryItem: true } },
+    { id: 'all_118',       name: 'Guds periodiske system', desc: 'Alle 118 samlet! Skjult ending.', symbols: Object.keys(typeof ELEMENTS !== 'undefined' ? ELEMENTS : {}), reward: { title: 'Guds periodiske system', godMode: true } },
 ];
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -238,5 +300,47 @@ function getElementsByTier(tier) {
     return Object.values(ELEMENTS).filter(e => e.tier === tier);
 }
 
-// Total natural elements we track
-const TOTAL_NATURAL_ELEMENTS = Object.keys(ELEMENTS).length;
+const TOTAL_NATURAL_ELEMENTS = Object.keys(ELEMENTS).filter(s => !ELEMENTS[s].synthetic).length;
+const TOTAL_ALL_ELEMENTS = Object.keys(ELEMENTS).length;
+
+// ── Transuranic synthesis recipes ───────────────────────────────────────────
+// Each recipe: target + projectile (or neutron source) → product.
+// Mirrors real-world nuclear physics. energyCost is consumed from fuel.
+// neutronSource: true = uses reactor neutrons (requires fissionUpgraded).
+
+const TRANSURANIC_RECIPES = [
+    // Sub-92 synthetics
+    { product: 'Tc', target: 'Mo', projectile: null, neutronSource: true,  energyCost: 20,  tier: 1, desc: 'Nøytronbombardering av molybden' },
+    { product: 'Pm', target: 'Nd', projectile: null, neutronSource: true,  energyCost: 25,  tier: 1, desc: 'Nøytronbombardering av neodym' },
+    // Light transuranic (reactor-bred)
+    { product: 'Np', target: 'U',  projectile: null, neutronSource: true,  energyCost: 30,  tier: 1, desc: 'U-238 + nøytron → Np-239' },
+    { product: 'Pu', target: 'U',  projectile: null, neutronSource: true,  energyCost: 40,  tier: 1, desc: 'U-238 → Np-239 → Pu-239' },
+    { product: 'Am', target: 'Pu', projectile: null, neutronSource: true,  energyCost: 60,  tier: 2, desc: 'Pu-239 + nøytroner → Am-241' },
+    { product: 'Cm', target: 'Pu', projectile: 'He', neutronSource: false, energyCost: 80,  tier: 2, desc: 'Pu-239 + He-4 → Cm-242' },
+    // Medium transuranic (cyclotron)
+    { product: 'Bk', target: 'Am', projectile: 'He', neutronSource: false, energyCost: 100, tier: 3, desc: 'Am-243 + He-4 → Bk-245' },
+    { product: 'Cf', target: 'Cm', projectile: 'He', neutronSource: false, energyCost: 120, tier: 3, desc: 'Cm-242 + He-4 → Cf-245' },
+    { product: 'Es', target: 'Cf', projectile: null, neutronSource: true,  energyCost: 150, tier: 3, desc: 'Intensiv nøytronfangst i Cf' },
+    { product: 'Fm', target: 'Es', projectile: null, neutronSource: true,  energyCost: 180, tier: 3, desc: 'Nøytronbombardering av Es-253' },
+    // Heavy transuranic (heavy-ion bombardment)
+    { product: 'Md', target: 'Es', projectile: 'He', neutronSource: false, energyCost: 200, tier: 4, desc: 'Es-253 + He-4 → Md-256' },
+    { product: 'No', target: 'Cm', projectile: 'C',  neutronSource: false, energyCost: 250, tier: 4, desc: 'Cm-246 + C-12 → No-254' },
+    { product: 'Lr', target: 'Cf', projectile: 'B',  neutronSource: false, energyCost: 300, tier: 4, desc: 'Cf-252 + B-11 → Lr-258' },
+    // Transactinides (particle accelerator)
+    { product: 'Rf', target: 'Cf', projectile: 'C',  neutronSource: false, energyCost: 400,  tier: 5, desc: 'Cf-249 + C-12 → Rf-257' },
+    { product: 'Db', target: 'Am', projectile: 'N',  neutronSource: false, energyCost: 450,  tier: 5, desc: 'Am-243 + N-15 → Db-256' },
+    { product: 'Sg', target: 'Cf', projectile: 'O',  neutronSource: false, energyCost: 500,  tier: 5, desc: 'Cf-249 + O-18 → Sg-263' },
+    { product: 'Bh', target: 'Bi', projectile: 'Cr', neutronSource: false, energyCost: 600,  tier: 5, desc: 'Bi-209 + Cr-54 → Bh-262' },
+    { product: 'Hs', target: 'Pb', projectile: 'Fe', neutronSource: false, energyCost: 650,  tier: 5, desc: 'Pb-208 + Fe-58 → Hs-265' },
+    { product: 'Mt', target: 'Bi', projectile: 'Fe', neutronSource: false, energyCost: 700,  tier: 5, desc: 'Bi-209 + Fe-58 → Mt-266' },
+    { product: 'Ds', target: 'Pb', projectile: 'Ni', neutronSource: false, energyCost: 800,  tier: 5, desc: 'Pb-208 + Ni-62 → Ds-269' },
+    { product: 'Rg', target: 'Bi', projectile: 'Ni', neutronSource: false, energyCost: 850,  tier: 5, desc: 'Bi-209 + Ni-64 → Rg-272' },
+    { product: 'Cn', target: 'Pb', projectile: 'Zn', neutronSource: false, energyCost: 900,  tier: 5, desc: 'Pb-208 + Zn-70 → Cn-277' },
+    { product: 'Nh', target: 'Bi', projectile: 'Zn', neutronSource: false, energyCost: 950,  tier: 5, desc: 'Bi-209 + Zn-70 → Nh-278' },
+    // Super-heavy (hot fusion with Ca-48)
+    { product: 'Fl', target: 'Pu', projectile: 'Ca', neutronSource: false, energyCost: 1000, tier: 6, desc: 'Pu-244 + Ca-48 → Fl-289' },
+    { product: 'Mc', target: 'Am', projectile: 'Ca', neutronSource: false, energyCost: 1100, tier: 6, desc: 'Am-243 + Ca-48 → Mc-288' },
+    { product: 'Lv', target: 'Cm', projectile: 'Ca', neutronSource: false, energyCost: 1200, tier: 6, desc: 'Cm-248 + Ca-48 → Lv-293' },
+    { product: 'Ts', target: 'Bk', projectile: 'Ca', neutronSource: false, energyCost: 1500, tier: 6, desc: 'Bk-249 + Ca-48 → Ts-294' },
+    { product: 'Og', target: 'Cf', projectile: 'Ca', neutronSource: false, energyCost: 2000, tier: 6, desc: 'Cf-249 + Ca-48 → Og-294' },
+];

--- a/src/data/minerals.js
+++ b/src/data/minerals.js
@@ -233,9 +233,9 @@ const MINERAL_DEFS = {
     pgm_ore: {
         id: 'pgm_ore', name: 'PGM-malm', type: 'mineral', subtype: 'ore',
         formula: 'PGM', tier: 5, color: 0xccccaa,
-        yields: [{ symbol: 'Ru', amount: 1, chance: 0.7 }, { symbol: 'Rh', amount: 1, chance: 0.5 }, { symbol: 'Pd', amount: 1, chance: 0.6 }],
+        yields: [{ symbol: 'Ru', amount: 1, chance: 0.7 }, { symbol: 'Rh', amount: 1, chance: 0.5 }, { symbol: 'Pd', amount: 1, chance: 0.6 }, { symbol: 'Pt', amount: 1, chance: 0.4 }, { symbol: 'Ir', amount: 1, chance: 0.3 }, { symbol: 'Os', amount: 1, chance: 0.2 }],
         energyCost: 5, smeltingTime: 6, stackSize: 10,
-        desc: 'Sjelden platinametall-malm. Inneholder ruthenium, rhodium og palladium.'
+        desc: 'Sjelden platinametall-malm. Inneholder alle seks platinametaller.'
     },
     argentite: {
         id: 'argentite', name: 'Argentitt', type: 'mineral', subtype: 'ore',
@@ -280,6 +280,109 @@ const MINERAL_DEFS = {
         yields: [{ symbol: 'Ba', amount: 2, chance: 1.0 }, { symbol: 'S', amount: 1, chance: 0.5 }],
         energyCost: 3, smeltingTime: 4, stackSize: 10,
         desc: 'Tungt hvitt mineral. Bariumkilde, brukes i fyrverkeri.'
+    },
+
+    // ── Phase 5 minerals: fills orphan element gaps ────────────────────────
+
+    // Critical fixes: V source for titanium alloy
+    vanadinite: {
+        id: 'vanadinite', name: 'Vanadinitt', type: 'mineral', subtype: 'ore',
+        formula: 'Pb\u2085(VO\u2084)\u2083Cl', tier: 3, color: 0xcc6633,
+        yields: [{ symbol: 'V', amount: 2, chance: 1.0 }, { symbol: 'Pb', amount: 1, chance: 0.5 }],
+        energyCost: 3, smeltingTime: 4, stackSize: 10,
+        desc: 'Oransjrøde krystaller. Viktigste vanadiumkilde.'
+    },
+
+    // Halogens
+    bromargyryte: {
+        id: 'bromargyryte', name: 'Bromargyryt', type: 'mineral', subtype: 'ore',
+        formula: 'AgBr', tier: 4, color: 0xccaa44,
+        yields: [{ symbol: 'Br', amount: 2, chance: 1.0 }, { symbol: 'Ag', amount: 1, chance: 0.4 }],
+        energyCost: 3, smeltingTime: 4, stackSize: 10,
+        desc: 'Gulaktig sølvhalid. Sjelden bromkilde.'
+    },
+    iodyrite: {
+        id: 'iodyrite', name: 'Jodyritt', type: 'mineral', subtype: 'ore',
+        formula: 'AgI', tier: 4, color: 0x886644,
+        yields: [{ symbol: 'I', amount: 2, chance: 1.0 }, { symbol: 'Ag', amount: 1, chance: 0.3 }],
+        energyCost: 3, smeltingTime: 4, stackSize: 10,
+        desc: 'Gult sølvjodid. Sjelden jodkilde.'
+    },
+
+    // Semiconductors
+    germanite: {
+        id: 'germanite', name: 'Germanitt', type: 'mineral', subtype: 'ore',
+        formula: 'Cu\u2082\u2086Fe\u2084Ge\u2084S\u2083\u2082', tier: 4, color: 0x998877,
+        yields: [{ symbol: 'Ge', amount: 2, chance: 1.0 }, { symbol: 'Cu', amount: 1, chance: 0.5 }, { symbol: 'S', amount: 1, chance: 0.3 }],
+        energyCost: 4, smeltingTime: 5, stackSize: 10,
+        desc: 'Sjelden kobber-germanium-sulfid. Halvlederkilde.'
+    },
+    stibnite: {
+        id: 'stibnite', name: 'Stibnitt', type: 'mineral', subtype: 'ore',
+        formula: 'Sb\u2082S\u2083', tier: 3, color: 0x555566,
+        yields: [{ symbol: 'Sb', amount: 2, chance: 1.0 }, { symbol: 'S', amount: 1, chance: 0.6 }],
+        energyCost: 3, smeltingTime: 4, stackSize: 10,
+        desc: 'Stålgrå nåler. Antimonkilde.'
+    },
+    gallite: {
+        id: 'gallite', name: 'Gallitt', type: 'mineral', subtype: 'ore',
+        formula: 'CuGaS\u2082', tier: 4, color: 0xaabbdd,
+        yields: [{ symbol: 'Ga', amount: 2, chance: 1.0 }, { symbol: 'Cu', amount: 1, chance: 0.4 }],
+        energyCost: 3, smeltingTime: 4, stackSize: 10,
+        desc: 'Sjelden galliumsulfid. Viktig for halvledere.'
+    },
+
+    // Rare earths & misc metals
+    xenotime: {
+        id: 'xenotime', name: 'Xenotim', type: 'mineral', subtype: 'ore',
+        formula: 'YPO\u2084', tier: 4, color: 0xbbaa88,
+        yields: [{ symbol: 'Y', amount: 2, chance: 1.0 }, { symbol: 'Dy', amount: 1, chance: 0.4 }, { symbol: 'Er', amount: 1, chance: 0.3 }, { symbol: 'Yb', amount: 1, chance: 0.2 }],
+        energyCost: 4, smeltingTime: 5, stackSize: 10,
+        desc: 'Brun fosfatmineral. Rik på tunge sjeldne jordartsmetaller.'
+    },
+    samarskite: {
+        id: 'samarskite', name: 'Samarskitt', type: 'mineral', subtype: 'ore',
+        formula: '(Y,Ce,U)(Nb,Ta)O\u2084', tier: 5, color: 0x332211,
+        yields: [{ symbol: 'Sm', amount: 1, chance: 0.7 }, { symbol: 'Gd', amount: 1, chance: 0.5 }, { symbol: 'Pr', amount: 1, chance: 0.4 }, { symbol: 'Nb', amount: 1, chance: 0.3 }],
+        energyCost: 5, smeltingTime: 6, stackSize: 10,
+        desc: 'Sort, radioaktivt. Kilde til samarium og gadolinium.'
+    },
+    celestine: {
+        id: 'celestine', name: 'Celestin', type: 'mineral', subtype: 'ore',
+        formula: 'SrSO\u2084', tier: 3, color: 0xaaccee,
+        yields: [{ symbol: 'Sr', amount: 2, chance: 1.0 }, { symbol: 'S', amount: 1, chance: 0.5 }],
+        energyCost: 2, smeltingTime: 3, stackSize: 10,
+        desc: 'Himmelblå krystaller. Strontiumkilde.'
+    },
+    pollucite: {
+        id: 'pollucite', name: 'Pollucitt', type: 'mineral', subtype: 'ore',
+        formula: 'CsAlSi\u2082O\u2086', tier: 5, color: 0xeeddcc,
+        yields: [{ symbol: 'Cs', amount: 2, chance: 1.0 }, { symbol: 'Rb', amount: 1, chance: 0.4 }],
+        energyCost: 4, smeltingTime: 5, stackSize: 10,
+        desc: 'Sjeldent zeolitt-mineral. Eneste kommersielle cesiumkilde.'
+    },
+    calaverite: {
+        id: 'calaverite', name: 'Calaveritt', type: 'mineral', subtype: 'ore',
+        formula: 'AuTe\u2082', tier: 5, color: 0xddcc44,
+        yields: [{ symbol: 'Te', amount: 2, chance: 1.0 }, { symbol: 'Au', amount: 1, chance: 0.5 }],
+        energyCost: 4, smeltingTime: 5, stackSize: 10,
+        desc: 'Gulltellurid. Sjelden kilde til tellur og gull.'
+    },
+    indite_ore: {
+        id: 'indite_ore', name: 'Inditt', type: 'mineral', subtype: 'ore',
+        formula: 'FeIn\u2082S\u2084', tier: 4, color: 0x7788aa,
+        yields: [{ symbol: 'In', amount: 2, chance: 1.0 }, { symbol: 'Fe', amount: 1, chance: 0.5 }],
+        energyCost: 3, smeltingTime: 4, stackSize: 10,
+        desc: 'Sjelden indiumsulfid. Viktig for berøringsskjermer.'
+    },
+
+    // Actinides
+    thorite: {
+        id: 'thorite', name: 'Thoritt', type: 'mineral', subtype: 'ore',
+        formula: 'ThSiO\u2084', tier: 6, color: 0x446644,
+        yields: [{ symbol: 'Th', amount: 2, chance: 1.0 }, { symbol: 'Si', amount: 1, chance: 0.5 }],
+        energyCost: 5, smeltingTime: 7, stackSize: 10,
+        desc: 'Radioaktivt thoriummineral. Alternativ kjernebrensel.'
     },
 
     // ── Crystals / Gemstones (subtype: 'crystal') ───────────────────────────
@@ -362,10 +465,10 @@ const MINERAL_DEFS = {
 const MINERAL_POOL = {
     1: ['quartz', 'hematite', 'magnetite', 'limestone', 'halite', 'bauxite', 'olivine', 'ice_crystal', 'sylvite'],
     2: ['pyrite', 'ilmenite', 'apatite', 'niter', 'borax', 'thortveitite'],
-    3: ['chalcopyrite', 'malachite', 'sphalerite', 'chromite', 'zircon', 'pentlandite', 'spodumene', 'cobaltite'],
-    4: ['galena', 'cassiterite', 'cinnabar', 'columbite', 'monazite', 'bastnaesite', 'greenockite', 'wolframite'],
-    5: ['argentite', 'native_gold', 'native_silver', 'pgm_ore'],
-    6: ['uraninite'],
+    3: ['chalcopyrite', 'malachite', 'sphalerite', 'chromite', 'zircon', 'pentlandite', 'spodumene', 'cobaltite', 'vanadinite', 'stibnite', 'celestine', 'barite'],
+    4: ['galena', 'cassiterite', 'cinnabar', 'columbite', 'monazite', 'bastnaesite', 'greenockite', 'wolframite', 'molybdenite', 'bromargyryte', 'iodyrite', 'germanite', 'gallite', 'xenotime', 'indite_ore'],
+    5: ['argentite', 'native_gold', 'native_silver', 'pgm_ore', 'samarskite', 'pollucite', 'calaverite'],
+    6: ['uraninite', 'thorite'],
 };
 
 const CRYSTAL_POOL = {

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -271,6 +271,62 @@ const SKILL_TREE_PATHS = [
             },
         ]
     },
+    // ── FYSIKER (Physicist – Phase 5: semiconductors, fission, fusion) ─────────
+    {
+        id:    'fysiker',
+        name:  'Fysiker',
+        desc:  'Halvledere, fisjon, fusjon',
+        prerequisitePath: 'kjemiker',
+        color: 0x8866ff,
+        icon:  'F',
+        unlockCondition: 'accelerator_found',
+        tiers: [
+            {
+                id:       'semiconductor_basics',
+                name:     'Halvledergrunnlag',
+                desc:     'Halvleder-crafting\nMineraler tiltrekkes\ni nærliggende rom',
+                category: 'UTIL',
+                maxStack: 3,
+                apply(hero) {
+                    hero.semiconductorUnlocked = true;
+                    hero.mineralMagnetRadius = (hero.mineralMagnetRadius || 0) + 1;
+                }
+            },
+            {
+                id:       'radiation_shield',
+                name:     'Strålingsshield',
+                desc:     'Radioaktivt gir\nikke HP-tap\n+1 min-tier loot',
+                category: 'UTIL',
+                maxStack: 2,
+                apply(hero) {
+                    hero.radiationShield = true;
+                    hero.lootTierBonus = (hero.lootTierBonus || 0) + 1;
+                }
+            },
+            {
+                id:       'fission_mastery',
+                name:     'Fisjonsbeherskelse',
+                desc:     'Reaktor gir 2×\nenergi fra U/Th\nLåser tier 1-3 syntetiske',
+                category: 'UTIL',
+                maxStack: 1,
+                apply(hero) {
+                    hero.fissionMastered = true;
+                    hero.fissionEnergyMul = 2.0;
+                }
+            },
+            {
+                id:       'fusion_pioneer',
+                name:     'Fusjonspioner',
+                desc:     'Fusjon-energi fra\nHe + H. Låser alle\nsyntetiske grunnstoff',
+                category: 'UTIL',
+                maxStack: 1,
+                apply(hero) {
+                    hero.fusionMastered = true;
+                    hero.fusionEnergyMul = 5.0;
+                }
+            },
+        ]
+    },
 ];
 
 // ── Flat list for backward compat (save/load, apply) ──────────────────────────
@@ -297,6 +353,7 @@ function isSkillUnlocked(hero, pathIndex, tierIndex) {
     if (path.unlockCondition === 'mineral_pickup' && !hero.geologistUnlocked) return false;
     if (path.unlockCondition === 'camp_room_found' && !hero.metallurgistUnlocked) return false;
     if (path.unlockCondition === 'chem_lab_found' && !hero.chemistUnlocked) return false;
+    if (path.unlockCondition === 'accelerator_found' && !hero.acceleratorUnlocked) return false;
 
     // Check prerequisite path (e.g. metallurg requires at least 1 geolog skill)
     if (path.prerequisitePath) {
@@ -418,9 +475,6 @@ const SKILL_SYNERGIES = [
         unapply(hero) { hero.chemBombBonus = Math.max(0, (hero.chemBombBonus || 0) - 0.20); hero.critChance = Math.max(0, hero.critChance - 0.10); },
     },
     {
-        // Three-path synergy: requires ≥1 skill from each of Geolog, Metallurg, and Kjemiker.
-        // Unlocks transmutation (convert 5 of any element into 1 of an adjacent element)
-        // via a button in the Chemistry Lab.
         id:    'transmutation',
         name:  'Transmutasjon',
         desc:  '5 av grunnstoff X → 1 av nabo (kjemilab)',
@@ -428,6 +482,24 @@ const SKILL_SYNERGIES = [
         color: 0xff88cc,
         apply(hero) { hero.transmutationUnlocked = true; },
         unapply(hero) { hero.transmutationUnlocked = false; },
+    },
+    {
+        id:    'nuclear_forge',
+        name:  'Atomsmedja',
+        desc:  '+3 ATK, −25% akselerator-energi',
+        paths: ['fysiker', 'metallurg'],
+        color: 0xaa66ff,
+        apply(hero) { hero.attack += 3; hero.acceleratorEfficiency = (hero.acceleratorEfficiency || 1.0) * 0.75; },
+        unapply(hero) { hero.attack -= 3; hero.acceleratorEfficiency = (hero.acceleratorEfficiency || 1.0) / 0.75; },
+    },
+    {
+        id:    'quantum_chemistry',
+        name:  'Kvantekjemi',
+        desc:  '+30% potion-styrke, +20% bombe-radius',
+        paths: ['fysiker', 'kjemiker'],
+        color: 0x8888ff,
+        apply(hero) { hero.potionMagnitudeBonus = (hero.potionMagnitudeBonus || 0) + 0.30; hero.chemRadiusBonus = (hero.chemRadiusBonus || 0) + 0.20; },
+        unapply(hero) { hero.potionMagnitudeBonus = Math.max(0, (hero.potionMagnitudeBonus || 0) - 0.30); hero.chemRadiusBonus = Math.max(0, (hero.chemRadiusBonus || 0) - 0.20); },
     },
 ];
 

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -317,7 +317,7 @@ const SKILL_TREE_PATHS = [
             {
                 id:       'fusion_pioneer',
                 name:     'Fusjonspioner',
-                desc:     'Fusjon-energi fra\nHe + H. Låser alle\nsyntetiske grunnstoff',
+                desc:     'D-T fusjon: H + Li\n→ He + energi.\nLåser alle syntetiske',
                 category: 'UTIL',
                 maxStack: 1,
                 apply(hero) {

--- a/src/entities/HeroCrafting.js
+++ b/src/entities/HeroCrafting.js
@@ -50,6 +50,18 @@ const HeroCrafting = {
         hero.transmutationUnlocked = false; // Transmutasjon synergy (3-path)
         hero.toxicBladeChance = 0;
 
+        // Physicist mod (Phase 5)
+        hero.acceleratorUnlocked = false;
+        hero.semiconductorUnlocked = false;
+        hero.mineralMagnetRadius = 0;
+        hero.radiationShield = false;
+        hero.lootTierBonus = 0;
+        hero.fissionMastered = false;
+        hero.fissionEnergyMul = 1.0;
+        hero.fusionMastered = false;
+        hero.fusionEnergyMul = 1.0;
+        hero.acceleratorEfficiency = 1.0;
+
         // Zone progression (Phase 4)
         hero.completedZones = [];
 
@@ -112,6 +124,16 @@ const HeroCrafting = {
             chemBombChain:        hero.chemBombChain,
             transmutationUnlocked: hero.transmutationUnlocked,
             toxicBladeChance:     hero.toxicBladeChance,
+            acceleratorUnlocked:  hero.acceleratorUnlocked,
+            semiconductorUnlocked: hero.semiconductorUnlocked,
+            mineralMagnetRadius:  hero.mineralMagnetRadius,
+            radiationShield:      hero.radiationShield,
+            lootTierBonus:        hero.lootTierBonus,
+            fissionMastered:      hero.fissionMastered,
+            fissionEnergyMul:     hero.fissionEnergyMul,
+            fusionMastered:       hero.fusionMastered,
+            fusionEnergyMul:      hero.fusionEnergyMul,
+            acceleratorEfficiency: hero.acceleratorEfficiency,
             completedZones:       [...hero.completedZones],
             appliedElementBonuses: { ...hero.appliedElementBonuses },
             elementGoldMul:       hero.elementGoldMul,
@@ -168,6 +190,16 @@ const HeroCrafting = {
         hero.chemBombChain        = stats.chemBombChain        || false;
         hero.transmutationUnlocked = stats.transmutationUnlocked || false;
         hero.toxicBladeChance     = stats.toxicBladeChance     || 0;
+        hero.acceleratorUnlocked  = stats.acceleratorUnlocked  || false;
+        hero.semiconductorUnlocked = stats.semiconductorUnlocked || false;
+        hero.mineralMagnetRadius  = stats.mineralMagnetRadius  || 0;
+        hero.radiationShield      = stats.radiationShield      || false;
+        hero.lootTierBonus        = stats.lootTierBonus        || 0;
+        hero.fissionMastered      = stats.fissionMastered      || false;
+        hero.fissionEnergyMul     = stats.fissionEnergyMul     || 1.0;
+        hero.fusionMastered       = stats.fusionMastered       || false;
+        hero.fusionEnergyMul      = stats.fusionEnergyMul      || 1.0;
+        hero.acceleratorEfficiency = stats.acceleratorEfficiency || 1.0;
         hero.completedZones       = stats.completedZones       ? [...stats.completedZones] : [];
         hero.appliedElementBonuses = stats.appliedElementBonuses ? { ...stats.appliedElementBonuses } : {};
         hero.elementGoldMul       = stats.elementGoldMul       || 0;

--- a/src/main.js
+++ b/src/main.js
@@ -26,7 +26,8 @@ const config = {
         SettingsScene,
         ElementBookScene,
         SmelteryScene,
-        ChemLabScene
+        ChemLabScene,
+        AcceleratorScene
     ]
 };
 

--- a/src/maze.js
+++ b/src/maze.js
@@ -198,6 +198,19 @@ class MazeGenerator {
                 this.specialRooms.push({ type: 'magma_chamber', tiles });
             }
         }
+
+        // Particle Accelerator: world 13+, 20% chance (guaranteed world 15+)
+        // Used for fission energy and transuranic element synthesis.
+        if (worldNum >= 13 && deadEnds.length > 0) {
+            const accChance = worldNum >= 15 ? 1.0 : 0.20;
+            if (Math.random() < accChance) {
+                const de = deadEnds.shift();
+                const tiles = this._gatherRoomTiles(de.x, de.y, 3 + Math.floor(Math.random() * 2));
+                if (tiles.length >= 1) {
+                    this.specialRooms.push({ type: 'accelerator', tiles });
+                }
+            }
+        }
     }
 
     /** Gather up to maxSize floor tiles around a starting point (BFS). */

--- a/src/scenes/AcceleratorScene.js
+++ b/src/scenes/AcceleratorScene.js
@@ -1,0 +1,230 @@
+// ─── Labyrint Hero – Particle Accelerator Scene ──────────────────────────────
+// Overlay scene for synthesizing transuranic and synthetic elements.
+// Opens at Accelerator rooms (world 13+) via P key.
+// Uses TRANSURANIC_RECIPES: target + projectile (or neutron source) → product.
+
+class AcceleratorScene extends Phaser.Scene {
+    constructor() { super({ key: 'AcceleratorScene' }); }
+
+    init(data) {
+        this.heroRef = data.heroRef || null;
+        this.worldNum = data.worldNum || 1;
+    }
+
+    create() {
+        const { width: W, height: H } = this.cameras.main;
+        const cx = W / 2, cy = H / 2;
+        this.smelter = new SmeltingSystem();
+        this._dyn = [];
+        this._scrollOffset = 0;
+        this._maxScroll = 0;
+
+        this.add.rectangle(cx, cy, W, H, 0x000000, 0.85);
+
+        this.panelW = Math.min(W - 80, 900);
+        this.panelH = Math.min(H - 80, 640);
+        this.px = cx - this.panelW / 2;
+        this.py = cy - this.panelH / 2;
+
+        const panel = this.add.graphics();
+        panel.fillStyle(0x0a0818, 0.97);
+        panel.fillRoundedRect(this.px, this.py, this.panelW, this.panelH, 8);
+        panel.lineStyle(2, 0x8866ff);
+        panel.strokeRoundedRect(this.px, this.py, this.panelW, this.panelH, 8);
+
+        this.add.text(cx, this.py + 22, 'PARTIKKELAKSELERATOR', {
+            fontSize: '18px', color: '#8866ff', fontFamily: 'monospace', fontStyle: 'bold'
+        }).setOrigin(0.5);
+
+        const fuel = this.smelter.calculateFuelEnergy(this.heroRef);
+        this._fuelText = this.add.text(this.px + this.panelW - 20, this.py + 22, `Energi: ${fuel}`, {
+            fontSize: '14px', color: '#6644aa', fontFamily: 'monospace'
+        }).setOrigin(1, 0.5);
+
+        this.add.rectangle(cx, this.py + 42, this.panelW - 20, 1, 0x331166);
+
+        this.add.text(this.px + 20, this.py + 50, 'Syntetiser nye grunnstoffer ved å bombardere et mål med et prosjektil.', {
+            fontSize: '13px', color: '#665588', fontFamily: 'monospace',
+            wordWrap: { width: this.panelW - 40 }
+        });
+
+        const closeBtn = this.add.text(this.px + this.panelW - 20, this.py + 10, '✕', {
+            fontSize: '22px', color: '#6644aa', fontFamily: 'monospace'
+        }).setOrigin(0.5).setInteractive({ useHandCursor: true });
+        closeBtn.on('pointerdown', () => this.scene.stop());
+        this.input.keyboard.on('keydown-ESC', () => this.scene.stop());
+        this.input.keyboard.on('keydown-P', () => this.scene.stop());
+
+        this.contentY = this.py + 72;
+
+        this.input.on('wheel', (pointer, go, dx, dy) => {
+            this._scrollOffset = this._clampScroll(this._scrollOffset + dy * 0.5);
+            this._refresh();
+        });
+
+        this._dragState = { active: false, startY: 0, startOffset: 0, engaged: false };
+        this.input.on('pointerdown', (p) => {
+            this._dragState = { active: true, engaged: false, startY: p.y, startOffset: this._scrollOffset };
+        });
+        this.input.on('pointermove', (p) => {
+            if (!this._dragState.active || !p.isDown) return;
+            const dy = p.y - this._dragState.startY;
+            if (!this._dragState.engaged && Math.abs(dy) < 8) return;
+            this._dragState.engaged = true;
+            this._scrollOffset = this._clampScroll(this._dragState.startOffset - dy);
+            this._refresh();
+        });
+        this.input.on('pointerup', () => { this._dragState.active = false; });
+
+        this._refresh();
+    }
+
+    _clampScroll(v) { return Math.max(0, Math.min(v, this._maxScroll || 0)); }
+
+    _viewportHeight() { return this.panelH - (this.contentY - this.py) - 30; }
+
+    _d(obj) { this._dyn.push(obj); return obj; }
+
+    _refresh() {
+        UIHelper.clearDynamic(this._dyn);
+
+        const cbg = this._d(this.add.graphics());
+        cbg.fillStyle(0x0a0818, 0.78);
+        cbg.fillRoundedRect(this.px + 6, this.contentY - 4, this.panelW - 12, this.panelH - (this.contentY - this.py) - 10, 4);
+
+        const hero = this.heroRef;
+        const fuel = this.smelter.calculateFuelEnergy(hero);
+        this._fuelText.setText(`Energi: ${fuel}`);
+        const tracker = hero.elementTracker;
+        const efficiency = hero.acceleratorEfficiency || 1.0;
+
+        if (typeof TRANSURANIC_RECIPES === 'undefined') return;
+
+        const recipes = TRANSURANIC_RECIPES;
+        const startX = this.px + 20;
+        const colW = Math.min(this.panelW - 40, 860);
+        const visBot = this.py + this.panelH - 30;
+        const rowStep = 48;
+        let y = this.contentY;
+
+        recipes.forEach((recipe, idx) => {
+            const baseY = y + idx * rowStep;
+            const ry = baseY - this._scrollOffset;
+            if (ry > visBot || ry < this.contentY - rowStep) return;
+
+            const productElem = ELEMENTS[recipe.product];
+            if (!productElem) return;
+
+            const adjustedCost = Math.max(1, Math.round(recipe.energyCost * efficiency));
+            const hasTarget = tracker.getCount(recipe.target) >= 1;
+            const hasProjectile = !recipe.projectile || tracker.getCount(recipe.projectile) >= 1;
+            const hasNeutron = !recipe.neutronSource || hero.fissionMastered || hero.fissionUpgraded;
+            const hasFuel = fuel >= adjustedCost;
+            const alreadyHas = tracker.getCount(recipe.product) > 0;
+
+            // Tier gating: tier 1-3 require fissionMastered, tier 4+ require fusionMastered
+            const tierOk = recipe.tier <= 3
+                ? (hero.fissionMastered || hero.fissionUpgraded)
+                : hero.fusionMastered;
+
+            const canCraft = hasTarget && hasProjectile && hasNeutron && hasFuel && tierOk;
+            const col = canCraft ? 0x8866ff : (alreadyHas ? 0x336633 : 0x332244);
+            const hexCol = '#' + col.toString(16).padStart(6, '0');
+
+            const bg = this._d(this.add.graphics());
+            bg.fillStyle(col, alreadyHas ? 0.12 : 0.08);
+            bg.fillRoundedRect(startX, ry, colW, 42, 4);
+            bg.lineStyle(1, col, 0.3);
+            bg.strokeRoundedRect(startX, ry, colW, 42, 4);
+
+            // Product name + atomic number
+            const pCol = '#' + (productElem.color || 0xaaaaaa).toString(16).padStart(6, '0');
+            const check = alreadyHas ? ' ✓' : '';
+            this._d(this.add.text(startX + 8, ry + 4, `${recipe.product} (${productElem.name})${check}`, {
+                fontSize: '15px', color: pCol, fontFamily: 'monospace', fontStyle: 'bold'
+            }));
+
+            // Recipe description
+            const projLabel = recipe.neutronSource ? 'nøytroner' : recipe.projectile;
+            const recipeText = `${recipe.target} + ${projLabel} → ${recipe.product}  |  ${adjustedCost} energi  [T${recipe.tier}]`;
+            this._d(this.add.text(startX + 8, ry + 22, recipeText, {
+                fontSize: '13px', color: '#665588', fontFamily: 'monospace'
+            }));
+
+            // Status / craft button
+            if (canCraft) {
+                const btn = this._d(this.add.text(startX + colW - 80, ry + 10, '[ Syntetiser ]', {
+                    fontSize: '14px', color: '#8866ff', fontFamily: 'monospace', fontStyle: 'bold'
+                }).setInteractive({ useHandCursor: true }));
+                btn.on('pointerover', () => btn.setColor('#aa88ff'));
+                btn.on('pointerout', () => btn.setColor('#8866ff'));
+                btn.on('pointerdown', () => this._doSynthesize(recipe));
+            } else if (!tierOk) {
+                this._d(this.add.text(startX + colW - 120, ry + 14, recipe.tier <= 3 ? 'Krever Fisjon' : 'Krever Fusjon', {
+                    fontSize: '12px', color: '#443355', fontFamily: 'monospace'
+                }));
+            } else if (!hasFuel) {
+                this._d(this.add.text(startX + colW - 80, ry + 14, 'Lite energi', {
+                    fontSize: '12px', color: '#443355', fontFamily: 'monospace'
+                }));
+            }
+        });
+
+        // Max scroll
+        const viewportH = this._viewportHeight();
+        const contentSpan = recipes.length * rowStep;
+        this._maxScroll = Math.max(0, contentSpan - viewportH);
+        this._scrollOffset = this._clampScroll(this._scrollOffset);
+
+        if (this._maxScroll > 0) {
+            const trackX = this.px + this.panelW - 10;
+            const trackY = this.contentY;
+            const trackH = viewportH;
+            const thumbH = Math.max(24, trackH * (trackH / (trackH + this._maxScroll)));
+            const thumbY = trackY + (trackH - thumbH) * (this._scrollOffset / this._maxScroll);
+            const bar = this._d(this.add.graphics());
+            bar.fillStyle(0x221133, 0.6);
+            bar.fillRoundedRect(trackX, trackY, 4, trackH, 2);
+            bar.fillStyle(0x8866ff, 0.7);
+            bar.fillRoundedRect(trackX, thumbY, 4, thumbH, 2);
+        }
+    }
+
+    _doSynthesize(recipe) {
+        const hero = this.heroRef;
+        const tracker = hero.elementTracker;
+        const efficiency = hero.acceleratorEfficiency || 1.0;
+        const cost = Math.max(1, Math.round(recipe.energyCost * efficiency));
+
+        // Consume target element
+        tracker.collected[recipe.target] = (tracker.collected[recipe.target] || 0) - 1;
+        if (tracker.collected[recipe.target] <= 0) delete tracker.collected[recipe.target];
+
+        // Consume projectile element (if not neutron-source)
+        if (recipe.projectile) {
+            tracker.collected[recipe.projectile] = (tracker.collected[recipe.projectile] || 0) - 1;
+            if (tracker.collected[recipe.projectile] <= 0) delete tracker.collected[recipe.projectile];
+        }
+
+        // Consume fuel
+        this.smelter.consumeFuel(hero, cost);
+
+        // Produce the synthetic element
+        tracker.collect(recipe.product, 1);
+        tracker.discover(recipe.product);
+
+        EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `Syntetisert: ${recipe.product}!`, color: '#8866ff' });
+
+        // Check for element bonus completions
+        const newBonuses = tracker.checkCompletions();
+        if (newBonuses.length > 0) {
+            tracker.applyBonusRewards(hero);
+            for (const bonus of newBonuses) {
+                EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `${bonus.name} fullført! ${bonus.desc}`, color: '#ffcc00' });
+            }
+        }
+
+        Audio.playPickup();
+        this._refresh();
+    }
+}

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -197,6 +197,13 @@ class GameScene extends Phaser.Scene {
                 }
             }
 
+            // Particle accelerator (P key)
+            const touchAccel = this.game.registry.get('touch_accelerator');
+            if (touchAccel) this.game.registry.set('touch_accelerator', false);
+            if ((Phaser.Input.Keyboard.JustDown(this.acceleratorKey) || touchAccel) && !this.scene.isActive('AcceleratorScene') && this._isInAccelerator()) {
+                this.scene.launch('AcceleratorScene', { heroRef: this.hero, worldNum: this.worldNum });
+            }
+
             const touchSkill = this.game.registry.get('touch_skilltree');
             if (touchSkill) this.game.registry.set('touch_skilltree', false);
             if ((Phaser.Input.Keyboard.JustDown(this.skillTreeKey) || touchSkill) && !this.scene.isActive('SkillScene')) {
@@ -206,6 +213,7 @@ class GameScene extends Phaser.Scene {
             // Auto-open prompts for special rooms
             this._checkCampRoom();
             this._checkChemLab();
+            this._checkAccelerator();
 
             this.monsterMgr.tickMonsters(delta);
             this._tickPet(delta);
@@ -262,6 +270,29 @@ class GameScene extends Phaser.Scene {
             }
         } else if (!this._isInChemLab()) {
             this._chemLabShown = false;
+        }
+    }
+
+    // ── Particle Accelerator ─────────────────────────────────────────────────
+
+    _isInAccelerator() {
+        if (!this._gen || !this._gen.specialRooms) return false;
+        const hx = this.hero.gridX, hy = this.hero.gridY;
+        return this._gen.specialRooms.some(room =>
+            room.type === 'accelerator' && room.tiles.some(t => t.x === hx && t.y === hy)
+        );
+    }
+
+    _checkAccelerator() {
+        if (!this._acceleratorShown && this._isInAccelerator()) {
+            this._acceleratorShown = true;
+            if (!this.hero.acceleratorUnlocked) {
+                this.hero.acceleratorUnlocked = true;
+                this._floatingText(this.hero.gridX, this.hero.gridY - 1, 'Fysiker-stien er ulåst!', '#8866ff');
+            }
+            this._showMessage('Partikkelakselerator! Trykk P for å syntetisere grunnstoffer.', '#8866ff');
+        } else if (!this._isInAccelerator()) {
+            this._acceleratorShown = false;
         }
     }
 

--- a/src/systems/ElementTracker.js
+++ b/src/systems/ElementTracker.js
@@ -93,6 +93,14 @@ class ElementTracker {
             if (r.magicAoe)         hero.magicAoeUnlocked = true;
             if (r.title)            hero.elementTitle = r.title;
             if (r.legendaryItem)    hero.legendaryItemEarned = true;
+            if (r.godMode) {
+                hero.godModeUnlocked = true;
+                hero.attack += 10;
+                hero.defense += 10;
+                hero.maxHearts += 5;
+                hero.hearts = Math.min(hero.hearts + 5, hero.maxHearts);
+                hero.visionRadius += 3;
+            }
         }
     }
 

--- a/src/systems/InputHandler.js
+++ b/src/systems/InputHandler.js
@@ -24,6 +24,7 @@ class InputHandler {
         scene.elementBookKey = scene.input.keyboard.addKey('B');
         scene.smelteryKey    = scene.input.keyboard.addKey('V');
         scene.chemLabKey     = scene.input.keyboard.addKey('C');
+        scene.acceleratorKey = scene.input.keyboard.addKey('P');
         scene.skillTreeKey   = scene.input.keyboard.addKey('T');
         scene.moveTimer    = 0;
 

--- a/src/systems/ItemSpawner.js
+++ b/src/systems/ItemSpawner.js
@@ -292,13 +292,27 @@ class ItemSpawner {
                     roomMinerals = 3 + Math.floor(Math.random() * 3);
                     mineralFn = () => rollBossMineral(wn); // T5-T6 minerals
                 } else if (room.type === 'gas_pocket') {
-                    // Gas pockets spawn oil/gas in deep zones, coal otherwise
+                    // Gas pockets spawn oil/gas in deep zones, coal otherwise.
+                    // From world 10+ they also yield noble gas elements directly
+                    // into the hero's element tracker when collected (He, Ne, Ar, Kr, Xe).
                     roomMinerals = 0;
                     const fuels = wn >= 15 ? [FUEL_DEFS.natural_gas, FUEL_DEFS.oil] : wn >= 10 ? [FUEL_DEFS.oil, FUEL_DEFS.coal] : [FUEL_DEFS.coal];
+                    const nobleGases = wn >= 10 ? ['Ar', 'Kr', 'Xe', 'Ne', 'He'] : null;
                     for (const tile of room.tiles) {
                         if (!scene.itemObjects.some(o => o.gridX === tile.x && o.gridY === tile.y)) {
                             const fuel = fuels[Math.floor(Math.random() * fuels.length)];
                             this._spawnFuelAt(tile.x, tile.y, fuel);
+                        }
+                    }
+                    // Noble gas collection: each gas pocket awards 1-2 random noble gases
+                    if (nobleGases && scene.hero && scene.hero.elementTracker) {
+                        const count = 1 + Math.floor(Math.random() * 2);
+                        for (let gi = 0; gi < count; gi++) {
+                            const gasIdx = Math.min(Math.floor(Math.random() * nobleGases.length), Math.floor((wn - 10) / 3));
+                            const gas = nobleGases[Math.min(gasIdx, nobleGases.length - 1)];
+                            scene.hero.elementTracker.collect(gas, 1);
+                            scene.hero.elementTracker.discover(gas);
+                            EventBus.emit('floatingText', { gx: room.tiles[0].x, gy: room.tiles[0].y, msg: `Edelgass samlet: ${gas}`, color: '#aaccff' });
                         }
                     }
                 } else {

--- a/src/systems/ItemSpawner.js
+++ b/src/systems/ItemSpawner.js
@@ -588,8 +588,8 @@ class ItemSpawner {
             const fuelId = fuelIds[Math.floor(Math.random() * fuelIds.length)];
             const fuel = FUEL_DEFS[fuelId];
             if (fuel) {
-                const fItem = { id: fuelId, name: fuel.name, type: 'fuel', tier: fuel.tier || 1, color: fuel.color, desc: fuel.desc || `Brensel (${fuel.energy} energi)`, count: 3 };
-                stock.push({ item: fItem, price: 5 + fuel.energy * 3 });
+                const fItem = { id: fuelId, name: fuel.name, type: 'fuel', tier: fuel.tier || 1, color: fuel.color, desc: fuel.desc || `Brensel (${fuel.energyValue} energi)`, count: 3 };
+                stock.push({ item: fItem, price: 5 + fuel.energyValue * 3 });
             }
         }
 

--- a/src/systems/SmeltingSystem.js
+++ b/src/systems/SmeltingSystem.js
@@ -241,6 +241,20 @@ class SmeltingSystem {
                 }
             }
         }
+        // Fission bonus: each U/Th in the element tracker acts as virtual
+        // fuel when the hero has mastered fission (Fysiker T3).
+        if (hero.fissionMastered || hero.fissionUpgraded) {
+            const fMul = hero.fissionEnergyMul || 1.0;
+            const uCount = hero.elementTracker ? hero.elementTracker.getCount('U') : 0;
+            const thCount = hero.elementTracker ? hero.elementTracker.getCount('Th') : 0;
+            total += Math.round((uCount * 50 + thCount * 40) * fMul);
+        }
+        // Fusion bonus: each He acts as massive virtual fuel (Fysiker T4).
+        if (hero.fusionMastered) {
+            const fuMul = hero.fusionEnergyMul || 1.0;
+            const heCount = hero.elementTracker ? hero.elementTracker.getCount('He') : 0;
+            total += Math.round(heCount * 200 * fuMul);
+        }
         return total;
     }
 

--- a/src/systems/SmeltingSystem.js
+++ b/src/systems/SmeltingSystem.js
@@ -249,11 +249,13 @@ class SmeltingSystem {
             const thCount = hero.elementTracker ? hero.elementTracker.getCount('Th') : 0;
             total += Math.round((uCount * 50 + thCount * 40) * fMul);
         }
-        // Fusion bonus: each He acts as massive virtual fuel (Fysiker T4).
+        // Fusion bonus: D-T fusion consumes H (deuterium) + Li (tritium bred
+        // from Li-6 + neutron). He is a byproduct, not fuel.
         if (hero.fusionMastered) {
             const fuMul = hero.fusionEnergyMul || 1.0;
-            const heCount = hero.elementTracker ? hero.elementTracker.getCount('He') : 0;
-            total += Math.round(heCount * 200 * fuMul);
+            const hCount = hero.elementTracker ? hero.elementTracker.getCount('H') : 0;
+            const liCount = hero.elementTracker ? hero.elementTracker.getCount('Li') : 0;
+            total += Math.round((hCount * 80 + liCount * 150) * fuMul);
         }
         return total;
     }


### PR DESCRIPTION
## Summary

Phase 5 of the Elements mod — the final phase. The game now contains all 118 elements of the periodic table, with 28 synthetic/transuranic elements that must be produced in a particle accelerator using realistic nuclear physics recipes.

### Bug fixes
- **Merchant NaN price** for fuel items (`fuel.energy` → `fuel.energyValue`) — natural gas showed "NaNg"
- **Uncraftable alloys**: PGM ore now yields Pt, Ir, Os (Pt-Ir alloy and plasma_core were impossible). Added vanadinite mineral for V (titanium alloy was impossible)

### 118 elements
- 28 synthetic elements added (Tc, Pm, Np through Og) with `synthetic: true` flag
- Periodic table layout extended with full period 7 + actinide row
- TRANSURANIC_RECIPES (28 entries) mirroring real nuclear physics:
  - Neutron bombardment for light transuranics (Np, Pu, Am)
  - Alpha bombardment (He-4) for medium (Cm, Bk, Cf)
  - Heavy-ion collisions (Cr+Bi, Fe+Pb, Ni+Bi) for transactinides
  - Ca-48 hot fusion for super-heavies (Fl through Og, up to 2000 energy)
- Endgame bonus "Guds periodiske system": all 118 → +10 ATK, +10 DEF, +5 hearts, +3 vision

### 15 new minerals
Covers previously-orphaned elements: vanadinite (V), bromargyryte (Br), iodyrite (I), germanite (Ge), stibnite (Sb), gallite (Ga), xenotime (Y+Dy+Er+Yb), samarskite (Sm+Gd+Pr), celestine (Sr), pollucite (Cs+Rb), calaverite (Te+Au), indite (In), thorite (Th). PGM ore expanded with Pt/Ir/Os.

### Noble gas collection
Gas pocket rooms (world 10+) now award 1-2 random noble gases (Ar, Kr, Xe, Ne, He) directly to the element tracker.

### Fysiker skill path (6th path)
Requires ≥1 Kjemiker skill. Unlocks when hero enters a particle accelerator room.
| Tier | Skill | Effect |
|------|-------|--------|
| T1 | Halvledergrunnlag | Semiconductor crafting + mineral magnet radius (×3) |
| T2 | Strålingsshield | No radiation HP loss + loot tier bonus (×2) |
| T3 | Fisjonsbeherskelse | 2× reactor energy from U/Th, unlocks tier 1-3 synthesis |
| T4 | Fusjonspioner | 5× D-T fusion energy from H+Li, unlocks ALL synthesis |

### Particle accelerator room
- Spawns from world 13 (20%), guaranteed world 15+
- AcceleratorScene: scrollable UI, tier-gated recipes, element consumption
- Opens with P key

### Fission/fusion energy (realistic D-T fusion)
- **Fission**: each U gives 50 virtual energy (×2 with T3), Th gives 40
- **Fusion**: uses D-T reaction — H (deuterium, 80 energy) + Li (tritium source via Li-6 + neutron, 150 energy), ×5 with T4. **He is a byproduct, not fuel.**
- Makes endgame super-heavy synthesis feasible

### New synergies
- **Atomsmedja** (Fysiker + Metallurg): +3 ATK, -25% accelerator energy
- **Kvantekjemi** (Fysiker + Kjemiker): +30% potion strength, +20% bomb radius

### Documentation
- **README.md**: Complete rewrite — now covers all 118 elements, 6 skill paths, pet system, CI, particle accelerator, full file structure
- **GDD.md**: Full Phase 5 section with Fysiker skill table, transuranic synthesis methods, D-T fusion mechanics, accelerator room, endgame reward
- **Elements-mod.md**: Phase 5 checklist ✅, corrected fusion fuel (H+Li, not He), updated energy table

## Test plan
- [ ] Open `index.html`; verify merchant fuel prices are numeric (not NaN)
- [ ] Play to world 5+; confirm vanadinite spawns and titanium alloy is now craftable
- [ ] Play to world 10+; enter a gas pocket and verify noble gas floating text appears
- [ ] Play to world 13+; find accelerator room, verify "Fysiker-stien er ulåst!" message
- [ ] Press P in accelerator; verify AcceleratorScene opens with recipe list
- [ ] Take Fysiker T3 (Fisjon); confirm tier 1-3 recipes become craftable and U/Th give virtual energy
- [ ] Synthesize Np (U + neutrons → Np); verify element tracker updates
- [ ] Take Fysiker T4 (Fusjon); confirm all recipes unlock including super-heavies
- [ ] Synthesize progressively heavier elements up the chain
- [ ] Open Element Book (B key); confirm synthetic elements appear with correct periodic table positions
- [ ] Verify save/load works with new hero properties
- [ ] Check `tests/test-runner.html` passes

https://claude.ai/code/session_01FHXkc6GijtFTVnV2XY5AJa