### PR TITLE
Wire all 6 gameplay technologies from semiconductor system (v0.44)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ---
 
+## v0.44 – 2026-04-17
+
+### Nye funksjoner
+- **Alle 6 gameplay-teknologier er nå fullt implementert:**
+  - **Kraftfelt:** Absorberer opptil 15 skade per etasje. Regenererer automatisk ved ny etasje. Visuell indikator i HUD
+  - **EMP-pulsgenerator:** 1 ladning per etasje. Trykk G for å lamme alle monstre i 50 runder. Blå flash-effekt
+  - **Laserturret:** 2 ladninger per etasje. Trykk H for å plassere. Automatisk 4 skade/runde mot monstre innen 5 ruter. Laserstrål-animasjon
+  - **Teleporter-noder:** Trykk J for å plassere noder (maks 5). Stå på en node og trykk J for å teleportere til neste. Sirkulær navigering
+  - **Elementskanner:** Alle mineraler vises automatisk på minikartet (grønne prikker) uavhengig av tåke
+  - **Ruteberegner:** BFS-pathfinding viser optimal rute til exit som grønn sti på minikartet
+
+### Tekniske endringer
+- Hero.takeDamage: Kraftfelt-absorpsjon før HP-tap med flytende tekst
+- CombatManager: Nye `handleEMP`, `handlePlaceTurret`, `handleTeleporter`, `tickLaserTurrets` med laser-beam-animasjon
+- UIScene minimap: BFS pathfinding (`_bfsPath`), elementskanner-overlay, turret/teleporter-noder-visning
+- UIScene HUD: Tech-status-indikatorer (kraftfelt HP, EMP/turret-ladninger, teleporter, rute, skanner)
+- InputHandler: G/H/J hurtigtaster for EMP/turret/teleporter
+- GameScene: Teknologi-effekter initialiseres per etasje (kraftfelt regen, EMP/turret-ladninger)
+- HeroCrafting: `empCharges`, `laserTurretCharges` i init/serialize/applyStats
+- MonsterManager: Laserturret-tick integrert i monster-syklusen
+
+---
+
 ## v0.43 – 2026-04-17
 
 ### Nye funksjoner

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,5 +1,5 @@
 # Labyrint Hero – Game Design Document
-**Versjon:** 0.43
+**Versjon:** 0.44
 **Sist oppdatert:** 2026-04-17
 
 ---
@@ -646,12 +646,12 @@ Konverterer rå elementer til halvlederkvalitet. Høy energikostnad.
 
 | Teknologi | Halvleder-input | Ny mekanikk |
 |-----------|----------------|-------------|
-| Ruteberegner | Si-wafer | Optimal rute på minikartet |
-| Elementskanner | Ge-krystall | Avslører alle elementer på etasjen |
-| Laserturret | GaAs | Plasserbar automatisk turret (4 skade/runde) |
-| Teleporter-noder | ITO | Plassér og teleportér mellom rom |
-| EMP-puls | SiC | Slår ut alle monstre i 50 runder |
-| Kraftfelt | CdTe | 15-skade barriere, regenererer mellom etasjer |
+| Ruteberegner | Si-wafer | BFS-pathfinding viser optimal rute til exit som grønn sti på minikartet. Alltid aktiv |
+| Elementskanner | Ge-krystall | Alle mineraler vises på minikartet (grønne prikker) uavhengig av tåke |
+| Laserturret | GaAs | 2 ladninger/etasje. [H] plasserer turret. 4 skade/runde automatisk mot monstre innen 5 ruter |
+| Teleporter-noder | ITO | [J] plasserer noder (maks 5). Stå på node + [J] teleporterer til neste node |
+| EMP-puls | SiC | 1 ladning/etasje. [G] lammer ALLE monstre i 50 runder |
+| Kraftfelt | CdTe | Absorberer 15 skade. Regenererer til 15 HP ved ny etasje |
 | Solcellepanel | CdTe | +30 gratis energi per verden |
 | Termoelektrisk gen. | Ge | +50 energi i vulkan/magma-soner |
 | Reaktorkontroll | Si-wafer | +50% fisjon/fusjon-energi |

--- a/src/entities/Hero.js
+++ b/src/entities/Hero.js
@@ -228,7 +228,16 @@ class Hero {
         }
         const armorMul = 1 + (this.elementArmorBonus || 0);
         const totalDef = Math.round((this.defense + cb.defense) * armorMul);
-        const dmg = Math.max(1, amount - totalDef);
+        let dmg = Math.max(1, amount - totalDef);
+        if (this.techForceFieldHP > 0) {
+            const absorbed = Math.min(dmg, this.techForceFieldHP);
+            this.techForceFieldHP -= absorbed;
+            dmg -= absorbed;
+            if (absorbed > 0 && this.scene) {
+                this.scene._floatingText(this.gridX, this.gridY, `🛡 -${absorbed}`, '#55ff88');
+            }
+            if (dmg <= 0) return false;
+        }
         this.hearts -= dmg;
         if (this.hearts <= 0) {
             this.hearts = 0;

--- a/src/entities/HeroCrafting.js
+++ b/src/entities/HeroCrafting.js
@@ -78,6 +78,8 @@ const HeroCrafting = {
         hero.techReactorControl = false;
         hero.techSuperconductor = false;
         hero.teleporterNodes = [];
+        hero.empCharges = 0;
+        hero.laserTurretCharges = 0;
 
         // Zone progression (Phase 4)
         hero.completedZones = [];
@@ -164,6 +166,8 @@ const HeroCrafting = {
             techReactorControl:   hero.techReactorControl,
             techSuperconductor:   hero.techSuperconductor,
             teleporterNodes:      hero.teleporterNodes ? [...hero.teleporterNodes] : [],
+            empCharges:           hero.empCharges || 0,
+            laserTurretCharges:   hero.laserTurretCharges || 0,
             completedZones:       [...hero.completedZones],
             appliedElementBonuses: { ...hero.appliedElementBonuses },
             elementGoldMul:       hero.elementGoldMul,
@@ -243,6 +247,8 @@ const HeroCrafting = {
         hero.techReactorControl   = stats.techReactorControl   || false;
         hero.techSuperconductor   = stats.techSuperconductor   || false;
         hero.teleporterNodes      = stats.teleporterNodes      ? [...stats.teleporterNodes] : [];
+        hero.empCharges           = stats.empCharges           || 0;
+        hero.laserTurretCharges   = stats.laserTurretCharges   || 0;
         hero.completedZones       = stats.completedZones       ? [...stats.completedZones] : [];
         hero.appliedElementBonuses = stats.appliedElementBonuses ? { ...stats.appliedElementBonuses } : {};
         hero.elementGoldMul       = stats.elementGoldMul       || 0;

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -82,6 +82,13 @@ class GameScene extends Phaser.Scene {
             this.hero._draw();
         }
 
+        // ── Technology effects on floor start ─────────────────────────────
+        if (this.hero.techForceField) this.hero.techForceFieldHP = 15;
+        if (this.hero.techEMP) this.hero.empCharges = Math.max(this.hero.empCharges || 0, 1);
+        if (this.hero.techLaserTurret) this.hero.laserTurretCharges = Math.max(this.hero.laserTurretCharges || 0, 2);
+        this.laserTurrets = [];
+        this.teleporterNodes = [];
+
         // ── Pet companion ────────────────────────────────────────────────────
         this.pet = null;
         if (this.heroStats && this.heroStats.pet) {
@@ -169,6 +176,9 @@ class GameScene extends Phaser.Scene {
             this.combat.handleAttack();
             this.combat.handleBow();
             this.combat.handleUseItem();
+            this.combat.handleEMP();
+            this.combat.handlePlaceTurret();
+            this.combat.handleTeleporter();
             this.inputHandler.handleZoom();
 
             const touchInv = this.game.registry.get('touch_inventory');

--- a/src/scenes/UIScene.js
+++ b/src/scenes/UIScene.js
@@ -201,16 +201,17 @@ class UIScene extends Phaser.Scene {
             g.fillRect(px, py, sc, sc);
         }
 
-        // Minerals (tier-colored dots, requires Geologist skill)
-        if ((gs.hero.mineralVisionRadius || 0) > 0 && gs.itemObjects) {
+        // Minerals (tier-colored dots, requires Geologist skill or Element Scanner)
+        const hasScanner = gs.hero.techElementScanner;
+        if (((gs.hero.mineralVisionRadius || 0) > 0 || hasScanner) && gs.itemObjects) {
             for (const obj of gs.itemObjects) {
                 if (!obj.isMineral) continue;
-                if (gs.fog[obj.gridY] && gs.fog[obj.gridY][obj.gridX] === FOG.DARK) continue;
+                if (!hasScanner && gs.fog[obj.gridY] && gs.fog[obj.gridY][obj.gridX] === FOG.DARK) continue;
                 const px = mx + obj.gridX * sc;
                 const py = my + obj.gridY * sc;
                 const tierCol = (typeof MINERAL_TIER_COLORS !== 'undefined' && obj.item)
                     ? (MINERAL_TIER_COLORS[obj.item.tier] || 0x88ff88) : 0x88ff88;
-                g.fillStyle(tierCol, 0.8);
+                g.fillStyle(hasScanner ? 0x44ffaa : tierCol, 0.8);
                 g.fillRect(px, py, sc, sc);
             }
         }
@@ -221,6 +222,33 @@ class UIScene extends Phaser.Scene {
             const ppy = my + gs.pet.gridY * sc;
             g.fillStyle(0xffaadd);
             g.fillRect(ppx, ppy, sc, sc);
+        }
+
+        // Route calculator (BFS path to exit/boss)
+        if (gs.hero.techRouteCalc) {
+            const path = this._bfsPath(gs, gs.hero.gridX, gs.hero.gridY, gs.exitX, gs.exitY);
+            if (path) {
+                g.fillStyle(0x00ff88, 0.45);
+                for (const p of path) {
+                    g.fillRect(mx + p.x * sc, my + p.y * sc, sc, sc);
+                }
+            }
+        }
+
+        // Teleporter nodes (cyan dots)
+        if (gs.teleporterNodes) {
+            for (const n of gs.teleporterNodes) {
+                g.fillStyle(0x88ccff);
+                g.fillRect(mx + n.gx * sc, my + n.gy * sc, sc, sc);
+            }
+        }
+
+        // Laser turrets (blue dots)
+        if (gs.laserTurrets) {
+            for (const t of gs.laserTurrets) {
+                g.fillStyle(0x4488ff);
+                g.fillRect(mx + t.gx * sc, my + t.gy * sc, sc, sc);
+            }
         }
 
         // Hero (bright white dot)
@@ -234,6 +262,40 @@ class UIScene extends Phaser.Scene {
         b.clear();
         b.lineStyle(1, 0x334466, 0.8);
         b.strokeRect(mx - 2, my - 2, mW + 4, mH + 4);
+    }
+
+    _bfsPath(gs, sx, sy, tx, ty) {
+        if (sx === tx && sy === ty) return [];
+        const W = gs.tileW, H = gs.tileH, maze = gs.maze;
+        const visited = Array.from({ length: H }, () => new Uint8Array(W));
+        const prev = Array.from({ length: H }, () => new Array(W).fill(null));
+        const queue = [{ x: sx, y: sy }];
+        visited[sy][sx] = 1;
+        const dirs = [[0, -1], [0, 1], [-1, 0], [1, 0]];
+        while (queue.length > 0) {
+            const { x, y } = queue.shift();
+            for (const [dx, dy] of dirs) {
+                const nx = x + dx, ny = y + dy;
+                if (nx < 0 || nx >= W || ny < 0 || ny >= H) continue;
+                if (visited[ny][nx]) continue;
+                const t = maze[ny][nx];
+                if (t === TILE.WALL || t === TILE.CRACKED_WALL) continue;
+                visited[ny][nx] = 1;
+                prev[ny][nx] = { x, y };
+                if (nx === tx && ny === ty) {
+                    const path = [];
+                    let cx = tx, cy = ty;
+                    while (cx !== sx || cy !== sy) {
+                        path.push({ x: cx, y: cy });
+                        const p = prev[cy][cx];
+                        cx = p.x; cy = p.y;
+                    }
+                    return path;
+                }
+                queue.push({ x: nx, y: ny });
+            }
+        }
+        return null;
     }
 
     // ── Main refresh (called every frame from update) ─────────────────────────
@@ -354,6 +416,12 @@ class UIScene extends Phaser.Scene {
             const secs = Math.ceil((b.msLeft || 0) / 1000);
             effects.push(`+${b.amount} ${label} (${secs}s)`);
         }
+        if (hero.techForceFieldHP > 0) effects.push(`🛡 Felt ${hero.techForceFieldHP}`);
+        if (hero.techEMP && (hero.empCharges || 0) > 0) effects.push(`⚡ EMP ×${hero.empCharges} [G]`);
+        if (hero.techLaserTurret && (hero.laserTurretCharges || 0) > 0) effects.push(`🔫 Turret ×${hero.laserTurretCharges} [H]`);
+        if (hero.techTeleporter) effects.push(`📡 Tele [J]`);
+        if (hero.techRouteCalc) effects.push(`🗺 Rute`);
+        if (hero.techElementScanner) effects.push(`🔬 Skanner`);
         if (effects.length > 0) {
             this.statusText.setText(effects.join('  '));
             this.statusText.setVisible(true);

--- a/src/systems/CombatManager.js
+++ b/src/systems/CombatManager.js
@@ -88,6 +88,138 @@ class CombatManager {
         }
     }
 
+    // ── Tech Gadgets ──────────────────────────────────────────────────────────
+
+    handleEMP() {
+        const scene = this.scene;
+        const touchEmp = scene.game.registry.get('touch_emp');
+        if (touchEmp) scene.game.registry.set('touch_emp', false);
+        if (!Phaser.Input.Keyboard.JustDown(scene.empKey) && !touchEmp) return;
+        if (!scene.hero.techEMP) return;
+        if ((scene.hero.empCharges || 0) <= 0) {
+            scene._showMessage('Ingen EMP-ladninger igjen!', '#778899');
+            return;
+        }
+        scene.hero.empCharges--;
+        Audio.playLevelUp();
+        scene.cameras.main.flash(400, 120, 180, 255, false);
+        scene.cameras.main.shake(200, 0.008);
+        let stunned = 0;
+        for (const m of scene.monsters) {
+            if (!m.alive) continue;
+            m.applyStun(50);
+            stunned++;
+        }
+        scene._floatingText(scene.hero.gridX, scene.hero.gridY, `⚡ EMP! ${stunned} monstre lammet`, '#88ccff', true);
+    }
+
+    handlePlaceTurret() {
+        const scene = this.scene;
+        const touchTurret = scene.game.registry.get('touch_turret');
+        if (touchTurret) scene.game.registry.set('touch_turret', false);
+        if (!Phaser.Input.Keyboard.JustDown(scene.turretKey) && !touchTurret) return;
+        if (!scene.hero.techLaserTurret) return;
+        if ((scene.hero.laserTurretCharges || 0) <= 0) {
+            scene._showMessage('Ingen turret-ladninger igjen!', '#6688aa');
+            return;
+        }
+        const gx = scene.hero.gridX, gy = scene.hero.gridY;
+        if (scene.laserTurrets && scene.laserTurrets.some(t => t.gx === gx && t.gy === gy)) {
+            scene._showMessage('Allerede en turret her!', '#6688aa');
+            return;
+        }
+        scene.hero.laserTurretCharges--;
+        const turretGfx = scene.add.graphics();
+        turretGfx.setDepth(4);
+        const px = gx * TILE_SIZE, py = gy * TILE_SIZE, s = TILE_SIZE;
+        turretGfx.fillStyle(0x4466aa, 1);
+        turretGfx.fillRect(px + 6, py + 6, s - 12, s - 12);
+        turretGfx.fillStyle(0x88bbff, 1);
+        turretGfx.fillRect(px + 10, py + 10, s - 20, s - 20);
+        turretGfx.fillStyle(0xff4444, 1);
+        turretGfx.fillCircle(px + s / 2, py + s / 2, 3);
+        scene.laserTurrets.push({ gx, gy, graphic: turretGfx });
+        Audio.playPickup();
+        scene._floatingText(gx, gy, '🔫 Turret plassert!', '#6688ff');
+    }
+
+    handleTeleporter() {
+        const scene = this.scene;
+        const touchTele = scene.game.registry.get('touch_teleporter');
+        if (touchTele) scene.game.registry.set('touch_teleporter', false);
+        if (!Phaser.Input.Keyboard.JustDown(scene.teleporterKey) && !touchTele) return;
+        if (!scene.hero.techTeleporter) return;
+        const gx = scene.hero.gridX, gy = scene.hero.gridY;
+        const nodes = scene.teleporterNodes || [];
+        const atNode = nodes.findIndex(n => n.gx === gx && n.gy === gy);
+        if (atNode !== -1) {
+            if (nodes.length < 2) {
+                scene._showMessage('Plassér minst 2 noder for å teleportere!', '#aabbcc');
+                return;
+            }
+            const next = nodes[(atNode + 1) % nodes.length];
+            scene.hero.moveTo(next.gx, next.gy);
+            scene.hero.gridX = next.gx;
+            scene.hero.gridY = next.gy;
+            scene.mapRenderer.updateFog();
+            Audio.playExit();
+            scene.cameras.main.flash(200, 100, 150, 220, false);
+            scene._floatingText(next.gx, next.gy, '✦ Teleportert!', '#aabbff');
+            return;
+        }
+        if (nodes.length >= 5) {
+            scene._showMessage('Maks 5 teleporter-noder!', '#aabbcc');
+            return;
+        }
+        const nodeGfx = scene.add.graphics();
+        nodeGfx.setDepth(2);
+        const px = gx * TILE_SIZE, py = gy * TILE_SIZE, s = TILE_SIZE;
+        nodeGfx.fillStyle(0x5566aa, 0.5);
+        nodeGfx.fillCircle(px + s / 2, py + s / 2, s / 3);
+        nodeGfx.lineStyle(2, 0xaabbff, 0.8);
+        nodeGfx.strokeCircle(px + s / 2, py + s / 2, s / 3);
+        nodes.push({ gx, gy, graphic: nodeGfx });
+        scene.teleporterNodes = nodes;
+        Audio.playPickup();
+        scene._floatingText(gx, gy, `📡 Node ${nodes.length} plassert`, '#aabbff');
+    }
+
+    // ── Laser turret AI (called from MonsterManager tick) ──────────────────────
+
+    tickLaserTurrets() {
+        const scene = this.scene;
+        if (!scene.laserTurrets || scene.laserTurrets.length === 0) return;
+        for (const turret of scene.laserTurrets) {
+            let closest = null, bestDist = Infinity;
+            for (const m of scene.monsters) {
+                if (!m.alive) continue;
+                const dist = Math.abs(m.gridX - turret.gx) + Math.abs(m.gridY - turret.gy);
+                if (dist <= 5 && dist < bestDist) { bestDist = dist; closest = m; }
+            }
+            if (!closest) continue;
+            const result = closest.takeDamage(4);
+            scene._floatingText(closest.gridX, closest.gridY, '-4 ⚡', '#88bbff');
+            this._drawLaserBeam(turret, closest);
+            if (result === 'enraged') this._onBossEnraged(closest);
+            else if (result === true) this._onMonsterKilled(closest);
+        }
+    }
+
+    _drawLaserBeam(turret, target) {
+        const scene = this.scene;
+        const beam = scene.add.graphics();
+        beam.setDepth(15);
+        beam.lineStyle(2, 0x88bbff, 0.9);
+        beam.lineBetween(
+            turret.gx * TILE_SIZE + TILE_SIZE / 2, turret.gy * TILE_SIZE + TILE_SIZE / 2,
+            target.gridX * TILE_SIZE + TILE_SIZE / 2, target.gridY * TILE_SIZE + TILE_SIZE / 2
+        );
+        scene.tweens.add({
+            targets: beam, alpha: 0, duration: 300,
+            onComplete: () => { if (beam.scene) beam.destroy(); }
+        });
+    }
+
     // ── Damage calculation (pure logic, testable) ──────────────────────────────
 
     /**

--- a/src/systems/InputHandler.js
+++ b/src/systems/InputHandler.js
@@ -26,6 +26,9 @@ class InputHandler {
         scene.chemLabKey     = scene.input.keyboard.addKey('C');
         scene.acceleratorKey = scene.input.keyboard.addKey('P');
         scene.skillTreeKey   = scene.input.keyboard.addKey('T');
+        scene.empKey         = scene.input.keyboard.addKey('G');
+        scene.turretKey      = scene.input.keyboard.addKey('H');
+        scene.teleporterKey  = scene.input.keyboard.addKey('J');
         scene.moveTimer    = 0;
 
         // Mouse wheel zoom

--- a/src/systems/MonsterManager.js
+++ b/src/systems/MonsterManager.js
@@ -145,6 +145,8 @@ class MonsterManager {
 
         if (!regularReady && !bossReady) return;
 
+        if (regularReady) scene.combat.tickLaserTurrets();
+
         for (const m of [...scene.monsters]) {
             if (!m.alive) continue;
             const isBoss = m.type === 'boss';


### PR DESCRIPTION
## Summary
Follow-up to #106 – implements the actual gameplay effects for all 6 semiconductor technologies that were flag-only.

| Teknologi | Tast | Effekt |
|-----------|------|--------|
| **Kraftfelt** | Passiv | Absorberer 15 skade per etasje, regenererer automatisk ved ny etasje |
| **EMP-puls** | G | Lammer alle monstre i 50 runder (1 ladning/etasje) |
| **Laserturret** | H | Plasserer turret som gjør 4 skade/runde mot monstre innen 5 ruter (2 ladninger/etasje) |
| **Teleporter-noder** | J | Plassér noder (maks 5), stå på node + J for å teleportere til neste |
| **Elementskanner** | Passiv | Alle mineraler synlige på minikartet gjennom tåke |
| **Ruteberegner** | Passiv | BFS-pathfinding viser optimal rute til exit som grønn sti på minikartet |

### Technical changes
- `Hero.takeDamage`: Force field absorbs damage before HP with floating text feedback
- `CombatManager`: New `handleEMP`, `handlePlaceTurret`, `handleTeleporter`, `tickLaserTurrets` with laser beam animation
- `UIScene`: BFS pathfinding (`_bfsPath`), element scanner overlay, turret/teleporter node display, tech status indicators in HUD
- `InputHandler`: G/H/J hotkeys for EMP/turret/teleporter
- `GameScene`: Tech effects initialized per floor (force field regen, EMP/turret charges)
- `HeroCrafting`: `empCharges`, `laserTurretCharges` in init/serialize/applyStats
- `MonsterManager`: Laser turret tick integrated into monster cycle

## Test plan
- [ ] Install Kraftfelt → take damage → verify shield absorbs before HP, shows floating text
- [ ] Enter new floor → verify force field resets to 15
- [ ] Install EMP → press G → verify all monsters stunned for 50 rounds, blue flash
- [ ] Install Laserturret → press H → verify turret placed, auto-attacks nearby monsters with beam animation
- [ ] Install Teleporter → press J twice in different rooms → press J on first node → verify teleport to second
- [ ] Install Elementskanner → check minimap shows all minerals (green dots) even through fog
- [ ] Install Ruteberegner → check minimap shows green path to exit
- [ ] Save/load → verify empCharges, laserTurretCharges persist correctly

https://claude.ai/code/session_01JFmWCC8hDFBLTCaxKAQQk6