### PR TITLE
Fix all 18 open issues across 5 sprints (v0.45)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -47,6 +47,17 @@
 - SmelteryScene: Mineral-tooltips med tier og yields i Lager-fanen
 - ItemSpawner/SmelteryScene/AcceleratorScene: Bonus-meldinger bruker `big: true` for tydeligere visning
 
+### Nye funksjoner (Sprint 5)
+- **Varierte gjenstandssprites (#124):** Potions (flaskeform), dynamitt (røde pinner med lunte), bomber (rund med lunte), syrer (boblende flaske). Både verdenskart og inventar-ikoner er oppdatert
+- **4 nye monstertyper (#125):** Skjelett (verden 4+, høy ATK), Golem (verden 6+, høy HP/lav ATK), Skygge (verden 8+, lilla, unnvikende), Demon (verden 10+, rød, brann). Hver type har unike prosedyregenererte sprites og tilpassede stats
+
+### Tekniske endringer (Sprint 5)
+- ItemGraphics: Nye `drawWorldIcon`/`drawInventoryIcon`-case for `_chemType` (potion, explosive, acid, medicine)
+- constants.js: 4 nye monster-entries i HP/ATK/COLOR/XP-tabellene
+- MonsterManager: `_monsterPool()` utvides til 11 verdener med gradvis innføring av nye monstre
+- MonsterGraphics: Nye `drawSkeleton`, `drawGolem`, `drawWraith`, `drawDemon` prosedyre-sprites
+- Monster.js: Switch-case og delegat-metoder for de 4 nye typene
+
 ---
 
 ## v0.44 – 2026-04-17

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ---
 
+## v0.45 – 2026-04-18
+
+### Feilrettinger
+- **Scroll i menyer påvirket kamerazoom (#123):** Musehjul-scroll i overlay-scener (Smelteovn, Kjemilab, Inventar, Elementbok, Skilltre, Akselerator, Innstillinger) blokkerer nå zoom-endring i GameScene. Også lagt til AcceleratorScene i input-blokkeringen
+- **Skilltre-synergier overlappet med T4-skills (#115):** Synergy-seksjonen beregner nå posisjon dynamisk basert på faktisk antall tiers i stedet for hardkodet 3. T4-badge vises nå korrekt
+
+### Balanseendringer
+- **Skilltre-synergier krever høyere tier (#116):** 6 av 12 synergier krever nå T2-skills fra begge stier i stedet for bare T1. Påvirkede synergier: Smiekunst, Alkymist, Giftjeger, Transmutasjon, Atomsmedja og Kvantekjemi. Tier-krav vises i synergi-oversikten
+
+### Tekniske endringer
+- InputHandler: Wheel-handler sjekker `scene.isActive()` for alle overlay-scener før zoom
+- GameScene: `blocked`-variabel inkluderer nå AcceleratorScene
+- SkillScene: `cardsEndY` beregnes fra `maxTiers` dynamisk, tier-badge bruker `'T' + (tierIndex + 1)`
+- skills.js: `getActiveSynergies()` sjekker `pathMaxTier` mot `syn.minTier` (default 1). 6 synergier har fått `minTier: 2`
+
+---
+
 ## v0.44 – 2026-04-17
 
 ### Nye funksjoner

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,15 @@
 - ChemistrySystem: `potionScale` redusert (0.15/verden). 25% maxHP-gulv kun for `mol.tier >= 3`
 - Inventory: Deserialisering gjenskaper `_chemItem` via `ChemistrySystem._createUsableItem()` for molekyler i quickUse og backpack
 - ChemLabScene: Tab-system (Oppskrifter/Transmutasjon), grunnstoff-filterrad, større panel
+- **Partikkelakselerator spawner nå fra verden 13+ (#108):** Akselerator-rom plasseres nå før valgfrie rom (malmkammer, hydrotermisk, gasslomme, magmakammer) i prioritering, slik at dead-ends er tilgjengelige
+- **Lettere å finne basis-grunnstoffer i høyere verdener (#119):** 20% sjanse for å rulle tier 1-2 mineral uansett verdensnummer, sikrer tilgang til Al, Fe, Cu og andre viktige elementer
+- **Elementbok: lantanoider/aktinoider flyttet ned (#113):** Økt avstand (1.5 rader) mellom hovedtabellen og lantanoider/aktinoider. Lagt til «Ln»/«An»-etiketter. Gruppebonuser vises nå i flere rader
+- **Elementbok: viser raffinerte grunnstoffer (#120):** Tooltip viser nå antall rene/raffinerte former ved siden av rå-antallet (f.eks. «Lagret: 12 (3 ren)»)
+
+### Tekniske endringer (Sprint 3)
+- maze.js: Akselerator-plassering flyttet opp i `_placeSpecialRooms()` prioritet (etter camp_room/chem_lab, før valgfrie rom)
+- minerals.js: `rollMineralTier()` har 20% sjanse for basis-tier (1-2) fra verden 5+
+- ElementBookScene: `yOffset` for rows >= 8 økt til `+1.5`, lantanoid/aktinoid-labels, multi-rad bonuser, raffinert-telling i tooltip
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,12 @@
 ### Feilrettinger
 - **Scroll i menyer påvirket kamerazoom (#123):** Musehjul-scroll i overlay-scener (Smelteovn, Kjemilab, Inventar, Elementbok, Skilltre, Akselerator, Innstillinger) blokkerer nå zoom-endring i GameScene. Også lagt til AcceleratorScene i input-blokkeringen
 - **Skilltre-synergier overlappet med T4-skills (#115):** Synergy-seksjonen beregner nå posisjon dynamisk basert på faktisk antall tiers i stedet for hardkodet 3. T4-badge vises nå korrekt
+- **Potions fra kjemilab healte fullt (#121):** Redusert potionScale fra 0.4 til 0.15 per verden for mykere skalering. 25% maxHP-gulv gjelder nå kun T3+ potions. Fikset serialisering: molekyl-items i ryggsekk og quick-use gjenskaper nå `use()`-funksjonen korrekt ved innlasting
+
+### Nye funksjoner
+- **Grunnstoff-filtrering i Kjemilab (#109):** Klikkbare grunnstoff-ikoner øverst filtrerer oppskrifter etter ingrediens. Grunnstoffer man ikke har vises dimmet
+- **Egen Transmutasjon-tab i Kjemilab (#111):** Ny fane «Transmutasjon» med dedikert visning av alle tilgjengelige transmutasjoner, input → output og knapper. Kun synlig når transmutasjon er låst opp
+- **Større kjemilab-vindu (#117):** Kjemilab-panelet utvidet fra 760×600 til 960×720 for bedre oversikt
 
 ### Balanseendringer
 - **Skilltre-synergier krever høyere tier (#116):** 6 av 12 synergier krever nå T2-skills fra begge stier i stedet for bare T1. Påvirkede synergier: Smiekunst, Alkymist, Giftjeger, Transmutasjon, Atomsmedja og Kvantekjemi. Tier-krav vises i synergi-oversikten
@@ -16,6 +22,9 @@
 - GameScene: `blocked`-variabel inkluderer nå AcceleratorScene
 - SkillScene: `cardsEndY` beregnes fra `maxTiers` dynamisk, tier-badge bruker `'T' + (tierIndex + 1)`
 - skills.js: `getActiveSynergies()` sjekker `pathMaxTier` mot `syn.minTier` (default 1). 6 synergier har fått `minTier: 2`
+- ChemistrySystem: `potionScale` redusert (0.15/verden). 25% maxHP-gulv kun for `mol.tier >= 3`
+- Inventory: Deserialisering gjenskaper `_chemItem` via `ChemistrySystem._createUsableItem()` for molekyler i quickUse og backpack
+- ChemLabScene: Tab-system (Oppskrifter/Transmutasjon), grunnstoff-filterrad, større panel
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,10 +30,22 @@
 - **Elementbok: lantanoider/aktinoider flyttet ned (#113):** Økt avstand (1.5 rader) mellom hovedtabellen og lantanoider/aktinoider. Lagt til «Ln»/«An»-etiketter. Gruppebonuser vises nå i flere rader
 - **Elementbok: viser raffinerte grunnstoffer (#120):** Tooltip viser nå antall rene/raffinerte former ved siden av rå-antallet (f.eks. «Lagret: 12 (3 ren)»)
 
-### Tekniske endringer (Sprint 3)
-- maze.js: Akselerator-plassering flyttet opp i `_placeSpecialRooms()` prioritet (etter camp_room/chem_lab, før valgfrie rom)
+### Nye funksjoner (Sprint 4)
+- **Delvis bruk av energikilder (#112):** Ubrukt energi fra brensel lagres nå i en reserve (`fuelReserve`) som brukes ved neste crafting-operasjon. Kull (3 energi) brukt på 1-energi-oppskrift bevarer 2 energi til neste gang
+- **Smi nøkler og hakker (#122):** Nye smi-oppskrifter: Smidd nøkkel (bronse), Smidd hakke (stål). Viktige verktøy kan nå produseres i stedet for å finnes tilfeldig
+- **Forstørrelsesbelte – øk ryggsekk (#118):** Nytt smi-objekt fra skandium som gir +3 ryggsekk-plasser. Kan oppgraderes maks 2 ganger (totalt +6 plasser)
+- **Tooltip over mineraler i Lager (#110):** Hover over mineral i Lager-fanen viser tier og hvilke grunnstoffer det gir
+- **Tydelige meldinger ved gruppeprestasjoner (#114):** Element-gruppeprestasjoner og synergier vises nå med stor, tydelig tekst (★-merket) på spillskjermen. Gjelder for smelting, akselerator og mineral-oppsamling
+
+### Tekniske endringer
+- maze.js: Akselerator-plassering flyttet opp i `_placeSpecialRooms()` prioritet
 - minerals.js: `rollMineralTier()` har 20% sjanse for basis-tier (1-2) fra verden 5+
 - ElementBookScene: `yOffset` for rows >= 8 økt til `+1.5`, lantanoid/aktinoid-labels, multi-rad bonuser, raffinert-telling i tooltip
+- SmeltingSystem: `fuelReserve` deduceres først i `consumeFuel()`, overskudd lagres tilbake. `calculateFuelEnergy()` inkluderer reserve
+- HeroCrafting: Nye felter `fuelReserve`, `_backpackUpgrades` med serialisering
+- alloys.js: Nye smi-oppskrifter `forged_key` (bronse), `forged_pickaxe` (stål), `backpack_upgrade` (skandium)
+- SmelteryScene: Mineral-tooltips med tier og yields i Lager-fanen
+- ItemSpawner/SmelteryScene/AcceleratorScene: Bonus-meldinger bruker `big: true` for tydeligere visning
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,7 +37,16 @@
 - **Tooltip over mineraler i Lager (#110):** Hover over mineral i Lager-fanen viser tier og hvilke grunnstoffer det gir
 - **Tydelige meldinger ved gruppeprestasjoner (#114):** Element-gruppeprestasjoner og synergier vises nå med stor, tydelig tekst (★-merket) på spillskjermen. Gjelder for smelting, akselerator og mineral-oppsamling
 
+### Forbedringer (oppfølging)
+- **Partikkelakselerator synlig på kart og minikart:** Akselerator-rom har nå distinkt lilla sci-fi-dekorasjon med ringstruktur, energikjerne og partikkelspor. Spesialrom (leirplass, kjemilab, akselerator) vises nå med fargekodede markører på minikartet
+- **Jevnere mineralfordeling i høyere verdener:** Ny vektet fordeling: 15% 3 tier under, 20% 2 under, 20% 1 under, 35% aktuell tier, 10% tier over. Sikrer T1-T3 mineraler selv i verden 13+
+- **Grunnstoff-filtrering i Smelteovn:** Klikkbare grunnstoff-ikoner øverst i Smelt-, Legering- og Smi-faner filtrerer oppskrifter etter ingrediens-element. Samme layout som Kjemilaben
+
 ### Tekniske endringer
+- MapRenderer: Ny `accelerator` case med lilla ringstruktur og metallvegger
+- UIScene: Minimap viser camp_room (oransje), chem_lab (grønn), accelerator (lilla) markører
+- minerals.js: `rollMineralTier()` redesignet med 5-trinn vektet fordeling i stedet for hard base-tier
+- SmelteryScene: Ny `_drawElementFilterRow()` med klikkbare grunnstoff-badges, element-filter på legerings-tab
 - maze.js: Akselerator-plassering flyttet opp i `_placeSpecialRooms()` prioritet
 - minerals.js: `rollMineralTier()` har 20% sjanse for basis-tier (1-2) fra verden 5+
 - ElementBookScene: `yOffset` for rows >= 8 økt til `+1.5`, lantanoid/aktinoid-labels, multi-rad bonuser, raffinert-telling i tooltip

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,6 +1,6 @@
 # Labyrint Hero – Game Design Document
-**Versjon:** 0.44
-**Sist oppdatert:** 2026-04-17
+**Versjon:** 0.45
+**Sist oppdatert:** 2026-04-18
 
 ---
 
@@ -306,18 +306,18 @@ Livspotte, Stor livspotte, Styrkebrygg (midlertidig +ATK i 60 sek, skalerer med 
 - **Kjemiker** (lås: finn kjemisk lab) – potion-varighet, bombeskade, eksplosjonsradius. **Kreves for å lage kjemikalier.**
 
 ### Synergier
-Aktiveres automatisk når helten har evner fra begge stier i et par:
-| Synergi | Stier | Effekt |
-|---------|-------|--------|
-| Motangrep | Kriger + Villmarksjeger | 20% motangrep |
-| Tornehud | Kriger + Villmarksjeger | 1 tornskade, +1 syn |
-| Jordens kraft | Geolog + Kriger | +1 DEF, +1 mineral-syn |
-| Smiekunst | Metallurg + Kriger | +3 ATK, +20% malmeffekt |
-| Malmkjenne | Metallurg + Geolog | +1 mineral-syn, -10% smeltetid |
-| Giftklinger | Kjemiker + Kriger | +2 ATK, 15% gift |
-| Alkymist | Kjemiker + Metallurg | +20% potens, -15% energi |
-| Naturkjenner | Geolog + Villmarksjeger | +1 mineral-syn, +2 kjæl.-HP |
-| Giftjeger | Kjemiker + Villmarksjeger | +20% kjemibombe, +10% krit |
+Aktiveres automatisk når helten har evner fra begge stier i et par. Noen synergier krever høyere tier (T2) for å aktiveres:
+| Synergi | Stier | Min. tier | Effekt |
+|---------|-------|-----------|--------|
+| Motangrep | Kriger + Villmarksjeger | T1 | 20% motangrep |
+| Tornehud | Kriger + Villmarksjeger | T1 | 1 tornskade, +1 syn |
+| Jordens kraft | Geolog + Kriger | T1 | +1 DEF, +1 mineral-syn |
+| Smiekunst | Metallurg + Kriger | T2 | +3 ATK, +20% malmeffekt |
+| Malmkjenne | Metallurg + Geolog | T1 | +1 mineral-syn, -10% smeltetid |
+| Giftklinger | Kjemiker + Kriger | T1 | +2 ATK, 15% gift |
+| Alkymist | Kjemiker + Metallurg | T2 | +20% potens, -15% energi |
+| Naturkjenner | Geolog + Villmarksjeger | T1 | +1 mineral-syn, +2 kjæl.-HP |
+| Giftjeger | Kjemiker + Villmarksjeger | T2 | +20% kjemibombe, +10% krit |
 
 ---
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -63,10 +63,10 @@ const MOVE_ANIM_MS    = 90;   // ms for hero/monster slide tween
 const HERO_BASE_ATTACK  = 3;
 const HERO_BASE_HEARTS  = 5;
 // v0.7 balance: monsters are significantly tougher
-const MONSTER_BASE_HP   = { goblin: 10, orc: 18,  troll: 30,  boss: 35 };
-const MONSTER_ATTACK    = { goblin: 2,  orc: 4,   troll: 6,   boss: 3  };
-const MONSTER_COLOR     = { goblin: COLORS.MONSTER, orc: COLORS.MONSTER_ORC, troll: COLORS.MONSTER_TRL, boss: COLORS.BOSS, zone_boss: 0xff22ff };
-const MONSTER_XP        = { goblin: 10, orc: 25,  troll: 50,  boss: 150, zone_boss: 300 };
+const MONSTER_BASE_HP   = { goblin: 10, orc: 18, troll: 30, skeleton: 12, golem: 40, wraith: 15, demon: 25, boss: 35 };
+const MONSTER_ATTACK    = { goblin: 2,  orc: 4,  troll: 6,  skeleton: 5,  golem: 3,  wraith: 6,  demon: 7,  boss: 3  };
+const MONSTER_COLOR     = { goblin: COLORS.MONSTER, orc: COLORS.MONSTER_ORC, troll: COLORS.MONSTER_TRL, skeleton: 0xccccaa, golem: 0x888877, wraith: 0x6644aa, demon: 0xcc2222, boss: COLORS.BOSS, zone_boss: 0xff22ff };
+const MONSTER_XP        = { goblin: 10, orc: 25, troll: 50, skeleton: 20, golem: 60, wraith: 40, demon: 55, boss: 150, zone_boss: 300 };
 
 // v0.7 balance: much slower XP curve → less frequent skill picks
 const XP_BASE           = 100;   // XP needed for level 2

--- a/src/data/alloys.js
+++ b/src/data/alloys.js
@@ -354,6 +354,18 @@ const ALLOY_EQUIPMENT = {
     phosphor_shield:  { id: 'phosphor_shield',  name: 'Fosfor-skjold',       type: 'armor',  alloyId: 'phosphor_crystal', color: 0xddffcc, def: 5, hearts: 2, visionBonus: 1, desc: '+5 DEF, +2 HP, +1 syn (fosfor)' },
     scandium_rapier:  { id: 'scandium_rapier',  name: 'Skandium-rapir',      type: 'weapon', alloyId: 'scandium_alloy',   color: 0xbbddcc, atk: 6, hearts: 1, desc: '+6 ATK, +1 HP (skandium)' },
     scandium_harness: { id: 'scandium_harness', name: 'Skandium-harnisk',    type: 'armor',  alloyId: 'scandium_alloy',   color: 0xbbddcc, def: 5, hearts: 3, desc: '+5 DEF, +3 HP (lettrustning)' },
+    // ── Craftable tools (keys, pickaxes, backpack upgrades) ─────────────
+    forged_key:      { id: 'key',     name: 'Smidd nøkkel',        type: 'tool', alloyId: 'bronze',         color: 0xffcc00, desc: 'Åpner låste dører', use() { return false; } },
+    forged_pickaxe:  { id: 'pickaxe', name: 'Smidd hakke',         type: 'tool', alloyId: 'steel',          color: 0xaa7744, desc: 'Bryter gjennom sprukne vegger', use() { return false; } },
+    backpack_upgrade:{ id: 'backpack_upgrade', name: 'Forstørrelsesbelte', type: 'consumable', alloyId: 'scandium_alloy', color: 0xbbddcc, desc: '+3 ryggsekk-plasser (maks 2 oppgraderinger)',
+        use(hero) {
+            const upgrades = hero._backpackUpgrades || 0;
+            if (upgrades >= 2) return false;
+            hero._backpackUpgrades = upgrades + 1;
+            hero.inventory.expandBackpack(3);
+            return true;
+        }
+    },
 };
 
 // ── Pet equipment (forged from alloys at the Smeltery) ──────────────────────

--- a/src/data/minerals.js
+++ b/src/data/minerals.js
@@ -488,6 +488,12 @@ const CRYSTAL_POOL = {
  * World 1-2 → mostly T1, World 3-4 → T1-T2, World 5 → T2-T3, etc.
  */
 function rollMineralTier(worldNum) {
+    // 20% chance to roll a base-tier (1-2) mineral regardless of world,
+    // ensuring important elements like Al, Fe, Cu remain accessible.
+    if (worldNum >= 5 && Math.random() < 0.20) {
+        return Math.random() < 0.6 ? 1 : 2;
+    }
+
     // Base tier: 1 for worlds 1-2, 2 for worlds 3-4, 3 for worlds 5-6, etc.
     const baseTier = Math.max(1, Math.ceil(worldNum / 2));
     let tier = baseTier;

--- a/src/data/minerals.js
+++ b/src/data/minerals.js
@@ -486,24 +486,17 @@ const CRYSTAL_POOL = {
  * Roll a mineral tier based on world number.
  * Zone as floor-tier with random upward spread.
  * World 1-2 → mostly T1, World 3-4 → T1-T2, World 5 → T2-T3, etc.
+ * Higher worlds still produce a spread of tiers so base elements stay accessible.
  */
 function rollMineralTier(worldNum) {
-    // 20% chance to roll a base-tier (1-2) mineral regardless of world,
-    // ensuring important elements like Al, Fe, Cu remain accessible.
-    if (worldNum >= 5 && Math.random() < 0.20) {
-        return Math.random() < 0.6 ? 1 : 2;
-    }
-
-    // Base tier: 1 for worlds 1-2, 2 for worlds 3-4, 3 for worlds 5-6, etc.
-    const baseTier = Math.max(1, Math.ceil(worldNum / 2));
-    let tier = baseTier;
-
-    // 12% chance to roll one tier higher, 3% for two tiers higher
+    const baseTier = Math.min(6, Math.max(1, Math.ceil(worldNum / 2)));
     const roll = Math.random();
-    if (roll < 0.03)      tier += 2;
-    else if (roll < 0.15) tier += 1;
-
-    return Math.min(tier, 6);
+    // Spread: 15% much lower, 20% lower, 20% slightly lower, 35% current, 10% higher
+    if (roll < 0.15) return Math.max(1, baseTier - 3);
+    if (roll < 0.35) return Math.max(1, baseTier - 2);
+    if (roll < 0.55) return Math.max(1, baseTier - 1);
+    if (roll < 0.90) return baseTier;
+    return Math.min(6, baseTier + 1);
 }
 
 /**

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -426,6 +426,7 @@ const SKILL_SYNERGIES = [
         desc:  '+3 Angrep, +20% malmeffekt',
         paths: ['metallurg', 'kriger'],
         color: 0xff6622,
+        minTier: 2,
         apply(hero) { hero.attack += 3; hero.oreEfficiencyChance = (hero.oreEfficiencyChance || 0) + 0.20; },
         unapply(hero) { hero.attack -= 3; hero.oreEfficiencyChance = Math.max(0, (hero.oreEfficiencyChance || 0) - 0.20); },
     },
@@ -453,6 +454,7 @@ const SKILL_SYNERGIES = [
         desc:  '+20% potens, -15% energi',
         paths: ['kjemiker', 'metallurg'],
         color: 0x88aa44,
+        minTier: 2,
         apply(hero) { hero.potionPotencyBonus = (hero.potionPotencyBonus || 0) + 0.20; hero.smeltingEfficiency = (hero.smeltingEfficiency || 1.0) * 0.85; },
         unapply(hero) { hero.potionPotencyBonus = Math.max(0, (hero.potionPotencyBonus || 0) - 0.20); hero.smeltingEfficiency = (hero.smeltingEfficiency || 1.0) / 0.85; },
     },
@@ -471,6 +473,7 @@ const SKILL_SYNERGIES = [
         desc:  '+20% kjemibombe, +10% crit',
         paths: ['kjemiker', 'villmarksjeger'],
         color: 0x66cc88,
+        minTier: 2,
         apply(hero) { hero.chemBombBonus = (hero.chemBombBonus || 0) + 0.20; hero.critChance = Math.min(0.75, hero.critChance + 0.10); },
         unapply(hero) { hero.chemBombBonus = Math.max(0, (hero.chemBombBonus || 0) - 0.20); hero.critChance = Math.max(0, hero.critChance - 0.10); },
     },
@@ -480,6 +483,7 @@ const SKILL_SYNERGIES = [
         desc:  '5 av grunnstoff X → 1 av nabo (kjemilab)',
         paths: ['geolog', 'metallurg', 'kjemiker'],
         color: 0xff88cc,
+        minTier: 2,
         apply(hero) { hero.transmutationUnlocked = true; },
         unapply(hero) { hero.transmutationUnlocked = false; },
     },
@@ -489,6 +493,7 @@ const SKILL_SYNERGIES = [
         desc:  '+3 ATK, −25% akselerator-energi',
         paths: ['fysiker', 'metallurg'],
         color: 0xaa66ff,
+        minTier: 2,
         apply(hero) { hero.attack += 3; hero.acceleratorEfficiency = (hero.acceleratorEfficiency || 1.0) * 0.75; },
         unapply(hero) { hero.attack -= 3; hero.acceleratorEfficiency = (hero.acceleratorEfficiency || 1.0) / 0.75; },
     },
@@ -498,6 +503,7 @@ const SKILL_SYNERGIES = [
         desc:  '+30% potion-styrke, +20% bombe-radius',
         paths: ['fysiker', 'kjemiker'],
         color: 0x8888ff,
+        minTier: 2,
         apply(hero) { hero.potionMagnitudeBonus = (hero.potionMagnitudeBonus || 0) + 0.30; hero.chemRadiusBonus = (hero.chemRadiusBonus || 0) + 0.20; },
         unapply(hero) { hero.potionMagnitudeBonus = Math.max(0, (hero.potionMagnitudeBonus || 0) - 0.30); hero.chemRadiusBonus = Math.max(0, (hero.chemRadiusBonus || 0) - 0.20); },
     },
@@ -505,16 +511,17 @@ const SKILL_SYNERGIES = [
 
 /** Check which synergies are active for a hero and return their IDs. */
 function getActiveSynergies(hero) {
-    const pathCounts = {};
+    const pathMaxTier = {};
     for (const skillId of (hero.skills || [])) {
         for (const path of SKILL_TREE_PATHS) {
-            if (path.tiers.some(t => t.id === skillId)) {
-                pathCounts[path.id] = (pathCounts[path.id] || 0) + 1;
+            const tierIndex = path.tiers.findIndex(t => t.id === skillId);
+            if (tierIndex >= 0) {
+                pathMaxTier[path.id] = Math.max(pathMaxTier[path.id] || 0, tierIndex + 1);
             }
         }
     }
     return SKILL_SYNERGIES.filter(syn =>
-        syn.paths.every(p => (pathCounts[p] || 0) >= 1)
+        syn.paths.every(p => (pathMaxTier[p] || 0) >= (syn.minTier || 1))
     );
 }
 

--- a/src/entities/HeroCrafting.js
+++ b/src/entities/HeroCrafting.js
@@ -99,6 +99,8 @@ const HeroCrafting = {
 
         // Camp stash – persistent storage for minerals, fuel, etc.
         hero.campStash = [];
+        hero.fuelReserve = 0;
+        hero._backpackUpgrades = 0;
     },
 
     /** Return serializable crafting state from a hero instance. */
@@ -131,6 +133,8 @@ const HeroCrafting = {
             reforgeUnlocked:      hero.reforgeUnlocked,
             alloyInventory:       { ...hero.alloyInventory },
             campStash:            hero.campStash.map(e => ({ ...e })),
+            fuelReserve:          hero.fuelReserve || 0,
+            _backpackUpgrades:    hero._backpackUpgrades || 0,
             chemistUnlocked:      hero.chemistUnlocked,
             chemLabUnlocked:      hero.chemLabUnlocked,
             potionDurationBonus:  hero.potionDurationBonus,
@@ -212,6 +216,8 @@ const HeroCrafting = {
         hero.reforgeUnlocked      = stats.reforgeUnlocked      || false;
         hero.alloyInventory       = stats.alloyInventory       ? { ...stats.alloyInventory } : {};
         hero.campStash            = (stats.campStash || []).map(e => ({ ...e }));
+        hero.fuelReserve          = stats.fuelReserve || 0;
+        hero._backpackUpgrades    = stats._backpackUpgrades || 0;
         hero.chemistUnlocked      = stats.chemistUnlocked      || false;
         hero.chemLabUnlocked      = stats.chemLabUnlocked      || false;
         hero.potionDurationBonus  = stats.potionDurationBonus  || 0;

--- a/src/entities/Monster.js
+++ b/src/entities/Monster.js
@@ -62,6 +62,10 @@ class Monster {
             case 'boss':      this._drawBoss(g, s);     break;
             case 'orc':       this._drawOrc(g, s);      break;
             case 'troll':     this._drawTroll(g, s);    break;
+            case 'skeleton':  this._drawSkeleton(g, s); break;
+            case 'golem':     this._drawGolem(g, s);    break;
+            case 'wraith':    this._drawWraith(g, s);   break;
+            case 'demon':     this._drawDemon(g, s);    break;
             default:          this._drawGoblin(g, s);   break;
         }
 
@@ -119,10 +123,14 @@ class Monster {
     // ── Goblin ─────────────────────────────────────────────────────────────────
     // Small, green, pointy ears, yellow slit eyes, wide toothy grin
 
-    _drawGoblin(g, s)  { MonsterGraphics.drawGoblin(g, s); }
-    _drawOrc(g, s)     { MonsterGraphics.drawOrc(g, s); }
-    _drawTroll(g, s)   { MonsterGraphics.drawTroll(g, s); }
-    _drawBoss(g, s)    { MonsterGraphics.drawBoss(g, s, this.phase); }
+    _drawGoblin(g, s)   { MonsterGraphics.drawGoblin(g, s); }
+    _drawOrc(g, s)      { MonsterGraphics.drawOrc(g, s); }
+    _drawTroll(g, s)    { MonsterGraphics.drawTroll(g, s); }
+    _drawSkeleton(g, s) { MonsterGraphics.drawSkeleton(g, s); }
+    _drawGolem(g, s)    { MonsterGraphics.drawGolem(g, s); }
+    _drawWraith(g, s)   { MonsterGraphics.drawWraith(g, s); }
+    _drawDemon(g, s)    { MonsterGraphics.drawDemon(g, s); }
+    _drawBoss(g, s)     { MonsterGraphics.drawBoss(g, s, this.phase); }
     _drawZoneBoss(g, s) { MonsterGraphics.drawZoneBoss(g, s, this.phase); }
 
     // ── Combat ────────────────────────────────────────────────────────────────

--- a/src/graphics/ItemGraphics.js
+++ b/src/graphics/ItemGraphics.js
@@ -168,6 +168,38 @@ const ItemGraphics = {
             g.fillCircle(cx + 5, py + 12, 5);
             g.fillStyle(0xffffff, 0.3);
             g.fillCircle(cx - 3, py + 11, 2);
+        } else if (item._chemType === 'potion' || item._chemType === 'medicine') {
+            // Flask shape
+            g.fillRoundedRect(cx - 4, cy - 2, 8, 12, 3);
+            g.fillRect(cx - 2, cy - 6, 4, 5);
+            g.fillStyle(0xffffff, 0.3);
+            g.fillCircle(cx - 2, cy + 2, 2);
+        } else if (item._chemType === 'explosive' && (item.id === 'dynamite' || item.id === 'potassium_nitrate')) {
+            // Dynamite sticks
+            g.fillRoundedRect(cx - 5, cy - 4, 4, 14, 1);
+            g.fillRoundedRect(cx - 1, cy - 6, 4, 16, 1);
+            g.fillRoundedRect(cx + 3, cy - 3, 4, 13, 1);
+            g.fillStyle(0xffcc00, 0.9);
+            g.fillRect(cx, cy - 10, 1, 5);
+            g.fillCircle(cx, cy - 10, 2);
+        } else if (item._chemType === 'explosive') {
+            // Round bomb
+            g.fillCircle(cx, cy + 2, 8);
+            g.fillStyle(0x222222, 0.6);
+            g.fillCircle(cx, cy + 2, 6);
+            g.fillStyle(col, 0.9);
+            g.fillCircle(cx, cy + 2, 5);
+            g.fillStyle(0xffcc00, 0.9);
+            g.fillRect(cx - 1, cy - 8, 2, 5);
+            g.fillCircle(cx, cy - 9, 2);
+        } else if (item._chemType === 'acid') {
+            // Bubbling vial
+            g.fillRoundedRect(cx - 4, cy - 2, 8, 12, 2);
+            g.fillRect(cx - 2, cy - 6, 4, 5);
+            g.fillStyle(0xffffff, 0.4);
+            g.fillCircle(cx - 2, cy + 1, 2);
+            g.fillCircle(cx + 2, cy - 1, 1.5);
+            g.fillCircle(cx, cy + 4, 1);
         } else if (item.type === 'consumable') {
             g.fillCircle(cx, cy, s / 4.5);
             g.fillStyle(0xffffff, 0.3);
@@ -300,6 +332,22 @@ const ItemGraphics = {
             g.fillStyle(0x664422, 0.7);
             g.fillCircle(x - 7, y, 3);
             g.fillCircle(x + 7, y, 3);
+        } else if (item._chemType === 'potion' || item._chemType === 'medicine') {
+            g.fillRoundedRect(x - 3, y - 1, 6, 9, 2);
+            g.fillRect(x - 1, y - 4, 3, 4);
+            g.fillStyle(0xffffff, 0.3);
+            g.fillCircle(x - 1, y + 2, 1.5);
+        } else if (item._chemType === 'explosive') {
+            g.fillCircle(x, y + 1, 6);
+            g.fillStyle(0xffcc00, 0.9);
+            g.fillRect(x, y - 6, 1, 4);
+            g.fillCircle(x, y - 7, 1.5);
+        } else if (item._chemType === 'acid') {
+            g.fillRoundedRect(x - 3, y - 1, 6, 9, 2);
+            g.fillRect(x - 1, y - 4, 3, 4);
+            g.fillStyle(0xffffff, 0.4);
+            g.fillCircle(x - 1, y + 1, 1.5);
+            g.fillCircle(x + 1, y + 3, 1);
         } else {
             g.fillCircle(x, y, s / 3.5);
             g.fillStyle(0xffffff, 0.35);

--- a/src/graphics/MonsterGraphics.js
+++ b/src/graphics/MonsterGraphics.js
@@ -356,5 +356,115 @@ const MonsterGraphics = {
         g.fillTriangle(cx + 5, 11, cx + 6, 16, cx + 7, 11);
         g.fillTriangle(cx - 5, 14, cx - 6, 10, cx - 3, 14);
         g.fillTriangle(cx + 3, 14, cx + 4, 10, cx + 5, 14);
+    },
+
+    // ── Skeleton ──────────────────────────────────────────────────────────────
+    drawSkeleton(g, s) {
+        const cx = s >> 1;
+        g.fillStyle(0x000000, 0.2);
+        g.fillEllipse(cx, 31, 14, 4);
+        // Legs (bone)
+        g.fillStyle(0xddddbb);
+        g.fillRect(cx - 4, 22, 2, 10);
+        g.fillRect(cx + 2, 22, 2, 10);
+        // Ribcage
+        g.fillStyle(0xccccaa);
+        g.fillRect(cx - 5, 14, 10, 9);
+        g.fillStyle(0x111111, 0.3);
+        g.fillRect(cx - 3, 16, 2, 5);
+        g.fillRect(cx + 1, 16, 2, 5);
+        // Skull
+        g.fillStyle(0xeeeedd);
+        g.fillRoundedRect(cx - 6, 3, 12, 12, 4);
+        // Eyes (dark sockets)
+        g.fillStyle(0x111111);
+        g.fillCircle(cx - 3, 8, 2);
+        g.fillCircle(cx + 3, 8, 2);
+        // Jaw
+        g.fillStyle(0xddddcc);
+        g.fillRect(cx - 4, 13, 8, 3);
+    },
+
+    // ── Golem ─────────────────────────────────────────────────────────────────
+    drawGolem(g, s) {
+        const cx = s >> 1;
+        g.fillStyle(0x000000, 0.25);
+        g.fillEllipse(cx, 32, 20, 5);
+        // Legs (thick stone)
+        g.fillStyle(0x666655);
+        g.fillRoundedRect(cx - 8, 24, 6, 8, 2);
+        g.fillRoundedRect(cx + 2, 24, 6, 8, 2);
+        // Body (massive)
+        g.fillStyle(0x888877);
+        g.fillRoundedRect(cx - 10, 10, 20, 16, 3);
+        g.fillStyle(0x777766);
+        g.fillRoundedRect(cx - 8, 12, 16, 12, 2);
+        // Arms
+        g.fillStyle(0x999988);
+        g.fillRoundedRect(cx - 14, 12, 6, 12, 2);
+        g.fillRoundedRect(cx + 8, 12, 6, 12, 2);
+        // Head (small on big body)
+        g.fillStyle(0xaaaa99);
+        g.fillRoundedRect(cx - 5, 3, 10, 9, 3);
+        // Glowing eyes
+        g.fillStyle(0xffaa00);
+        g.fillCircle(cx - 2, 7, 1.5);
+        g.fillCircle(cx + 2, 7, 1.5);
+    },
+
+    // ── Wraith ────────────────────────────────────────────────────────────────
+    drawWraith(g, s) {
+        const cx = s >> 1;
+        // Ghostly body (tattered robe)
+        g.fillStyle(0x4422aa, 0.6);
+        g.fillTriangle(cx - 10, 30, cx + 10, 30, cx, 8);
+        g.fillStyle(0x5533bb, 0.5);
+        g.fillTriangle(cx - 8, 28, cx + 8, 28, cx, 10);
+        // Hood
+        g.fillStyle(0x332266, 0.8);
+        g.fillRoundedRect(cx - 7, 3, 14, 10, 4);
+        // Glowing eyes
+        g.fillStyle(0xcc44ff, 0.9);
+        g.fillCircle(cx - 3, 8, 2);
+        g.fillCircle(cx + 3, 8, 2);
+        g.fillStyle(0xffffff, 0.4);
+        g.fillCircle(cx - 3, 8, 1);
+        g.fillCircle(cx + 3, 8, 1);
+        // Wispy tendrils
+        g.fillStyle(0x5533bb, 0.3);
+        g.fillTriangle(cx - 12, 28, cx - 6, 18, cx - 8, 30);
+        g.fillTriangle(cx + 12, 28, cx + 6, 18, cx + 8, 30);
+    },
+
+    // ── Demon ─────────────────────────────────────────────────────────────────
+    drawDemon(g, s) {
+        const cx = s >> 1;
+        g.fillStyle(0x000000, 0.25);
+        g.fillEllipse(cx, 31, 16, 4);
+        // Legs
+        g.fillStyle(0x881111);
+        g.fillRect(cx - 5, 22, 4, 9);
+        g.fillRect(cx + 1, 22, 4, 9);
+        // Body
+        g.fillStyle(0xcc2222);
+        g.fillRoundedRect(cx - 8, 12, 16, 12, 3);
+        // Arms
+        g.fillStyle(0xaa1111);
+        g.fillRoundedRect(cx - 12, 14, 5, 10, 2);
+        g.fillRoundedRect(cx + 7, 14, 5, 10, 2);
+        // Head
+        g.fillStyle(0xdd3333);
+        g.fillRoundedRect(cx - 6, 3, 12, 11, 3);
+        // Horns
+        g.fillStyle(0x332211);
+        g.fillTriangle(cx - 6, 5, cx - 10, -2, cx - 4, 3);
+        g.fillTriangle(cx + 6, 5, cx + 10, -2, cx + 4, 3);
+        // Eyes (fire)
+        g.fillStyle(0xff6600);
+        g.fillCircle(cx - 3, 8, 2);
+        g.fillCircle(cx + 3, 8, 2);
+        // Mouth
+        g.fillStyle(0xff4400, 0.7);
+        g.fillRect(cx - 3, 11, 6, 2);
     }
 };

--- a/src/maze.js
+++ b/src/maze.js
@@ -163,6 +163,19 @@ class MazeGenerator {
             }
         }
 
+        // Particle Accelerator: world 13+, 20% chance (guaranteed world 15+)
+        // Placed before optional rooms to ensure dead-ends are available.
+        if (worldNum >= 13 && deadEnds.length > 0) {
+            const accChance = worldNum >= 15 ? 1.0 : 0.20;
+            if (Math.random() < accChance) {
+                const de = deadEnds.shift();
+                const tiles = this._gatherRoomTiles(de.x, de.y, 3 + Math.floor(Math.random() * 2));
+                if (tiles.length >= 1) {
+                    this.specialRooms.push({ type: 'accelerator', tiles });
+                }
+            }
+        }
+
         // Ore Chamber: world 5+, 25% chance – concentrated T2-T3 ores
         if (worldNum >= 5 && deadEnds.length > 0 && Math.random() < 0.25) {
             const de = deadEnds.shift();
@@ -196,19 +209,6 @@ class MazeGenerator {
             const tiles = this._gatherRoomTiles(de.x, de.y, 2 + Math.floor(Math.random() * 2));
             if (tiles.length >= 1) {
                 this.specialRooms.push({ type: 'magma_chamber', tiles });
-            }
-        }
-
-        // Particle Accelerator: world 13+, 20% chance (guaranteed world 15+)
-        // Used for fission energy and transuranic element synthesis.
-        if (worldNum >= 13 && deadEnds.length > 0) {
-            const accChance = worldNum >= 15 ? 1.0 : 0.20;
-            if (Math.random() < accChance) {
-                const de = deadEnds.shift();
-                const tiles = this._gatherRoomTiles(de.x, de.y, 3 + Math.floor(Math.random() * 2));
-                if (tiles.length >= 1) {
-                    this.specialRooms.push({ type: 'accelerator', tiles });
-                }
             }
         }
     }

--- a/src/scenes/AcceleratorScene.js
+++ b/src/scenes/AcceleratorScene.js
@@ -220,7 +220,7 @@ class AcceleratorScene extends Phaser.Scene {
         if (newBonuses.length > 0) {
             tracker.applyBonusRewards(hero);
             for (const bonus of newBonuses) {
-                EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `${bonus.name} fullført! ${bonus.desc}`, color: '#ffcc00' });
+                EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `★ ${bonus.name} fullført! ${bonus.desc}`, color: '#ffcc00', big: true });
             }
         }
 

--- a/src/scenes/ChemLabScene.js
+++ b/src/scenes/ChemLabScene.js
@@ -16,16 +16,16 @@ class ChemLabScene extends Phaser.Scene {
         this.chem = new ChemistrySystem();
         this.smelter = new SmeltingSystem();
         this._dyn = [];
-        this._filter = 'all'; // 'all' | 'potion' | 'explosive' | 'medicine'
+        this._filter = 'all';
+        this._elementFilter = null;
+        this._tab = 'recipes'; // 'recipes' | 'transmutation'
 
         // ── Dim overlay ───────────────────────────────────────────────────────
         this.add.rectangle(cx, cy, W, H, 0x000000, 0.82);
 
-        // ── Panel ─────────────────────────────────────────────────────────────
-        // Slightly larger than before to accommodate bumped fonts without
-        // crowding the portrait. Leaves margin around the canvas.
-        this.panelW = Math.min(W - 80, 760);
-        this.panelH = Math.min(H - 80, 600);
+        // ── Panel (larger for better overview) ────────────────────────────────
+        this.panelW = Math.min(W - 40, 960);
+        this.panelH = Math.min(H - 40, 720);
         this.px = cx - this.panelW / 2;
         this.py = cy - this.panelH / 2;
 
@@ -77,7 +77,27 @@ class ChemLabScene extends Phaser.Scene {
 
         this.add.rectangle(cx, this.py + 42, this.panelW - 20, 1, 0x113322);
 
-        // ── Filter buttons ────────────────────────────────────────────────────
+        // ── Tab buttons (Recipes | Transmutation) ─────────────────────────────
+        this._tabBtns = [];
+        const showTransmutation = !!this.heroRef.transmutationUnlocked;
+        const tabs = [{ id: 'recipes', label: 'Oppskrifter' }];
+        if (showTransmutation) tabs.push({ id: 'transmutation', label: 'Transmutasjon' });
+
+        const tabY = this.py + 52;
+        tabs.forEach((t, i) => {
+            const tx = this.px + 30 + i * 140;
+            const active = this._tab === t.id;
+            const btn = this.add.text(tx, tabY, t.label, {
+                fontSize: '15px', color: active ? '#33dd88' : '#335533',
+                fontFamily: 'monospace', fontStyle: active ? 'bold' : 'normal'
+            }).setInteractive({ useHandCursor: true });
+            btn.on('pointerdown', () => { this._tab = t.id; this._scrollOffset = 0; this._refresh(); });
+            this._tabBtns.push(btn);
+        });
+
+        this.add.rectangle(cx, tabY + 16, this.panelW - 20, 1, 0x113322);
+
+        // ── Filter buttons (only for recipes tab) ─────────────────────────────
         this._filterBtns = [];
         const filters = [
             { id: 'all', label: 'Alle' },
@@ -86,20 +106,20 @@ class ChemLabScene extends Phaser.Scene {
             { id: 'medicine', label: 'Medisin' },
             { id: 'acid', label: 'Syrer' },
         ];
-        const filterY = this.py + 62;
-        const filterStep = Math.min(120, (this.panelW - 80) / filters.length);
+        const filterY = tabY + 26;
+        const filterStep = Math.min(100, (this.panelW - 80) / filters.length);
         filters.forEach((f, i) => {
             const fx = this.px + 30 + i * filterStep + filterStep / 2;
             const active = this._filter === f.id;
             const btn = this.add.text(fx, filterY, f.label, {
-                fontSize: '16px', color: active ? '#33dd88' : '#335533',
+                fontSize: '14px', color: active ? '#33dd88' : '#335533',
                 fontFamily: 'monospace', fontStyle: active ? 'bold' : 'normal'
             }).setOrigin(0.5).setInteractive({ useHandCursor: true });
-            btn.on('pointerdown', () => { this._filter = f.id; this._refresh(); });
+            btn.on('pointerdown', () => { this._filter = f.id; this._scrollOffset = 0; this._refresh(); });
             this._filterBtns.push(btn);
         });
 
-        this.add.rectangle(cx, filterY + 16, this.panelW - 20, 1, 0x113322);
+        this.add.rectangle(cx, filterY + 14, this.panelW - 20, 1, 0x113322);
 
         // Close
         const closeBtn = this.add.text(this.px + this.panelW - 20, this.py + 10, '✕', {
@@ -109,7 +129,7 @@ class ChemLabScene extends Phaser.Scene {
         this.input.keyboard.on('keydown-ESC', () => this.scene.stop());
         this.input.keyboard.on('keydown-C', () => this.scene.stop());
 
-        this.contentY = filterY + 28;
+        this.contentY = filterY + 26;
         this._scrollOffset = 0;
         this._maxScroll = 0;
 
@@ -119,8 +139,7 @@ class ChemLabScene extends Phaser.Scene {
             this._refresh();
         });
 
-        // Touch / mouse-drag scrolling with small movement threshold so that
-        // short taps still trigger interactive [Lag] buttons.
+        // Touch / mouse-drag scrolling
         this._dragState = { active: false, startY: 0, startOffset: 0, engaged: false };
         this.input.on('pointerdown', (pointer) => {
             this._dragState.active = true;
@@ -153,6 +172,13 @@ class ChemLabScene extends Phaser.Scene {
     _refresh() {
         UIHelper.clearDynamic(this._dyn);
 
+        // Update tab styles
+        const tabIds = this._tabBtns.map((_, i) => i === 0 ? 'recipes' : 'transmutation');
+        UIHelper.updateTabButtons(this._tabBtns, tabIds, this._tab, '#33dd88', '#335533');
+
+        // Show/hide filter buttons based on active tab
+        this._filterBtns.forEach(btn => btn.setVisible(this._tab === 'recipes'));
+
         // Dark backing behind content for readability
         const cbg = this._d(this.add.graphics());
         cbg.fillStyle(0x080a10, 0.78);
@@ -163,11 +189,13 @@ class ChemLabScene extends Phaser.Scene {
         const fuel = this.smelter.calculateFuelEnergy(this.heroRef);
         this._fuelText.setText(`Energi: ${fuel}`);
 
-        if (this._hasKjemikerSkill()) {
-            this._drawRecipes(fuel);
-        } else {
+        if (!this._hasKjemikerSkill()) {
             this._drawLockedMessage();
             this._contentEndY = this.contentY;
+        } else if (this._tab === 'transmutation') {
+            this._drawTransmutationTab();
+        } else {
+            this._drawRecipes(fuel);
         }
 
         // Compute max scroll from last-drawn content, clamp and draw scrollbar.
@@ -210,12 +238,68 @@ class ChemLabScene extends Phaser.Scene {
 
     _d(obj) { this._dyn.push(obj); return obj; }
 
+    // ── Element filter row ───────────────────────────────────────────────────
+
+    _drawElementFilterRow(y) {
+        const hero = this.heroRef;
+        const collected = hero.elementTracker.collected;
+        const allRecipeElements = new Set();
+
+        // Gather all elements used in any recipe
+        for (const mol of Object.values(MOLECULE_DEFS)) {
+            for (const r of mol.recipe) allRecipeElements.add(r.symbol);
+        }
+
+        const leftX = this.px + 10;
+        let bx = leftX;
+        const maxW = this.panelW - 180;
+
+        // "Alle" reset button
+        const allBtn = this._d(this.add.text(bx, y, 'Alle', {
+            fontSize: '12px',
+            color: this._elementFilter === null ? '#33dd88' : '#335533',
+            fontFamily: 'monospace', fontStyle: this._elementFilter === null ? 'bold' : 'normal',
+            backgroundColor: '#081808', padding: { x: 3, y: 1 }
+        }).setInteractive({ useHandCursor: true }));
+        allBtn.on('pointerdown', () => { this._elementFilter = null; this._scrollOffset = 0; this._refresh(); });
+        bx += allBtn.width + 4;
+
+        for (const symbol of allRecipeElements) {
+            const count = collected[symbol] || 0;
+            const elem = typeof ELEMENTS !== 'undefined' ? ELEMENTS[symbol] : null;
+            const col = elem ? elem.color : 0xaaaaaa;
+            const hexCol = '#' + col.toString(16).padStart(6, '0');
+            const isActive = this._elementFilter === symbol;
+            const dimmed = count === 0;
+
+            const badge = this._d(this.add.text(bx, y, symbol, {
+                fontSize: '12px',
+                color: isActive ? '#33dd88' : (dimmed ? '#222222' : hexCol),
+                fontFamily: 'monospace',
+                fontStyle: isActive ? 'bold' : 'normal',
+                backgroundColor: isActive ? '#113311' : '#081808',
+                padding: { x: 3, y: 1 }
+            }).setInteractive({ useHandCursor: true }));
+            badge.on('pointerdown', () => {
+                this._elementFilter = isActive ? null : symbol;
+                this._scrollOffset = 0;
+                this._refresh();
+            });
+            bx += badge.width + 3;
+            if (bx > leftX + maxW) { bx = leftX; y += 18; }
+        }
+
+        return y + 20;
+    }
+
     _drawRecipes(fuel) {
         const hero = this.heroRef;
-        const cx = this.px + this.panelW / 2;
         let y = this.contentY;
-        // Leave room on the right for element inventory column.
-        const colW = Math.min(400, this.panelW - 180);
+
+        // Element filter row
+        y = this._drawElementFilterRow(y);
+
+        const colW = Math.min(500, this.panelW - 180);
         const leftX = this.px + 20;
         const rightX = this.px + this.panelW - 160;
         const rowStep = 62;
@@ -223,9 +307,16 @@ class ChemLabScene extends Phaser.Scene {
         // Left column: recipes
         let allMols = this.chem.getAvailableMolecules(hero, fuel);
 
-        // Apply filter
+        // Apply subtype filter
         if (this._filter !== 'all') {
             allMols = allMols.filter(e => e.mol.subtype === this._filter);
+        }
+
+        // Apply element filter
+        if (this._elementFilter) {
+            allMols = allMols.filter(e =>
+                e.mol.recipe.some(r => r.symbol === this._elementFilter)
+            );
         }
 
         if (allMols.length === 0) {
@@ -256,7 +347,7 @@ class ChemLabScene extends Phaser.Scene {
             const icon = icons[m.subtype] || '⚗';
             this._d(this.add.text(leftX + 6, my + 4, icon, { fontSize: '14px' }));
 
-            // Name + formula – truncate long names to fit slot
+            // Name + formula
             const dispName = m.name.length > 26 ? m.name.slice(0, 25) + '…' : m.name;
             this._d(this.add.text(leftX + 28, my + 5, dispName, {
                 fontSize: '15px', color: hexCol, fontFamily: 'monospace', fontStyle: 'bold'
@@ -335,53 +426,105 @@ class ChemLabScene extends Phaser.Scene {
         }));
 
         const hero = this.heroRef;
-        const transmutable = !!hero.transmutationUnlocked;
-        if (transmutable) {
-            this._d(this.add.text(x, y + 18, 'Transmutasjon: klikk ↔ for 5 → 1 nabo', {
-                fontSize: '11px', color: '#ff88cc', fontFamily: 'monospace'
-            }));
-        }
-
         const collected = hero.elementTracker.collected;
         const entries = Object.entries(collected).filter(([, v]) => v > 0);
         if (entries.length === 0) {
-            this._d(this.add.text(x, y + (transmutable ? 34 : 18), 'Ingen lagret.', {
+            this._d(this.add.text(x, y + 18, 'Ingen lagret.', {
                 fontSize: '14px', color: '#334433', fontFamily: 'monospace'
             }));
             return;
         }
 
-        let bx = x, by = y + (transmutable ? 36 : 18);
+        let bx = x, by = y + 18;
         for (const [symbol, count] of entries) {
             const elem = typeof ELEMENTS !== 'undefined' ? ELEMENTS[symbol] : null;
             const col = elem ? elem.color : 0xaaaaaa;
             const hexCol = '#' + col.toString(16).padStart(6, '0');
-            const badge = this._d(this.add.text(bx, by, `${symbol}:${count}`, {
+            this._d(this.add.text(bx, by, `${symbol}:${count}`, {
                 fontSize: '14px', color: hexCol, fontFamily: 'monospace',
                 backgroundColor: '#081808', padding: { x: 3, y: 1 }
             }));
-            let bwidth = badge.width;
-            // Transmutation button (only clickable when count ≥ 5).
-            if (transmutable) {
-                const canTransmute = count >= 5;
-                const tbtn = this._d(this.add.text(bx + bwidth + 2, by, '↔', {
-                    fontSize: '14px',
-                    color: canTransmute ? '#ff88cc' : '#553344',
-                    fontFamily: 'monospace',
-                    backgroundColor: '#180818',
-                    padding: { x: 3, y: 1 }
-                }));
-                if (canTransmute) {
-                    tbtn.setInteractive({ useHandCursor: true });
-                    tbtn.on('pointerover', () => tbtn.setColor('#ffaadd'));
-                    tbtn.on('pointerout', () => tbtn.setColor('#ff88cc'));
-                    tbtn.on('pointerdown', () => this._doTransmute(symbol));
-                }
-                bwidth += tbtn.width + 4;
-            }
-            bx += bwidth + 6;
+            bx += 60;
             if (bx > x + w - 30) { bx = x; by += 22; }
         }
+    }
+
+    // ── Transmutation tab ────────────────────────────────────────────────────
+
+    _drawTransmutationTab() {
+        const hero = this.heroRef;
+        const collected = hero.elementTracker.collected;
+        const entries = Object.entries(collected).filter(([, v]) => v > 0);
+        let y = this.contentY;
+        const leftX = this.px + 20;
+        const colW = Math.min(500, this.panelW - 180);
+
+        this._d(this.add.text(leftX, y, 'Transmutasjon: 5 av et grunnstoff → 1 av nabo i periodesystemet', {
+            fontSize: '13px', color: '#ff88cc', fontFamily: 'monospace'
+        }));
+        y += 24;
+
+        if (entries.length === 0) {
+            this._d(this.add.text(leftX + colW / 2, y + 40, 'Ingen grunnstoffer lagret.', {
+                fontSize: '14px', color: '#334433', fontFamily: 'monospace'
+            }).setOrigin(0.5));
+            this._contentEndY = y + 80;
+            return;
+        }
+
+        const visBot = this.py + this.panelH - 30;
+        const rowStep = 36;
+
+        entries.forEach(([symbol, count], idx) => {
+            const baseY = y + idx * rowStep;
+            const my = baseY - (this._scrollOffset || 0);
+            if (my > visBot || my < y - rowStep) return;
+
+            const canTransmute = count >= 5;
+            const elem = typeof ELEMENTS !== 'undefined' ? ELEMENTS[symbol] : null;
+            const col = elem ? elem.color : 0xaaaaaa;
+            const hexCol = '#' + col.toString(16).padStart(6, '0');
+
+            // Find target element
+            let targetSym = null;
+            if (elem && typeof ELEMENTS !== 'undefined') {
+                const srcZ = elem.atomicNumber;
+                for (const [sym, def] of Object.entries(ELEMENTS)) {
+                    if (def.atomicNumber === srcZ + 1) { targetSym = sym; break; }
+                }
+                if (!targetSym) {
+                    for (const [sym, def] of Object.entries(ELEMENTS)) {
+                        if (def.atomicNumber === srcZ - 1) { targetSym = sym; break; }
+                    }
+                }
+            }
+
+            const bg = this._d(this.add.graphics());
+            bg.fillStyle(canTransmute ? 0xff88cc : 0x221122, 0.08);
+            bg.fillRoundedRect(leftX, my, colW, 30, 4);
+            bg.lineStyle(1, canTransmute ? 0xff88cc : 0x331133, 0.3);
+            bg.strokeRoundedRect(leftX, my, colW, 30, 4);
+
+            this._d(this.add.text(leftX + 10, my + 7, `${symbol} ×${count}`, {
+                fontSize: '14px', color: hexCol, fontFamily: 'monospace', fontStyle: 'bold'
+            }));
+
+            const arrow = targetSym ? `→ 1 ${targetSym}` : '(ingen nabo)';
+            this._d(this.add.text(leftX + 120, my + 7, `5 ${symbol} ${arrow}`, {
+                fontSize: '13px', color: canTransmute ? '#cc88aa' : '#443344', fontFamily: 'monospace'
+            }));
+
+            if (canTransmute && targetSym) {
+                const btn = this._d(this.add.text(leftX + colW - 80, my + 5, '[ Transmuter ]', {
+                    fontSize: '13px', color: '#ff88cc', fontFamily: 'monospace', fontStyle: 'bold'
+                }).setInteractive({ useHandCursor: true }));
+                btn.on('pointerover', () => btn.setColor('#ffaadd'));
+                btn.on('pointerout', () => btn.setColor('#ff88cc'));
+                btn.on('pointerdown', () => this._doTransmute(symbol));
+            }
+        });
+
+        this._contentEndY = y + entries.length * rowStep;
     }
 
     _doTransmute(symbol) {

--- a/src/scenes/ElementBookScene.js
+++ b/src/scenes/ElementBookScene.js
@@ -60,6 +60,15 @@ class ElementBookScene extends Phaser.Scene {
 
         if (typeof PERIODIC_TABLE_LAYOUT === 'undefined') return;
 
+        // Lanthanide/actinide labels
+        const lantY = tableY + 9.5 * cellH;
+        this.add.text(tableX - 2, lantY, 'Ln', {
+            fontSize: '10px', color: '#556644', fontFamily: 'monospace'
+        });
+        this.add.text(tableX - 2, lantY + cellH, 'An', {
+            fontSize: '10px', color: '#556644', fontFamily: 'monospace'
+        });
+
         // Category colors for discovered elements
         const catColors = {
             metal:       0xccaa88,
@@ -78,10 +87,10 @@ class ElementBookScene extends Phaser.Scene {
 
             const isDiscovered = tracker && tracker.isDiscovered(entry.symbol);
 
-            // Map rows: 0-6 = periods 1-7, 8 = lanthanides/actinides row 1, etc.
-            // Add a small gap before rows 8+ (lanthanides/actinides)
+            // Map rows: 0-6 = periods 1-7, 8-9 = lanthanides/actinides
+            // Add a visible gap before rows 8+ to separate them from the main table
             let yOffset = entry.row;
-            if (entry.row >= 8) yOffset = entry.row + 0.5; // half-row gap
+            if (entry.row >= 8) yOffset = entry.row + 1.5;
 
             const cellX = tableX + entry.col * cellW;
             const cellY = tableY + yOffset * cellH;
@@ -120,7 +129,10 @@ class ElementBookScene extends Phaser.Scene {
                 hitZone.on('pointerover', () => {
                     g.lineStyle(2, 0xffffff, 0.8);
                     g.strokeRoundedRect(cellX, cellY, cellW - 2, cellH - 2, 2);
-                    this.tooltipText.setText(`${elem.symbol} – ${elem.name} (${elem.atomicNumber})\n${elem.description}`);
+                    const rawCount = tracker ? tracker.getCount(entry.symbol) : 0;
+                    const refined = this.heroRef && this.heroRef.refinedElements ? (this.heroRef.refinedElements[entry.symbol] || 0) : 0;
+                    const countStr = refined > 0 ? `  |  Lagret: ${rawCount} (${refined} ren)` : (rawCount > 0 ? `  |  Lagret: ${rawCount}` : '');
+                    this.tooltipText.setText(`${elem.symbol} – ${elem.name} (${elem.atomicNumber})${countStr}\n${elem.description}`);
                 });
                 hitZone.on('pointerout', () => {
                     g.clear();
@@ -145,26 +157,32 @@ class ElementBookScene extends Phaser.Scene {
             }
         }
 
-        // ── Completion bonuses ────────────────────────────────────────────────
+        // ── Completion bonuses (multi-row layout) ─────────────────────────────
         if (typeof ELEMENT_BONUSES !== 'undefined') {
-            const bonusY = tableY + 10.5 * cellH + 10;
-            const bonusW = Math.min(panelW - 20, ELEMENT_BONUSES.length * 130);
-            const startBX = cx - bonusW / 2 + 60;
+            const bonusY = tableY + 11.5 * cellH + 10;
+            const perRow = Math.min(5, ELEMENT_BONUSES.length);
+            const slotW = Math.min(150, (panelW - 40) / perRow);
 
             this.add.text(cx, bonusY - 4, 'GRUPPEPRESTASJONER', {
                 fontSize: '13px', color: '#555544', fontFamily: 'monospace'
             }).setOrigin(0.5);
 
             ELEMENT_BONUSES.forEach((bonus, i) => {
-                const bx = startBX + i * 125;
+                const row = Math.floor(i / perRow);
+                const col = i % perRow;
+                const rowCount = Math.min(perRow, ELEMENT_BONUSES.length - row * perRow);
+                const rowW = rowCount * slotW;
+                const bx = cx - rowW / 2 + col * slotW + slotW / 2;
+                const by = bonusY + 10 + row * 32;
+
                 const completed = tracker && tracker.isBonusCompleted(bonus.id);
-                const col = completed ? '#ffcc44' : '#333344';
+                const bonusCol = completed ? '#ffcc44' : '#333344';
                 const icon = completed ? '★' : '○';
-                this.add.text(bx, bonusY + 10, `${icon} ${bonus.name}`, {
-                    fontSize: '10px', color: col, fontFamily: 'monospace'
+                this.add.text(bx, by, `${icon} ${bonus.name}`, {
+                    fontSize: '10px', color: bonusCol, fontFamily: 'monospace'
                 }).setOrigin(0.5);
-                this.add.text(bx, bonusY + 22, bonus.desc, {
-                    fontSize: '13px', color: completed ? '#887766' : '#222233', fontFamily: 'monospace'
+                this.add.text(bx, by + 12, bonus.desc, {
+                    fontSize: '11px', color: completed ? '#887766' : '#222233', fontFamily: 'monospace'
                 }).setOrigin(0.5);
             });
         }

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -169,7 +169,7 @@ class GameScene extends Phaser.Scene {
 
     update(time, delta) {
         if (!this.hero || !this.hero.alive) return;
-        const blocked = this.scene.isActive('SkillScene') || this.scene.isActive('InventoryScene') || this.scene.isActive('MerchantScene') || this.scene.isActive('ElementBookScene') || this.scene.isActive('SmelteryScene') || this.scene.isActive('ChemLabScene');
+        const blocked = this.scene.isActive('SkillScene') || this.scene.isActive('InventoryScene') || this.scene.isActive('MerchantScene') || this.scene.isActive('ElementBookScene') || this.scene.isActive('SmelteryScene') || this.scene.isActive('ChemLabScene') || this.scene.isActive('AcceleratorScene');
 
         if (!blocked) {
             this.inputHandler.handleInput(delta);

--- a/src/scenes/SkillScene.js
+++ b/src/scenes/SkillScene.js
@@ -66,8 +66,8 @@ class SkillScene extends Phaser.Scene {
         });
 
         // ── Synergies display (right below skill cards) ───────────────────────
-        // 3 tiers × (cardH + 10) + header offset = cards end
-        const cardsEndY = py + 50 + 28 + 3 * (140 + 10) - 10;
+        const maxTiers = Math.max(...SKILL_TREE_PATHS.map(p => p.tiers.length));
+        const cardsEndY = py + 50 + 28 + (maxTiers - 1) * (140 + 10) + 108;
         this._drawSynergies(cx, cardsEndY + 12, panelW);
 
         // ── Footer ────────────────────────────────────────────────────────────
@@ -201,7 +201,7 @@ class SkillScene extends Phaser.Scene {
         bg.strokeRoundedRect(cx - w / 2, y, w, h, 5);
 
         // Tier badge (T1/T2/T3)
-        const tierLabel = ['T1','T2','T3'][tierIndex] || '';
+        const tierLabel = 'T' + (tierIndex + 1);
         const tierG = this.add.graphics();
         tierG.fillStyle(locked ? 0x1a1535 : colColor, locked ? 0.3 : 0.25);
         tierG.fillRoundedRect(cx + w / 2 - 24, y + 2, 22, 14, 3);
@@ -298,8 +298,9 @@ class SkillScene extends Phaser.Scene {
                 return path ? path.name[0] : '?';
             }).join('+');
             const icon = isActive ? '✦' : '○';
+            const tierReq = (syn.minTier || 1) > 1 ? ` [T${syn.minTier}]` : '';
 
-            this.add.text(sx, sy + row * rowH, `${icon} ${initials} ${syn.name}`, {
+            this.add.text(sx, sy + row * rowH, `${icon} ${initials}${tierReq} ${syn.name}`, {
                 fontSize: '10px', color: nameCol, fontFamily: 'monospace'
             }).setOrigin(0.5);
             this.add.text(sx, sy + row * rowH + 12, syn.desc, {

--- a/src/scenes/SmelteryScene.js
+++ b/src/scenes/SmelteryScene.js
@@ -105,7 +105,8 @@ class SmelteryScene extends Phaser.Scene {
         this.input.keyboard.on('keydown-V', () => this.scene.stop());
 
         // ── Content area ──────────────────────────────────────────────────────
-        this.contentY = tabY + 30;
+        this._baseContentY = tabY + 30;
+        this.contentY = this._baseContentY;
         this._scrollOffsets = { stash: 0, smelt: 0, alloy: 0, forge: 0, refine: 0, tech: 0 };
         this._maxScrolls = { stash: 0, smelt: 0, alloy: 0, forge: 0, refine: 0, tech: 0 };
         this._elementFilter = null; // null = show all, or element symbol string
@@ -152,6 +153,7 @@ class SmelteryScene extends Phaser.Scene {
 
     _refresh() {
         UIHelper.clearDynamic(this._dyn);
+        this.contentY = this._baseContentY;
 
         // Dark backing behind content for readability
         const cbg = this._d(this.add.graphics());
@@ -177,6 +179,7 @@ class SmelteryScene extends Phaser.Scene {
             case 'alloy':
             case 'forge':
                 if (this._hasMetallurgSkill()) {
+                    this._drawElementFilterRow();
                     if (this._tab === 'smelt') this._drawSmeltTab();
                     else if (this._tab === 'alloy') this._drawAlloyTab();
                     else this._drawForgeTab();
@@ -233,6 +236,63 @@ class SmelteryScene extends Phaser.Scene {
         return (this.heroRef.skills || []).some(s =>
             s === 'mineral_eye' || s === 'efficient_mining' || s === 'master_prospector'
         );
+    }
+
+    _drawElementFilterRow() {
+        const hero = this.heroRef;
+        const collected = hero.elementTracker.collected;
+        const leftX = this.px + 10;
+        const maxW = this.panelW - 40;
+        let y = this.contentY;
+        let bx = leftX;
+
+        // "Alle" reset button
+        const allBtn = this._d(this.add.text(bx, y, 'Alle', {
+            fontSize: '12px',
+            color: this._elementFilter === null ? '#ff7722' : '#554433',
+            fontFamily: 'monospace', fontStyle: this._elementFilter === null ? 'bold' : 'normal',
+            backgroundColor: '#0a0608', padding: { x: 3, y: 1 }
+        }).setInteractive({ useHandCursor: true }));
+        allBtn.on('pointerdown', () => { this._elementFilter = null; this._scrollOffsets[this._tab] = 0; this._refresh(); });
+        bx += allBtn.width + 4;
+
+        // Collect all elements used in recipes for this tab context
+        const recipeElements = new Set();
+        if (typeof ALLOY_DEFS !== 'undefined') {
+            for (const alloy of Object.values(ALLOY_DEFS)) {
+                for (const r of alloy.recipe) recipeElements.add(r.symbol);
+            }
+        }
+        for (const [symbol] of Object.entries(collected)) {
+            recipeElements.add(symbol);
+        }
+
+        for (const symbol of recipeElements) {
+            const count = collected[symbol] || 0;
+            const elem = typeof ELEMENTS !== 'undefined' ? ELEMENTS[symbol] : null;
+            const col = elem ? elem.color : 0xaaaaaa;
+            const hexCol = '#' + col.toString(16).padStart(6, '0');
+            const isActive = this._elementFilter === symbol;
+            const dimmed = count === 0;
+
+            const badge = this._d(this.add.text(bx, y, symbol, {
+                fontSize: '12px',
+                color: isActive ? '#ff7722' : (dimmed ? '#222222' : hexCol),
+                fontFamily: 'monospace',
+                fontStyle: isActive ? 'bold' : 'normal',
+                backgroundColor: isActive ? '#331100' : '#0a0608',
+                padding: { x: 3, y: 1 }
+            }).setInteractive({ useHandCursor: true }));
+            badge.on('pointerdown', () => {
+                this._elementFilter = isActive ? null : symbol;
+                this._scrollOffsets[this._tab] = 0;
+                this._refresh();
+            });
+            bx += badge.width + 3;
+            if (bx > leftX + maxW) { bx = leftX; y += 18; }
+        }
+
+        this.contentY = y + 22;
     }
 
     _drawLockedTab() {
@@ -705,7 +765,10 @@ class SmelteryScene extends Phaser.Scene {
         y += 22;
 
         const fuel = this.smelter.calculateFuelEnergy(hero);
-        const alloys = this.smelter.getAvailableAlloys(hero, fuel);
+        let alloys = this.smelter.getAvailableAlloys(hero, fuel);
+        if (this._elementFilter) {
+            alloys = alloys.filter(e => e.alloy.recipe.some(r => r.symbol === this._elementFilter));
+        }
         const colW = Math.min(560, this.panelW - 40);
         const startX = this.px + 20;
         const rowStep = 60;

--- a/src/scenes/SmelteryScene.js
+++ b/src/scenes/SmelteryScene.js
@@ -295,9 +295,22 @@ class SmelteryScene extends Phaser.Scene {
 
             const stashDepName = (def.type === 'mineral' && typeof getMineralDisplayName !== 'undefined')
                 ? getMineralDisplayName(def, hero) : def.name;
-            this._d(this.add.text(leftX + 4, adjY, `${stashDepName} ×${entry.count}`, {
+            const nameText = this._d(this.add.text(leftX + 4, adjY, `${stashDepName} ×${entry.count}`, {
                 fontSize: '14px', color: hexCol, fontFamily: 'monospace'
-            }));
+            }).setInteractive());
+            if (def.type === 'mineral' && def.yields) {
+                const yieldStr = def.yields.map(y => y.symbol).join(', ');
+                nameText.on('pointerover', () => {
+                    if (this._mineralTooltip) this._mineralTooltip.destroy();
+                    this._mineralTooltip = this._d(this.add.text(leftX + 4, adjY - 18, `T${def.tier} → ${yieldStr}`, {
+                        fontSize: '12px', color: '#bbaa88', fontFamily: 'monospace',
+                        backgroundColor: '#0a0608', padding: { x: 4, y: 2 }
+                    }));
+                });
+                nameText.on('pointerout', () => {
+                    if (this._mineralTooltip) { this._mineralTooltip.destroy(); this._mineralTooltip = null; }
+                });
+            }
 
             const btn = this._d(this.add.text(leftX + colW - 10, adjY, '→', {
                 fontSize: '16px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
@@ -352,9 +365,22 @@ class SmelteryScene extends Phaser.Scene {
                 const col = def ? def.color : 0xaaaaaa;
                 const hexCol = '#' + col.toString(16).padStart(6, '0');
 
-                this._d(this.add.text(rightX + 4, adjY, `${stName} ×${stashEntry.count}`, {
+                const stText = this._d(this.add.text(rightX + 4, adjY, `${stName} ×${stashEntry.count}`, {
                     fontSize: '14px', color: hexCol, fontFamily: 'monospace'
-                }));
+                }).setInteractive());
+                if (def && def.type === 'mineral' && def.yields) {
+                    const yieldStr = def.yields.map(y => y.symbol).join(', ');
+                    stText.on('pointerover', () => {
+                        if (this._mineralTooltip) this._mineralTooltip.destroy();
+                        this._mineralTooltip = this._d(this.add.text(rightX + 4, adjY - 18, `T${def.tier} → ${yieldStr}`, {
+                            fontSize: '12px', color: '#bbaa88', fontFamily: 'monospace',
+                            backgroundColor: '#0a0608', padding: { x: 4, y: 2 }
+                        }));
+                    });
+                    stText.on('pointerout', () => {
+                        if (this._mineralTooltip) { this._mineralTooltip.destroy(); this._mineralTooltip = null; }
+                    });
+                }
 
                 const btn = this._d(this.add.text(rightX + colW - 10, adjY, '←', {
                     fontSize: '16px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
@@ -656,7 +682,7 @@ class SmelteryScene extends Phaser.Scene {
         if (newBonuses.length > 0) {
             hero.elementTracker.applyBonusRewards(hero);
             for (const bonus of newBonuses) {
-                EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `${bonus.name} fullført! ${bonus.desc}`, color: '#ffcc00' });
+                EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `★ ${bonus.name} fullført! ${bonus.desc}`, color: '#ffcc00', big: true });
             }
         }
         Audio.playPickup();

--- a/src/scenes/UIScene.js
+++ b/src/scenes/UIScene.js
@@ -251,6 +251,20 @@ class UIScene extends Phaser.Scene {
             }
         }
 
+        // Special rooms (camp=orange, chem=green, accelerator=purple on lit/dim tiles)
+        if (gs._gen && gs._gen.specialRooms) {
+            const roomColors = { camp_room: 0xff7722, chem_lab: 0x33dd88, accelerator: 0x8866ff };
+            for (const room of gs._gen.specialRooms) {
+                const rc = roomColors[room.type];
+                if (!rc) continue;
+                for (const t of room.tiles) {
+                    if (!gs.fog[t.y] || gs.fog[t.y][t.x] === FOG.DARK) continue;
+                    g.fillStyle(rc, 0.6);
+                    g.fillRect(mx + t.x * sc, my + t.y * sc, sc, sc);
+                }
+            }
+        }
+
         // Hero (bright white dot)
         const hpx = mx + gs.hero.gridX * sc;
         const hpy = my + gs.hero.gridY * sc;

--- a/src/systems/ChemistrySystem.js
+++ b/src/systems/ChemistrySystem.js
@@ -98,7 +98,7 @@ class ChemistrySystem {
         // Separate scaling curves: bombs scale faster than potions so they
         // keep pace with world monster HP; potions keep the older curve so
         // buffs don't become overpowered.
-        const potionScale = 1 + (wn - 1) * 0.4;
+        const potionScale = 1 + (wn - 1) * 0.15;
         const bombScale = 1 + (wn - 1) * 0.6;
         const bombFloor = wn * 2; // flat damage bonus per world
         // Radius auto-upgrade kicks in at world 5 and 8 so high-world bombs
@@ -133,7 +133,7 @@ class ChemistrySystem {
             // From world 4+ healing potions scale with % max HP so they stay
             // meaningful against higher HP pools.
             const flatHP = Math.round(eff.healHP * potencyMul * potionMagnitudeMul * potionScale);
-            const hp = wn >= 4
+            const hp = (wn >= 4 && mol.tier >= 3)
                 ? Math.max(flatHP, Math.round((hero.maxHearts || flatHP) * 0.25 * potencyMul))
                 : flatHP;
             item.desc = `+${hp} HP`;

--- a/src/systems/InputHandler.js
+++ b/src/systems/InputHandler.js
@@ -31,8 +31,13 @@ class InputHandler {
         scene.teleporterKey  = scene.input.keyboard.addKey('J');
         scene.moveTimer    = 0;
 
-        // Mouse wheel zoom
+        // Mouse wheel zoom (blocked when overlay scenes are open)
         scene.input.on('wheel', (pointer, gameObjects, deltaX, deltaY) => {
+            const sm = scene.scene;
+            if (sm.isActive('SkillScene') || sm.isActive('InventoryScene') ||
+                sm.isActive('MerchantScene') || sm.isActive('ElementBookScene') ||
+                sm.isActive('SmelteryScene') || sm.isActive('ChemLabScene') ||
+                sm.isActive('AcceleratorScene') || sm.isActive('SettingsScene')) return;
             const z  = scene.cameras.main.zoom;
             const nz = deltaY < 0
                 ? Math.min(ZOOM_MAX, z + ZOOM_STEP)

--- a/src/systems/Inventory.js
+++ b/src/systems/Inventory.js
@@ -345,9 +345,15 @@ class Inventory {
             }
         });
 
-        // Restore quick-use slot
-        if (data.quickUse && data.quickUse.id && ITEM_DEFS[data.quickUse.id]) {
-            inv.quickUse = { id: data.quickUse.id, count: data.quickUse.count || 1 };
+        // Restore quick-use slot (check both standard and molecule defs)
+        if (data.quickUse && data.quickUse.id) {
+            if (ITEM_DEFS[data.quickUse.id]) {
+                inv.quickUse = { id: data.quickUse.id, count: data.quickUse.count || 1 };
+            } else if (typeof MOLECULE_DEFS !== 'undefined' && MOLECULE_DEFS[data.quickUse.id]) {
+                const chemSys = new ChemistrySystem();
+                const chemItem = chemSys._createUsableItem(MOLECULE_DEFS[data.quickUse.id], hero, hero.worldNum || 1);
+                inv.quickUse = { id: data.quickUse.id, count: data.quickUse.count || 1, _chemItem: chemItem };
+            }
         }
 
         // Restore backpack (supports old format [id], new [{id, count}], and rarity [{id, rarity}])
@@ -369,7 +375,9 @@ class Inventory {
                     } else if (entry.isFuel && typeof FUEL_DEFS !== 'undefined' && FUEL_DEFS[entry.id]) {
                         inv.backpack[i] = { id: entry.id, count: entry.count || 1 };
                     } else if (entry.isMolecule && typeof MOLECULE_DEFS !== 'undefined' && MOLECULE_DEFS[entry.id]) {
-                        inv.backpack[i] = { id: entry.id, count: entry.count || 1 };
+                        const chemSys = new ChemistrySystem();
+                        const chemItem = chemSys._createUsableItem(MOLECULE_DEFS[entry.id], hero, hero.worldNum || 1);
+                        inv.backpack[i] = { id: entry.id, count: entry.count || 1, _chemItem: chemItem };
                     } else if (lookupDef(entry.id)) {
                         if (entry.count !== undefined) {
                             // Stacked consumable/tool

--- a/src/systems/ItemSpawner.js
+++ b/src/systems/ItemSpawner.js
@@ -501,7 +501,7 @@ class ItemSpawner {
                         // Check for completion bonuses and apply rewards
                         const newBonuses = scene.hero.elementTracker.checkCompletions();
                         for (const bonus of newBonuses) {
-                            scene._floatingText(hx, hy, `${bonus.name} fullført! ${bonus.desc}`, '#ffcc00');
+                            scene._floatingText(hx, hy, `★ ${bonus.name} fullført! ${bonus.desc}`, '#ffcc00', true);
                         }
                         if (newBonuses.length > 0) {
                             scene.hero.elementTracker.applyBonusRewards(scene.hero);

--- a/src/systems/MapRenderer.js
+++ b/src/systems/MapRenderer.js
@@ -505,6 +505,24 @@ class MapRenderer {
                     g.fillCircle(px + (seed & 7) + 8, py + (seed2 & 5) + 8, 3);
                     g.fillStyle(0xffaa00, 0.15);
                     g.fillCircle(px + (seed >> 2 & 5) + 12, py + (seed2 >> 2 & 5) + 6, 2);
+                } else if (room.type === 'accelerator') {
+                    // Particle accelerator: sci-fi purple glow with ring structure
+                    g.fillStyle(0x8866ff, 0.15);
+                    g.fillCircle(px + S / 2, py + S / 2, S / 2);
+                    // Ring structure
+                    g.lineStyle(2, 0x8866ff, 0.35);
+                    g.strokeCircle(px + S / 2, py + S / 2, 8);
+                    // Energy core
+                    g.fillStyle(0xaa88ff, 0.4);
+                    g.fillCircle(px + S / 2, py + S / 2, 3);
+                    // Particle trails
+                    g.fillStyle(0xcc99ff, 0.25);
+                    g.fillCircle(px + (seed & 7) + 4, py + (seed2 & 5) + 6, 1.5);
+                    g.fillCircle(px + (seed >> 2 & 7) + 14, py + (seed2 >> 2 & 5) + 14, 1);
+                    // Metal walls
+                    g.fillStyle(0x555566, 0.3);
+                    g.fillRect(px + 2, py + 2, 3, S - 4);
+                    g.fillRect(px + S - 5, py + 2, 3, S - 4);
                 }
                 break;
             }

--- a/src/systems/MonsterManager.js
+++ b/src/systems/MonsterManager.js
@@ -51,8 +51,11 @@ class MonsterManager {
         if (wn <= 1) return ['goblin'];
         if (wn <= 2) return ['goblin', 'orc', 'orc'];
         if (wn <= 3) return ['orc', 'orc', 'troll'];
-        if (wn <= 5) return ['orc', 'troll', 'troll'];
-        return ['troll', 'troll', 'troll'];
+        if (wn <= 4) return ['orc', 'skeleton', 'troll'];
+        if (wn <= 6) return ['skeleton', 'troll', 'golem'];
+        if (wn <= 8) return ['troll', 'golem', 'wraith'];
+        if (wn <= 10) return ['golem', 'wraith', 'demon'];
+        return ['wraith', 'demon', 'demon'];
     }
 
     // ── Monster AI tick ───────────────────────────────────────────────────────

--- a/src/systems/SmeltingSystem.js
+++ b/src/systems/SmeltingSystem.js
@@ -225,7 +225,7 @@ class SmeltingSystem {
      * @returns {number} Total energy available
      */
     calculateFuelEnergy(hero) {
-        let total = 0;
+        let total = hero.fuelReserve || 0;
         for (const entry of hero.inventory.backpack) {
             if (!entry) continue;
             const def = this._getFuelDef(entry);
@@ -277,7 +277,14 @@ class SmeltingSystem {
      */
     consumeFuel(hero, energyNeeded) {
         let remaining = energyNeeded;
-        // Consume from backpack first
+        // Deduct from fuel reserve first
+        if (hero.fuelReserve > 0) {
+            const fromReserve = Math.min(hero.fuelReserve, remaining);
+            hero.fuelReserve -= fromReserve;
+            remaining -= fromReserve;
+        }
+        if (remaining <= 0) return true;
+        // Consume from backpack
         for (let i = 0; i < hero.inventory.backpack.length && remaining > 0; i++) {
             const entry = hero.inventory.backpack[i];
             if (!entry) continue;
@@ -304,6 +311,10 @@ class SmeltingSystem {
                 }
                 if (entry.count <= 0) hero.campStash.splice(i, 1);
             }
+        }
+        // Store leftover energy in reserve for next operation
+        if (remaining < 0) {
+            hero.fuelReserve = (hero.fuelReserve || 0) + Math.abs(remaining);
         }
         return remaining <= 0;
     }


### PR DESCRIPTION
## Summary

Fixes all 18 open issues organized in 5 sprints, grouped by subsystem to minimize testing.

### Sprint 1: Input/Scroll + Skilltre
- **#123** — Block wheel zoom when overlay scenes are open
- **#115** — Fix synergy section overlapping T4 skill cards (dynamic layout)
- **#116** — 6 synergies now require T2 skills instead of T1

### Sprint 2: Kjemilab + Potions
- **#121** — Fix potion healing: reduce scaling (0.4→0.15/world), restrict 25% maxHP floor to T3+, fix molecule serialization so potions survive save/load
- **#109** — Add element-based recipe filtering in ChemLab (clickable badges)
- **#111** — Dedicated Transmutation tab in ChemLab
- **#117** — Larger ChemLab panel (760×600 → 960×720)

### Sprint 3: Maze/Mineraler + Elementbok
- **#108** — Fix accelerator not spawning: moved placement before optional rooms in priority
- **#119** — 20% chance for base-tier (T1-T2) minerals in world 5+ to keep Al/Fe/Cu accessible
- **#113** — Lanthanides/actinides moved down with 1.5-row gap, multi-row bonus display
- **#120** — ElementBook tooltip shows refined element counts

### Sprint 4: Smeltery + Crafting
- **#112** — Partial fuel usage: leftover energy stored in `fuelReserve`
- **#122** — Craftable keys (bronze) and pickaxes (steel) in Forge tab
- **#118** — Backpack expansion belt (+3 slots, max 2 upgrades) from scandium
- **#110** — Mineral tooltips in Stash tab showing tier and element yields
- **#114** — Prominent on-screen notifications (★) for element bonuses and synergies

### Sprint 5: Visuell variasjon
- **#124** — Distinct procedural sprites for potions (flask), dynamite (sticks), bombs (round), acids (vial)
- **#125** — 4 new monster types: skeleton (world 4+), golem (world 6+), wraith (world 8+), demon (world 10+)

## Test plan
- [ ] Open each overlay scene and verify mouse wheel does NOT zoom the game behind it
- [ ] Check skill tree layout with T4 paths — synergies should not overlap
- [ ] Craft potions in ChemLab, save/load, verify they heal correct amount (not full)
- [ ] Test element filtering and Transmutation tab in ChemLab
- [ ] Generate worlds 13-15+ multiple times — verify accelerator rooms appear
- [ ] Check mineral drops in world 8+ for mix of tiers including T1-T2
- [ ] Open ElementBook — verify lanthanide/actinide gap and refined counts in tooltip
- [ ] Smelt with coal (3 energy) on 1-energy recipe — verify 2 energy preserved
- [ ] Forge key, pickaxe, and backpack upgrade in Smi tab
- [ ] Hover over minerals in Stash tab for tooltips
- [ ] Play to world 4+ and verify skeleton, golem, wraith, demon monsters appear
- [ ] Craft chemistry items and verify distinct icons in world and inventory
- [ ] Run `simulator.html` for balance verification

https://claude.ai/code/session_01UwsQ5L4AxHdhFvW8s1xxfc