### PR TITLE
Sprint: Victory scene, NG+, touch controls, monsters, balance

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ---
 
+## v0.47 – 2026-04-25
+
+### Nye funksjoner
+- **Victory-scene ved 118 grunnstoffer:** Når spilleren samler alle 118 grunnstoffer trigges en episk victory-scene med fanfare, gullpartikler, mini periodisk tabell, og tittelen «Guds periodiske system». Victory kan trigges umiddelbart (i spill-scenen) eller ved verdensavslutning
+- **New Game+ (NG+):** Etter victory kan spilleren starte en ny reise med beholdte levels/skills/gull, men nullstilt elementsamling. Monstre skaleres +40% HP og +25% angrep per NG+-syklus
+- **Victory-badge i meny:** Spillere som har fullført spillet ser gull-badge «✦ Guds periodiske system» med NG+-nivå i hovedmenyen
+- **NG+-indikator i HUD:** Sonenavn viser NG+-syklus (f.eks. «Overflatelag 1/3 NG+1»)
+- **Victory-fanfare:** Ny prosedyregenerert lyd med stigende arpeggio og vedvarende akkord
+
+### Feilrettinger
+- **Transmutasjon trigget ikke elementbonuser (#bug):** ChemLabScene._doTransmute() manglet checkCompletions() etter transmutasjon — grunnstoffer oppdaget via transmutasjon kunne ikke trigge bonuser som «Guds periodiske system»
+- **Elementbok viste feil mål:** Endret fra «X/90» (kun naturlige) til «X/118» (alle grunnstoffer) for å reflektere spillets faktiske mål
+
+### Tekniske endringer
+- constants.js: Ny `FINAL_WORLD = 25` konstant
+- HeroCrafting: Nye felt `ngPlusLevel` og `victoryAchieved` med serialisering/deserialisering
+- ElementTracker: Emitter `elementBonusComplete` via EventBus ved bonus-fullføring
+- GameScene: Lytter på `elementBonusComplete` for umiddelbar victory-trigger; `_checkExit()` sjekker alle 118 samlet
+- GameOverScene: Ny `_gameCompleteScreen()` med sparkle-partikler, mini periodisk tabell, NG+-start
+- MonsterManager: NG+-skalering stacker med vanskelighetsgrad-multiplikatorer
+- AudioManager: Ny `playVictory()` metode
+
+---
+
 ## v0.46 – 2026-04-19
 
 ### Forbedringer

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ---
 
+## v0.46 – 2026-04-19
+
+### Forbedringer
+- **Færre touch-knapper, kontekstsensitiv ÅPNE-knapp:** Menyknapper redusert fra 6 til 3 (INV, SKL, ÅPNE). ÅPNE-knappen endrer farge og label dynamisk basert på heltens plassering: BOK (elementbok) → SMI (leirplass) → LAB (kjemilab) → ACE (akselerator). Løser også manglende akselerator-knapp for mobil (#108)
+- **Minikart-toggle via trykk:** På touch-enheter kan minikartet nå toggles ved å trykke direkte på det, i stedet for en egen MAP-knapp
+
+### Tekniske endringer
+- TouchControls: Ny `_createContextButton()` og `updateContextButton(gameScene)` for dynamisk knapp. Fjernet `updateVisibility()` og individuelle menyknapper
+- GameScene: Ny `_handleTouchOpenContext()` erstatter individuelle touch-scene-handlinger. Tastaturkontroller (V, C, P, B) uendret
+- UIScene: Interaktiv sone over minikartet for touch-toggle. Kaller `updateContextButton()` i refresh
+
+---
+
 ## v0.45 – 2026-04-18
 
 ### Feilrettinger

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,6 +1,6 @@
 # Labyrint Hero – Game Design Document
-**Versjon:** 0.46
-**Sist oppdatert:** 2026-04-19
+**Versjon:** 0.47
+**Sist oppdatert:** 2026-04-25
 
 ---
 
@@ -618,7 +618,7 @@ Låses opp ved første besøk i partikkelakselerator. Krever ≥1 Kjemiker-skill
 
 **Edelgass-samling:** Gasslommer (verden 10+) gir 1–2 tilfeldige edelgasser (Ar, Kr, Xe, Ne, He) direkte i elementtrakeren.
 
-**Endgame:** Samle alle 118 grunnstoffer utløser «Guds periodiske system» – +10 ATK, +10 DEF, +5 hjerter, +3 synsfelt.
+**Endgame:** Samle alle 118 grunnstoffer utløser «Guds periodiske system» – +10 ATK, +10 DEF, +5 hjerter, +3 synsfelt. Ved fullføring vises en episk victory-scene med fanfare, gullpartikler og mini periodisk tabell. Spilleren tilbys **New Game+** som nullstiller elementsamlingen men beholder nivå, skills og gull. Monstre skaleres +40% HP / +25% ATK per NG+-syklus. Elementbok viser fremgang mot 118 (ikke 90).
 
 ### Halvleder-system (v0.43)
 

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,6 +1,6 @@
 # Labyrint Hero – Game Design Document
-**Versjon:** 0.45
-**Sist oppdatert:** 2026-04-18
+**Versjon:** 0.46
+**Sist oppdatert:** 2026-04-19
 
 ---
 
@@ -150,11 +150,16 @@ Heltens grunnstats gjør at verden 1 er farlig uten noe utstyr. Utstyr og evner 
 | SPACE / F / Angrepsknapp (touch) | Angrip i sett retning (eller nærmeste monster) |
 | R / Bueknapp (touch) | Skyt pil (krever bue utstyrt) |
 | Q / USE-knapp (touch) | Bruk første consumable i ryggsekken (bombe, drikk, etc.) |
-| E / Inventarknapp (touch) | Åpne/lukk inventory |
-| T | Vis ferdighetstre (kun visning) |
+| E / INV-knapp (touch) | Åpne/lukk inventory |
+| T / SKL-knapp (touch) | Vis ferdighetstre (kun visning) |
 | ESC | Lukk overlay |
-| +/- eller muskjul | Zoom inn/ut |
-| M / Minikartknapp (touch) | Vis/skjul minikart |
+| +/- eller mushjul | Zoom inn/ut |
+| M / trykk på minikart (touch) | Vis/skjul minikart |
+| V | Åpne smelteovn (i leirplass) |
+| C | Åpne kjemilab (i kjemilab) |
+| P | Åpne akselerator (i akselerator) |
+| B | Åpne elementbok |
+| ÅPNE-knapp (touch) | Kontekstsensitiv: åpner smelteovn/kjemilab/akselerator basert på plassering, ellers elementbok |
 | ⚙ (HUD) | Åpne lydinnstillinger |
 | Langt trykk (touch) | Slipp gjenstand i inventory (erstatter høyreklikk) |
 
@@ -426,7 +431,7 @@ Serveren avviser umulige poengsummer:
 | Butikk / handelsmann | ✅ Ferdig | Handelsmann-NPC i hver labyrint |
 | Gull + økonomi | ✅ Ferdig | Gullvaluta fra monstre/kister; handelsmann |
 | Gjenstandssjeldenhet | ✅ Ferdig | 5 sjeldenhetsgrader med stat-boost |
-| Touch/mobil-støtte | ✅ Ferdig | D-pad, handlingsknapper, responsiv skalering, langt-trykk drop |
+| Touch/mobil-støtte | ✅ Ferdig | D-pad, 3 handlingsknapper (ATK/BOW/USE), 3 menyknapper (INV/SKL/kontekstsensitiv ÅPNE), minikart-trykk-toggle, responsiv skalering, langt-trykk drop |
 | Leaderboard | ✅ Ferdig | Lokal + global ledertavle med filtrering, mineraler samlet, elementer oppdaget |
 
 ---

--- a/src/constants.js
+++ b/src/constants.js
@@ -72,6 +72,8 @@ const MONSTER_XP        = { goblin: 10, orc: 25, troll: 50, skeleton: 20, golem:
 const XP_BASE           = 100;   // XP needed for level 2
 const XP_GROWTH         = 1.55;  // multiplier per level
 
+const FINAL_WORLD = 25;
+
 // ── Zone system (Phase 4) ────────────────────────────────────────────────────
 // Zones group worlds into geological regions. Zone boss at last world of each.
 const ZONES = [

--- a/src/entities/HeroCrafting.js
+++ b/src/entities/HeroCrafting.js
@@ -83,6 +83,8 @@ const HeroCrafting = {
 
         // Zone progression (Phase 4)
         hero.completedZones = [];
+        hero.ngPlusLevel = 0;
+        hero.victoryAchieved = false;
 
         // Element bonus rewards
         hero.appliedElementBonuses = {};
@@ -173,6 +175,8 @@ const HeroCrafting = {
             empCharges:           hero.empCharges || 0,
             laserTurretCharges:   hero.laserTurretCharges || 0,
             completedZones:       [...hero.completedZones],
+            ngPlusLevel:          hero.ngPlusLevel,
+            victoryAchieved:      hero.victoryAchieved,
             appliedElementBonuses: { ...hero.appliedElementBonuses },
             elementGoldMul:       hero.elementGoldMul,
             elementPoisonResist:  hero.elementPoisonResist,
@@ -256,6 +260,8 @@ const HeroCrafting = {
         hero.empCharges           = stats.empCharges           || 0;
         hero.laserTurretCharges   = stats.laserTurretCharges   || 0;
         hero.completedZones       = stats.completedZones       ? [...stats.completedZones] : [];
+        hero.ngPlusLevel          = stats.ngPlusLevel          || 0;
+        hero.victoryAchieved      = stats.victoryAchieved      || false;
         hero.appliedElementBonuses = stats.appliedElementBonuses ? { ...stats.appliedElementBonuses } : {};
         hero.elementGoldMul       = stats.elementGoldMul       || 0;
         hero.elementPoisonResist  = stats.elementPoisonResist  || 0;

--- a/src/scenes/ChemLabScene.js
+++ b/src/scenes/ChemLabScene.js
@@ -532,6 +532,15 @@ class ChemLabScene extends Phaser.Scene {
         const produced = this.chem.transmute(hero, symbol);
         if (!produced) return;
         EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `Transmuted: 5 ${symbol} → 1 ${produced}`, color: '#ff88cc' });
+
+        const newBonuses = hero.elementTracker.checkCompletions();
+        if (newBonuses.length > 0) {
+            hero.elementTracker.applyBonusRewards(hero);
+            for (const bonus of newBonuses) {
+                EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `★ ${bonus.name} fullført! ${bonus.desc}`, color: '#ffcc00', big: true });
+            }
+        }
+
         Audio.playPickup();
         this._refresh();
     }

--- a/src/scenes/ElementBookScene.js
+++ b/src/scenes/ElementBookScene.js
@@ -32,7 +32,7 @@ class ElementBookScene extends Phaser.Scene {
 
         // Title
         const discovered = tracker ? tracker.discoveredCount : 0;
-        const total = typeof TOTAL_NATURAL_ELEMENTS !== 'undefined' ? TOTAL_NATURAL_ELEMENTS : '?';
+        const total = typeof TOTAL_ALL_ELEMENTS !== 'undefined' ? TOTAL_ALL_ELEMENTS : '?';
         this.add.text(cx, py + 18, `ELEMENTBOK  –  Det periodiske system`, {
             fontSize: '14px', color: '#997755', fontFamily: 'monospace', fontStyle: 'bold',
             stroke: '#4a3a22', strokeThickness: 1

--- a/src/scenes/GameOverScene.js
+++ b/src/scenes/GameOverScene.js
@@ -33,7 +33,8 @@ class GameOverScene extends Phaser.Scene {
                 goldEarned:         this.heroStats.gold || 0,
                 mineralsCollected:  this.heroStats.mineralsCollected || 0,
                 elementsDiscovered: elementsDiscovered,
-                result:             'worldComplete',
+                result:             this.type,
+                ngPlusLevel:        this.heroStats.ngPlusLevel || 0,
                 timeSeconds:        this.heroStats.totalPlayTime || this.timeSeconds
             };
             Leaderboard.record(entry);
@@ -46,6 +47,8 @@ class GameOverScene extends Phaser.Scene {
 
         if (this.type === 'death') {
             this._deathScreen(cx, cy, W, H);
+        } else if (this.type === 'gameComplete') {
+            this._gameCompleteScreen(cx, cy, W, H);
         } else {
             this._victoryScreen(cx, cy, W, H);
         }
@@ -177,6 +180,154 @@ class GameOverScene extends Phaser.Scene {
                 });
             }
             yOff += 24;
+        }
+    }
+
+    // ── Game complete screen (all 118 elements collected) ───────────────────
+
+    _gameCompleteScreen(cx, cy, W, H) {
+        Audio.stopMusic();
+        Audio.playVictory();
+
+        const g = this.add.graphics();
+        g.fillStyle(0x1a1400, 0.7);
+        g.fillRect(0, 0, W, H);
+
+        this._spawnCelebrationParticles(W, H);
+
+        const ngPlus = this.heroStats.ngPlusLevel || 0;
+        const ngLabel = ngPlus > 0 ? `  NG+${ngPlus}` : '';
+
+        this.add.text(cx, cy - 180, '✦ ✦ ✦', {
+            fontSize: '32px', color: '#ffcc00', fontFamily: 'monospace'
+        }).setOrigin(0.5);
+
+        const titleText = this.add.text(cx, cy - 145, 'GUDS PERIODISKE SYSTEM', {
+            fontSize: '36px', color: '#f5e642', fontFamily: 'monospace',
+            fontStyle: 'bold', stroke: '#7a6a00', strokeThickness: 6
+        }).setOrigin(0.5);
+        this.tweens.add({
+            targets: titleText, alpha: 0.7, duration: 800,
+            yoyo: true, repeat: -1, ease: 'Sine.easeInOut'
+        });
+
+        this.add.text(cx, cy - 100, `Du har samlet alle 118 grunnstoffer!${ngLabel}`, {
+            fontSize: '18px', color: '#ffffff', fontFamily: 'monospace'
+        }).setOrigin(0.5);
+
+        this.add.text(cx, cy - 76, 'Universets hemmeligheter er avslørt. Du er en sann mester!', {
+            fontSize: '12px', color: '#ccaa66', fontFamily: 'monospace'
+        }).setOrigin(0.5);
+
+        this._drawMiniPeriodicTable(cx, cy - 30);
+
+        this._fullStatsPanel(cx, cy + 40);
+
+        const ngBtn = this._button(cx, cy + 120, '[ NY REISE+ ]', '#ffcc00', 22);
+        ngBtn.on('pointerdown', () => this._startNewGamePlus());
+        this.tweens.add({ targets: ngBtn, alpha: 0.5, duration: 600, yoyo: true, repeat: -1 });
+
+        const freshBtn = this._button(cx, cy + 155, '[ NYTT SPILL ]', '#ff8844', 16);
+        freshBtn.on('pointerdown', () => {
+            SaveManager.clear();
+            this.scene.start('MenuScene');
+        });
+
+        const menuBtn = this._button(cx, cy + 185, '[ HOVED MENY ]', '#666688', 14);
+        menuBtn.on('pointerdown', () => this.scene.start('MenuScene'));
+    }
+
+    _drawMiniPeriodicTable(cx, cy) {
+        if (typeof PERIODIC_TABLE_LAYOUT === 'undefined' || typeof ELEMENTS === 'undefined') return;
+        const cellSize = 4;
+        const gap = 1;
+        const cols = 18, rows = 10;
+        const tableW = cols * (cellSize + gap);
+        const tableH = rows * (cellSize + gap);
+        const ox = cx - tableW / 2;
+        const oy = cy - tableH / 2;
+        const gfx = this.add.graphics();
+        for (const entry of PERIODIC_TABLE_LAYOUT) {
+            const elem = ELEMENTS[entry.symbol];
+            if (!elem) continue;
+            const x = ox + entry.col * (cellSize + gap);
+            const y = oy + entry.row * (cellSize + gap);
+            gfx.fillStyle(elem.color, 0.9);
+            gfx.fillRect(x, y, cellSize, cellSize);
+        }
+    }
+
+    _fullStatsPanel(cx, cy) {
+        const s = this.heroStats;
+        const et = s.elementTracker || {};
+        const discovered = et.discovered ? Object.keys(et.discovered).length : 0;
+        const completedZones = s.completedZones || [];
+        const ngPlus = s.ngPlusLevel || 0;
+        const totalTime = s.totalPlayTime || this.timeSeconds;
+
+        const lines = [
+            `Nivå: ${s.level}   Gull: ${s.gold}g`,
+            `Hjerter: ${s.hearts}/${s.maxHearts}  Angrep: ${s.attack}  Forsvar: ${s.defense}`,
+            `Grunnstoffer: ${discovered}/118   Soner: ${completedZones.length}/5`,
+            `Total spilltid: ${this._formatTime(totalTime)}`,
+        ];
+        if (ngPlus > 0) lines.push(`New Game+ syklus: ${ngPlus}`);
+        lines.forEach((line, i) => {
+            this.add.text(cx, cy + i * 18, line, {
+                fontSize: '13px', color: '#aabb99', fontFamily: 'monospace'
+            }).setOrigin(0.5);
+        });
+    }
+
+    _startNewGamePlus() {
+        const stats = { ...this.heroStats };
+        stats.ngPlusLevel = (stats.ngPlusLevel || 0) + 1;
+        stats.victoryAchieved = true;
+        // Reset element collection — the core challenge for NG+
+        stats.elementTracker = { discovered: {}, collected: {}, completedBonuses: {} };
+        stats.appliedElementBonuses = {};
+        stats.godModeUnlocked = false;
+        stats.cosmicPower = false;
+        stats.fusionUnlocked = false;
+        stats.fissionUpgraded = false;
+        stats.elementGoldMul = 0;
+        stats.elementPoisonResist = 0;
+        stats.elementArmorBonus = 0;
+        stats.merchantMineralsUnlocked = false;
+        stats.magicAoeUnlocked = false;
+        stats.elementTitle = null;
+        stats.legendaryItemEarned = false;
+        SaveManager.save(1, stats);
+        this.scene.start('GameScene', {
+            worldNum: 1,
+            heroStats: stats,
+            difficulty: this.difficulty
+        });
+    }
+
+    _spawnCelebrationParticles(W, H) {
+        const colors = [0xf5e642, 0xffcc00, 0xff8844, 0x88ddff, 0xffffff];
+        for (let i = 0; i < 30; i++) {
+            this.time.delayedCall(i * 120, () => {
+                const px = Math.random() * W;
+                const py = Math.random() * H;
+                const spark = this.add.graphics();
+                const col = colors[Math.floor(Math.random() * colors.length)];
+                spark.fillStyle(col, 0.8);
+                const size = 2 + Math.random() * 4;
+                spark.fillRect(-size / 2, -size / 2, size, size);
+                spark.x = px;
+                spark.y = py;
+                spark.setDepth(15);
+                this.tweens.add({
+                    targets: spark,
+                    y: py - 40 - Math.random() * 60,
+                    alpha: 0, scaleX: 0.1, scaleY: 0.1,
+                    duration: 1500 + Math.random() * 1000,
+                    ease: 'Sine.easeOut',
+                    onComplete: () => { if (spark.scene) spark.destroy(); }
+                });
+            });
         }
     }
 

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -149,6 +149,9 @@ class GameScene extends Phaser.Scene {
         EventBus.on('floatingText', (d) => this._floatingText(d.gx, d.gy, d.msg, d.color, d.big));
         EventBus.on('showMessage', (d) => this._showMessage(d.text, d.color));
         EventBus.on('spawnItem', (d) => this.itemSpawner.spawnItemAt(d.gx, d.gy, d.item));
+        EventBus.on('elementBonusComplete', (bonus) => {
+            if (bonus.id === 'all_118') this._triggerElementVictory();
+        });
 
         // ── HUD overlay ───────────────────────────────────────────────────────
         this.scene.launch('UIScene', { gameScene: this });
@@ -401,10 +404,37 @@ class GameScene extends Phaser.Scene {
 
         const worldTime = Math.round((Date.now() - this._worldStartTime) / 1000);
         this.hero.totalPlayTime = (this.hero.totalPlayTime || 0) + worldTime;
+
+        const hasAll118 = this.hero.elementTracker && this.hero.elementTracker.discoveredCount >= 118;
+        const isGameComplete = hasAll118 && !this.hero.victoryAchieved;
+
+        if (isGameComplete) {
+            this.hero.victoryAchieved = true;
+        }
+
         SaveManager.save(this.worldNum + 1, this._getFullStats());
         this.time.delayedCall(300, () => {
             this.scene.start('GameOverScene', {
-                type: 'worldComplete', worldNum: this.worldNum,
+                type: isGameComplete ? 'gameComplete' : 'worldComplete',
+                worldNum: this.worldNum,
+                heroStats: this._getFullStats(), difficulty: this.difficulty,
+                monstersKilled: this.monstersKilled,
+                timeSeconds: worldTime
+            });
+        });
+    }
+
+    _triggerElementVictory() {
+        if (this.hero.victoryAchieved) return;
+        this.hero.victoryAchieved = true;
+        this._floatingText(this.hero.gridX, this.hero.gridY, '✦ ALLE 118 GRUNNSTOFFER SAMLET! ✦', '#f5e642', true);
+        Audio.playVictory();
+        SaveManager.save(this.worldNum, this._getFullStats());
+        const worldTime = Math.round((Date.now() - this._worldStartTime) / 1000);
+        this.time.delayedCall(2500, () => {
+            this._stopOverlayScenes();
+            this.scene.start('GameOverScene', {
+                type: 'gameComplete', worldNum: this.worldNum,
                 heroStats: this._getFullStats(), difficulty: this.difficulty,
                 monstersKilled: this.monstersKilled,
                 timeSeconds: worldTime

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -186,31 +186,20 @@ class GameScene extends Phaser.Scene {
             if (Phaser.Input.Keyboard.JustDown(this.eKey) || touchInv) {
                 this.scene.launch('InventoryScene');
             }
-            const touchBook = this.game.registry.get('touch_elementbook');
-            if (touchBook) this.game.registry.set('touch_elementbook', false);
-            if ((Phaser.Input.Keyboard.JustDown(this.elementBookKey) || touchBook) && !this.scene.isActive('ElementBookScene')) {
+            if (Phaser.Input.Keyboard.JustDown(this.elementBookKey) && !this.scene.isActive('ElementBookScene')) {
                 this.scene.launch('ElementBookScene', { heroRef: this.hero });
             }
-            const touchSmelt = this.game.registry.get('touch_smeltery');
-            if (touchSmelt) this.game.registry.set('touch_smeltery', false);
-            if ((Phaser.Input.Keyboard.JustDown(this.smelteryKey) || touchSmelt) && !this.scene.isActive('SmelteryScene') && this._isInCampRoom()) {
+            if (Phaser.Input.Keyboard.JustDown(this.smelteryKey) && !this.scene.isActive('SmelteryScene') && this._isInCampRoom()) {
                 this.scene.launch('SmelteryScene', { heroRef: this.hero });
             }
-
-            const touchChem = this.game.registry.get('touch_chemlab');
-            if (touchChem) this.game.registry.set('touch_chemlab', false);
-            if ((Phaser.Input.Keyboard.JustDown(this.chemLabKey) || touchChem) && !this.scene.isActive('ChemLabScene') && this._isInChemLab()) {
+            if (Phaser.Input.Keyboard.JustDown(this.chemLabKey) && !this.scene.isActive('ChemLabScene') && this._isInChemLab()) {
                 if (this.hero.chemLabUnlocked) {
                     this.scene.launch('ChemLabScene', { heroRef: this.hero, worldNum: this.worldNum });
                 } else {
                     this._showMessage('Beseir en soneboss for å låse opp laboratoriet!', '#33dd88');
                 }
             }
-
-            // Particle accelerator (P key)
-            const touchAccel = this.game.registry.get('touch_accelerator');
-            if (touchAccel) this.game.registry.set('touch_accelerator', false);
-            if ((Phaser.Input.Keyboard.JustDown(this.acceleratorKey) || touchAccel) && !this.scene.isActive('AcceleratorScene') && this._isInAccelerator()) {
+            if (Phaser.Input.Keyboard.JustDown(this.acceleratorKey) && !this.scene.isActive('AcceleratorScene') && this._isInAccelerator()) {
                 this.scene.launch('AcceleratorScene', { heroRef: this.hero, worldNum: this.worldNum });
             }
 
@@ -218,6 +207,13 @@ class GameScene extends Phaser.Scene {
             if (touchSkill) this.game.registry.set('touch_skilltree', false);
             if ((Phaser.Input.Keyboard.JustDown(this.skillTreeKey) || touchSkill) && !this.scene.isActive('SkillScene')) {
                 this.scene.launch('SkillScene', { heroRef: this.hero, viewOnly: true });
+            }
+
+            // Context-sensitive touch button (opens scene based on hero location)
+            const touchCtx = this.game.registry.get('touch_open_context');
+            if (touchCtx) {
+                this.game.registry.set('touch_open_context', false);
+                this._handleTouchOpenContext();
             }
 
             // Auto-open prompts for special rooms
@@ -303,6 +299,24 @@ class GameScene extends Phaser.Scene {
             this._showMessage('Partikkelakselerator! Trykk P for å syntetisere grunnstoffer.', '#8866ff');
         } else if (!this._isInAccelerator()) {
             this._acceleratorShown = false;
+        }
+    }
+
+    // ── Context-sensitive touch open ────────────────────────────────────────
+
+    _handleTouchOpenContext() {
+        if (this._isInCampRoom() && !this.scene.isActive('SmelteryScene')) {
+            this.scene.launch('SmelteryScene', { heroRef: this.hero });
+        } else if (this._isInChemLab() && !this.scene.isActive('ChemLabScene')) {
+            if (this.hero.chemLabUnlocked) {
+                this.scene.launch('ChemLabScene', { heroRef: this.hero, worldNum: this.worldNum });
+            } else {
+                this._showMessage('Beseir en soneboss for å låse opp laboratoriet!', '#33dd88');
+            }
+        } else if (this._isInAccelerator() && !this.scene.isActive('AcceleratorScene')) {
+            this.scene.launch('AcceleratorScene', { heroRef: this.hero, worldNum: this.worldNum });
+        } else if (!this.scene.isActive('ElementBookScene')) {
+            this.scene.launch('ElementBookScene', { heroRef: this.hero });
         }
     }
 

--- a/src/scenes/MenuScene.js
+++ b/src/scenes/MenuScene.js
@@ -50,8 +50,13 @@ class MenuScene extends Phaser.Scene {
             const name = (saved.heroStats?.heroName) || 'Helten';
             const race = (saved.heroStats?.race)    || 'human';
             const lvl  = saved.heroStats?.level || 1;
-            this.add.text(cx, cy + 28, `${name}  ·  Verden ${saved.worldNum}  ·  Nivå ${lvl}`, {
-                fontSize: '15px', color: '#667788', fontFamily: 'monospace'
+            const victoryDone = saved.heroStats?.victoryAchieved;
+            const ngPlus = saved.heroStats?.ngPlusLevel || 0;
+            const badge = victoryDone
+                ? (ngPlus > 0 ? `✦ Guds periodiske system NG+${ngPlus}  ·  ` : '✦ Guds periodiske system  ·  ')
+                : '';
+            this.add.text(cx, cy + 28, `${badge}${name}  ·  Verden ${saved.worldNum}  ·  Nivå ${lvl}`, {
+                fontSize: '15px', color: victoryDone ? '#f5e642' : '#667788', fontFamily: 'monospace'
             }).setOrigin(0.5);
 
             const cont = this._btn(cx, cy + 58, '[ FORTSETT ]', '#00e87a', 22);

--- a/src/scenes/UIScene.js
+++ b/src/scenes/UIScene.js
@@ -375,12 +375,14 @@ class UIScene extends Phaser.Scene {
 
         // ── Labels ────────────────────────────────────────────────────────────
         const wn = this.gameScene.worldNum;
+        const ngPlus = hero.ngPlusLevel || 0;
+        const ngTag = ngPlus > 0 ? ` NG+${ngPlus}` : '';
         if (typeof getZone !== 'undefined') {
             const zone = getZone(wn);
             const floor = getZoneFloor(wn);
-            this.worldText.setText(`${zone.name} ${floor}/${zone.worlds.length}`);
+            this.worldText.setText(`${zone.name} ${floor}/${zone.worlds.length}${ngTag}`);
         } else {
-            this.worldText.setText(`Verden ${wn}`);
+            this.worldText.setText(`Verden ${wn}${ngTag}`);
         }
         this.levelText.setText(`Nivå ${hero.level}  XP ${hero.xp}/${hero.xpToNext}`);
         this.atkText.setText(`ATK ${hero.attack}  DEF ${hero.defense}  Syn ${hero.visionRadius}`);

--- a/src/scenes/UIScene.js
+++ b/src/scenes/UIScene.js
@@ -103,11 +103,18 @@ class UIScene extends Phaser.Scene {
         this._minimapY     = H - 8;    // bottom-anchored
         this._minimapThrottle = 0;
 
-        // Toggle minimap with M key or touch button
+        // Toggle minimap with M key or tap on minimap area
         this._minimapVisible = true;
         this.input.keyboard.on('keydown-M', () => {
             this._toggleMinimap();
         });
+
+        if (this.game.registry.get('isTouchDevice')) {
+            const mapZoneSz = 80;
+            const mapZone = this.add.zone(W - 8 - mapZoneSz / 2, H - 8 - mapZoneSz / 2, mapZoneSz, mapZoneSz)
+                .setInteractive().setDepth(99);
+            mapZone.on('pointerdown', () => this._toggleMinimap());
+        }
 
         this.refresh();
     }
@@ -332,7 +339,7 @@ class UIScene extends Phaser.Scene {
             this._minimapThrottle = now;
             this._drawMinimap();
         }
-        // Touch minimap toggle
+        // Legacy touch minimap toggle (from registry)
         if (this.game.registry.get('touch_minimap')) {
             this.game.registry.set('touch_minimap', false);
             this._toggleMinimap();
@@ -459,9 +466,9 @@ class UIScene extends Phaser.Scene {
             this.bossBar.setVisible(false);
         }
 
-        // ── Touch button visibility (unlock-gated) ───────────────────────────
-        if (this.touchControls) {
-            this.touchControls.updateVisibility(hero);
+        // ── Touch context button (update label/color based on hero location)
+        if (this.touchControls && this.gameScene) {
+            this.touchControls.updateContextButton(this.gameScene);
         }
     }
 }

--- a/src/systems/AudioManager.js
+++ b/src/systems/AudioManager.js
@@ -296,6 +296,20 @@ const Audio = (function () {
             );
         },
 
+        /** Game complete fanfare */
+        playVictory() {
+            if (!ctx || !sfxEnabled) return;
+            const fanfare = [0, 4, 7, 12, 16, 19, 24];
+            fanfare.forEach((s, i) =>
+                _note(_freq(s + 12), 0.30, sfxGain, 'triangle', 0.30, i * 0.12)
+            );
+            const chordTime = fanfare.length * 0.12 + 0.1;
+            [0, 7, 12, 16, 24].forEach(s =>
+                _note(_freq(s + 12), 0.8, sfxGain, 'sine', 0.18, chordTime)
+            );
+            _noise(0.6, sfxGain, 0.08, chordTime + 0.3, 2000);
+        },
+
         /** Boss nearby sting */
         playBossStrike() {
             if (!ctx || !sfxEnabled) return;

--- a/src/systems/ElementTracker.js
+++ b/src/systems/ElementTracker.js
@@ -53,6 +53,9 @@ class ElementTracker {
             if (allDiscovered) {
                 this.completedBonuses[bonus.id] = true;
                 newlyCompleted.push(bonus);
+                if (typeof EventBus !== 'undefined') {
+                    EventBus.emit('elementBonusComplete', bonus);
+                }
             }
         }
         return newlyCompleted;

--- a/src/systems/MonsterManager.js
+++ b/src/systems/MonsterManager.js
@@ -36,12 +36,15 @@ class MonsterManager {
             scene.monsters.push(new Monster(scene, x, y, types[Math.floor(Math.random() * types.length)]));
         }
 
-        // Apply difficulty HP/ATK multipliers
+        // Apply difficulty + NG+ HP/ATK multipliers
         const mods = scene._diffMods();
+        const ngPlus = scene.hero?.ngPlusLevel || 0;
+        const ngHpMul  = 1 + ngPlus * 0.40;
+        const ngAtkMul = 1 + ngPlus * 0.25;
         for (const m of scene.monsters) {
-            m.maxHp  = Math.max(1, Math.round(m.maxHp  * mods.hpMul));
+            m.maxHp  = Math.max(1, Math.round(m.maxHp  * mods.hpMul * ngHpMul));
             m.hp     = m.maxHp;
-            m.attack = Math.max(1, Math.round(m.attack * mods.atkMul));
+            m.attack = Math.max(1, Math.round(m.attack * mods.atkMul * ngAtkMul));
             m._draw();
         }
     }

--- a/src/systems/TouchControls.js
+++ b/src/systems/TouchControls.js
@@ -5,9 +5,10 @@ class TouchControls {
         this.scene = scene;
         this.game  = scene.game;
         this.widgets = [];
-        this._menuWidgets = []; // menu buttons tracked separately for visibility
-        this._domDpad = null;   // DOM-based d-pad container (for off-canvas placement)
+        this._domDpad = null;
         this._dpadButtons = [];
+        this._contextBtn = null; // {bg, txt, zone, x, y, sz} for dynamic updates
+        this._currentContext = 'book';
     }
 
     create() {
@@ -21,10 +22,8 @@ class TouchControls {
         reg.set('touch_inventory', false);
         reg.set('touch_minimap', false);
         reg.set('touch_use', false);
-        reg.set('touch_smeltery', false);
-        reg.set('touch_chemlab', false);
         reg.set('touch_skilltree', false);
-        reg.set('touch_elementbook', false);
+        reg.set('touch_open_context', false);
 
         this._createDpad();
         this._createActionButtons();
@@ -154,7 +153,7 @@ class TouchControls {
         this._createZoomButtons();
     }
 
-    // ── Menu Buttons (above action row, conditional visibility) ──────────────
+    // ── Menu Buttons (single row above action row) ──────────────────────────
 
     _createMenuButtons() {
         const sz   = 48;
@@ -164,25 +163,85 @@ class TouchControls {
         const baseX = W - 24 - sz / 2;
         const baseY = H - 24 - 56 / 2 - 10 - 56 - 10 - sz / 2; // above action row
 
-        const menuDefs = [
-            { label: 'INV', key: 'touch_inventory',   color: 0x335588, unlockKey: null },
-            { label: 'MAP', key: 'touch_minimap',      color: 0x338844, unlockKey: null },
-            { label: 'SKL', key: 'touch_skilltree',    color: 0x8866cc, unlockKey: null },
-            { label: 'BOK', key: 'touch_elementbook',  color: 0x997755, unlockKey: 'geologistUnlocked' },
-            { label: 'SMI', key: 'touch_smeltery',     color: 0xff7722, unlockKey: 'metallurgistUnlocked' },
-            { label: 'LAB', key: 'touch_chemlab',      color: 0x33dd88, unlockKey: 'chemLabUnlocked' },
+        const fixedDefs = [
+            { label: 'INV', key: 'touch_inventory',  color: 0x335588 },
+            { label: 'SKL', key: 'touch_skilltree',  color: 0x8866cc },
         ];
 
-        const cols = 3;
-        for (let i = 0; i < menuDefs.length; i++) {
-            const col = i % cols;
-            const row = Math.floor(i / cols);
-            const x = baseX - col * (sz + gap);
-            const y = baseY - row * (sz + gap);
-            const def = menuDefs[i];
-            const btnWidgets = this._makeMenuButton(x, y, sz, def.label, def.key, def.color);
-            this._menuWidgets.push({ widgets: btnWidgets, unlockKey: def.unlockKey });
+        for (let i = 0; i < fixedDefs.length; i++) {
+            const x = baseX - i * (sz + gap);
+            const y = baseY;
+            const def = fixedDefs[i];
+            this._makeMenuButton(x, y, sz, def.label, def.key, def.color);
         }
+
+        // Context-sensitive button (rightmost position = col 2)
+        const ctxX = baseX - 2 * (sz + gap);
+        const ctxY = baseY;
+        this._createContextButton(ctxX, ctxY, sz);
+    }
+
+    // ── Context-sensitive ÅPNE button ───────────────────────────────────────
+
+    _createContextButton(x, y, sz) {
+        const scene = this.scene;
+        const reg   = this.game.registry;
+        const alpha = 0.35;
+        const pressAlpha = 0.7;
+        const defaultColor = 0x997755;
+
+        const bg = scene.add.graphics();
+        this._drawRoundedBtn(bg, x, y, sz, defaultColor, alpha);
+        bg.setDepth(100);
+
+        const txt = scene.add.text(x, y, 'BOK', {
+            fontSize: '12px', color: '#eeeeff', fontFamily: 'monospace', fontStyle: 'bold'
+        }).setOrigin(0.5).setDepth(101).setAlpha(0.6);
+
+        const zone = scene.add.zone(x, y, sz, sz).setInteractive().setDepth(102);
+
+        zone.on('pointerdown', () => {
+            reg.set('touch_open_context', true);
+            this._drawRoundedBtn(bg, x, y, sz, this._contextBtn.color, pressAlpha);
+            txt.setAlpha(1);
+        });
+
+        const release = () => {
+            this._drawRoundedBtn(bg, x, y, sz, this._contextBtn.color, alpha);
+            txt.setAlpha(0.6);
+        };
+
+        zone.on('pointerup', release);
+        zone.on('pointerout', release);
+
+        this.widgets.push(bg, txt, zone);
+        this._contextBtn = { bg, txt, zone, x, y, sz, color: defaultColor };
+        this._currentContext = 'book';
+    }
+
+    updateContextButton(gameScene) {
+        if (!this._contextBtn) return;
+
+        let context = 'book';
+        if (gameScene._isInCampRoom())     context = 'smeltery';
+        else if (gameScene._isInChemLab()) context = 'chemlab';
+        else if (gameScene._isInAccelerator()) context = 'accelerator';
+
+        if (context === this._currentContext) return;
+        this._currentContext = context;
+
+        const defs = {
+            book:        { label: 'BOK', color: 0x997755 },
+            smeltery:    { label: 'SMI', color: 0xff7722 },
+            chemlab:     { label: 'LAB', color: 0x33dd88 },
+            accelerator: { label: 'ACE', color: 0x8866ff },
+        };
+
+        const def = defs[context];
+        const btn = this._contextBtn;
+        btn.color = def.color;
+        btn.txt.setText(def.label);
+        this._drawRoundedBtn(btn.bg, btn.x, btn.y, btn.sz, def.color, 0.35);
     }
 
     // ── Zoom & fullscreen (top-right) ────────────────────────────────────────
@@ -316,19 +375,6 @@ class TouchControls {
         zone.on('pointerout', release);
 
         this.widgets.push(bg, txt, zone);
-        return [bg, txt, zone];
-    }
-
-    /** Update menu button visibility based on hero unlock flags */
-    updateVisibility(hero) {
-        if (!hero) return;
-        for (const entry of this._menuWidgets) {
-            if (!entry.unlockKey) continue;
-            const visible = !!hero[entry.unlockKey];
-            for (const w of entry.widgets) {
-                w.setVisible(visible);
-            }
-        }
     }
 
     // ── Shared draw helper ───────────────────────────────────────────────────
@@ -348,7 +394,7 @@ class TouchControls {
     destroy() {
         for (const w of this.widgets) w.destroy();
         this.widgets = [];
-        this._menuWidgets = [];
+        this._contextBtn = null;
         // Clean up DOM d-pad
         if (this._domDpad) {
             this._domDpad.remove();


### PR DESCRIPTION
## Summary

- **Victory scene when all 118 elements collected:** Epic celebration with fanfare, sparkle particles, mini periodic table, and "Guds periodiske system" title. Triggers immediately in-game or on world exit
- **New Game+:** Resets element collection but keeps levels/skills/gold. Monsters scale +40%HP / +25%ATK per cycle. NG+ badge shown in HUD and menu
- **Touch controls redesign:** Reduced menu buttons from 6 to 3 (INV, SKL, context-sensitive ÅPNE). ÅPNE changes color/label based on hero location (SMI/LAB/ACE/BOK)
- **4 new monster types** with varied sprites (#124, #125)
- **Accelerator visibility + mineral spread** improvements
- **Smeltery element filter** for easier navigation
- **Partial fuel, craftable tools, backpack expansion, tooltips** (#112, #118, #122, #110, #114)
- **Bug fixes:** Overlay scroll-through (#123), skill tree layout (#115), potion balance (#121), ChemLab filtering (#109), transmutation tab (#111), accelerator spawn (#108, #119), ElementBook layout (#113, #120), missing checkCompletions in transmutation

## Test plan

- [ ] Verify victory scene triggers when all 118 elements are discovered (can use save manipulation)
- [x] Verify NG+ starts at world 1 with reset elements but kept stats, monsters are stronger
- [x] Verify ElementBookScene shows X/118 instead of X/90
- [x] Test touch controls: ÅPNE button changes in camp/lab/accelerator rooms
- [x] Verify minimap toggle via touch works
- [ ] Check save/load compatibility with new fields (ngPlusLevel, victoryAchieved)
- [ ] Verify menu shows golden victory badge for completed saves

https://claude.ai/code/session_01UwsQ5L4AxHdhFvW8s1xxfc

---
_Generated by [Claude Code](https://claude.ai/code/session_01UwsQ5L4AxHdhFvW8s1xxfc)_