### PR TITLE
Add monster behavior variety, XP scaling, fix lanthanide row (#127, #128)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ---
 
+## v0.48 – 2026-04-25
+
+### Nye funksjoner
+- **Mer variasjon mellom monstertyper (#128):** Hver monstertype har nå et eget oppførselsmønster i tillegg til ulike statistikker:
+  - **Goblin (erratisk):** Nøler tilfeldig (~18%) før den angriper – uforutsigbar bevegelse
+  - **Skjelett (bueskytter):** Skyter pil for halv skade når helten er på samme rad/kolonne (avstand 2–4) med fri sikt – angriper uten å bevege seg
+  - **Troll og Golem (treg):** Beveger seg kun annenhver tick – tunge motstandere som spilleren kan kite
+  - **Wraith (fasende):** Beveger seg gjennom vegger – kan ikke sperres inne i labyrintkorridorer
+  - **Demon (brennende):** 30% sjanse for å påføre 3-turns brann ved nærkampangrep
+  - Orker beholder sin gift-sjanse, bosser sine fase-2-mekanikker
+
+### Balanseendringer
+- **Bedre XP-skalering for høyere verdener (#128):** Monster-XP skaleres nå med `1 + 0.30·(verden−1) + 0.20·max(0, verden−8)`. Et monster i verden 25 gir ~11.6× XP sammenlignet med verden 1, slik at ferdighetsopplåsning følger den eksponentielle XP-kurven (`XP_GROWTH = 1.55`)
+- **Bosser skalerer nå XP med verden:** Vanlige bosser fikk tidligere flat 150 XP uavhengig av verden. Både `boss` og `zone_boss` ganges nå også med xpScale
+
+### Feilrettinger
+- **Elementbok: lantanoider plassert for langt fra aktinoider (#127):** Lantanoid-raden satt rett under hovedtabellen mens aktinoid-raden lå betydelig lenger ned. Begge radene er nå gruppert sammen med en liten luft til hovedtabellen, slik en standard periodisk tabell skal være. «Ln»/«An»-etiketter justert tilsvarende
+
+### Tekniske endringer
+- Monster.js: Nye oppførselsflagg `moveCadence`, `canPhase`, `isArcher`, `isErratic`, `burnsOnHit` og `tickCount`. Ny `xpScale`-formel anvendt på alle monstertyper inkludert bosser
+- MonsterManager.js: Tick-loopen respekterer `moveCadence` for trege monstre. `_moveMonster()` har egne grener for goblin-nøling, skjelett-bueskyting og wraith-faseflytting. Nye hjelpere `_hasClearShot()` og `_fireArrow()`
+- CombatManager.js: `monsterAttack()` påfører `applyBurn(3)` ved demonangrep
+- ElementBookScene.js: Lantanoid-/aktinoid-radoffset endret fra `row >= 8` til `row >= 7`, slik at lantanoidene (rad 7) også flyttes ned til 8.5 og aktinoidene (rad 8) til 9.5. «Ln»-etiketten flyttet fra y=9.5 til y=8.5
+
+---
+
 ## v0.47 – 2026-04-25
 
 ### Nye funksjoner

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,6 +1,6 @@
 # Labyrint Hero – Game Design Document
 **Versjon:** 0.47
-**Sist oppdatert:** 2026-04-25
+**Sist oppdatert:** 2026-04-25 (v0.48)
 
 ---
 
@@ -168,15 +168,29 @@ Heltens grunnstats gjør at verden 1 er farlig uten noe utstyr. Utstyr og evner 
 - **Monsterangrep:** `attack + 30% sjanse: +1`
 - **Forsvar:** trekkes fra innkommende skade, minimum 1
 
-### Monstere (v0.35 balanse)
-| Type | Base-HP | Base-ATK | XP | HP-skala | ATK-skala |
-|------|---------|----------|-----|----------|-----------|
-| Goblin | 10 | 2 | 10 | +35% per verden (+15% ekstra etter V8) | +20% per verden (+8% ekstra etter V8) |
-| Orc | 18 | 4 | 25 | +35% per verden (+15% ekstra etter V8) | +20% per verden (+8% ekstra etter V8) |
-| Troll | 30 | 6 | 50 | +35% per verden (+15% ekstra etter V8) | +20% per verden (+8% ekstra etter V8) |
-| Boss | 50 + V×35 | 3 + V×2 | 150 | – (eget uttrykk) | – (570ms tick) |
+### Monstere (v0.48 balanse)
+| Type | Base-HP | Base-ATK | XP | HP-skala | ATK-skala | Spesialoppførsel |
+|------|---------|----------|-----|----------|-----------|------------------|
+| Goblin | 10 | 2 | 10 | +35% per verden (+15% ekstra etter V8) | +20% per verden (+8% ekstra etter V8) | Erratisk: ~18% sjanse for å nøle |
+| Orc | 18 | 4 | 25 | +35% per verden (+15% ekstra etter V8) | +20% per verden (+8% ekstra etter V8) | Gift-bett: 20% gift på treff |
+| Troll | 30 | 6 | 50 | +35% per verden (+15% ekstra etter V8) | +20% per verden (+8% ekstra etter V8) | Treg: handler hver 2. tick · 30% gift |
+| Skjelett | 12 | 5 | 20 | +35%/V (+15% etter V8) | +20%/V (+8% etter V8) | Bueskytter: skyter pil (½ skade) på avstand 2–4 med fri sikt |
+| Golem | 40 | 3 | 60 | +35%/V (+15% etter V8) | +20%/V (+8% etter V8) | Treg: handler hver 2. tick |
+| Wraith | 15 | 6 | 40 | +35%/V (+15% etter V8) | +20%/V (+8% etter V8) | Fasende: kan bevege seg gjennom vegger |
+| Demon | 25 | 7 | 55 | +35%/V (+15% etter V8) | +20%/V (+8% etter V8) | 30% sjanse for å påføre brann (3 runder) på treff |
+| Boss | 50 + V×35 | 3 + V×2 | 150 × xpScale | – (eget uttrykk) | – (570ms tick) | Fase 2 ved ≤50% HP, 15% lamming i fase 2 |
+| Sone-boss | 80 + V×50 | 5 + V×3 | (300 + V×50) × xpScale | – (eget uttrykk) | – | Fase 2 + forsvar V×0.5 |
 
 Helten starter med 3 base-angrep. Verdensnummer V brukes til å skalere både HP og skade. Skalering er mykere tidlig og hardere sent for å bevare utfordringen.
+
+### XP-skalering per verden (v0.48)
+For å holde tritt med den eksponentielle XP-kurven (`XP_BASE = 100`, `XP_GROWTH = 1.55`) skaleres alle monsters XP-belønning etter verden:
+
+```
+xpScale = 1 + 0.30·(V−1) + 0.20·max(0, V−8)
+```
+
+Dette gir ~2.2× i V5, ~4.0× i V10, ~6.8× i V15, ~9.0× i V20 og ~11.6× i V25 — slik at ferdighetsopplåsning føles meningsfull også i sene verdener. Bossens XP skaleres nå også med xpScale (tidligere flat 150 XP uavhengig av verden).
 
 ### Vanskelighetsgrader (v0.35)
 | Innstilling | Monster HP | Monster ATK | XP-bonus | Felle-skade |
@@ -192,7 +206,7 @@ Bevegelse inn i monster-rute: helten setter facing uten å angripe (visuell flas
 | Effekt | Ikon | Varighet | Skade | Kilde | Kur |
 |--------|------|----------|-------|-------|-----|
 | Gift | ☠ | 4 runder | 1/2.5s | Orc (20%), Troll (30%) | Motgift, Krystallresistans |
-| Brann | 🔥 | 3 runder | 2/2.0s | Vulkandungeon-monstre (20%) | Brannsalve, Motgift, Krystallresistans |
+| Brann | 🔥 | 3 runder | 2/2.0s | Vulkandungeon-monstre (20%), Demon (30%) | Brannsalve, Motgift, Krystallresistans |
 | Frostbitt | ❄ | 4 runder | Ingen (halv fart) | Iskrystall-monstre (25%) | Frostsalve, Motgift |
 | Lammet | ⚡ | 1 runde | Ingen (skip turn) | Boss fase 2 (15%) | Venter ut |
 

--- a/src/entities/Monster.js
+++ b/src/entities/Monster.js
@@ -12,29 +12,41 @@ class Monster {
         const worldMul = scene.worldNum || 1;
         const hpScale  = 1 + (worldMul - 1) * 0.35 + Math.max(0, worldMul - 8) * 0.15;
         const atkScale = 1 + (worldMul - 1) * 0.20 + Math.max(0, worldMul - 8) * 0.08;
+        // XP scales steeply so skill unlocks keep up with the exponential XP_GROWTH curve
+        const xpScale  = 1 + (worldMul - 1) * 0.30 + Math.max(0, worldMul - 8) * 0.20;
 
         this.maxHp    = Math.round((MONSTER_BASE_HP[type]  || 4) * hpScale);
         this.hp       = this.maxHp;
         this.attack   = Math.round((MONSTER_ATTACK[type]  || 1) * atkScale);
         this.color    = MONSTER_COLOR[type]   || COLORS.MONSTER;
-        this.xpReward = MONSTER_XP[type]      || 10;
+        this.xpReward = Math.round((MONSTER_XP[type] || 10) * xpScale);
 
         // Bosses scale aggressively – always a significant threat
         if (type === 'boss') {
-            this.maxHp  = 50 + worldMul * 35;
-            this.hp     = this.maxHp;
-            this.attack = 3 + worldMul * 2;
+            this.maxHp    = 50 + worldMul * 35;
+            this.hp       = this.maxHp;
+            this.attack   = 3 + worldMul * 2;
+            this.xpReward = Math.round((MONSTER_XP[type] || 150) * xpScale);
         }
 
         // Zone boss – tougher boss that guards zone transitions
         if (type === 'zone_boss') {
-            this.maxHp  = 80 + worldMul * 50;
-            this.hp     = this.maxHp;
-            this.attack = 5 + worldMul * 3;
-            this.color  = 0xff22ff;
-            this.xpReward = 300 + worldMul * 50;
-            this.defense = Math.floor(worldMul * 0.5);
+            this.maxHp    = 80 + worldMul * 50;
+            this.hp       = this.maxHp;
+            this.attack   = 5 + worldMul * 3;
+            this.color    = 0xff22ff;
+            this.xpReward = Math.round((300 + worldMul * 50) * xpScale);
+            this.defense  = Math.floor(worldMul * 0.5);
         }
+
+        // Behavior tags – give each monster a distinct movement/attack pattern
+        // moveCadence: 1 = every tick, 2 = every other, 3 = every third (heavy/slow)
+        this.moveCadence = (type === 'troll' || type === 'golem') ? 2 : 1;
+        this.canPhase    = (type === 'wraith');                    // moves through walls
+        this.isArcher    = (type === 'skeleton');                  // ranged attack
+        this.isErratic   = (type === 'goblin');                    // sometimes hesitates
+        this.burnsOnHit  = (type === 'demon');                     // applies burn on melee hit
+        this.tickCount   = 0;
 
         // Boss phase tracking (1 = normal, 2 = enraged at ≤50% HP)
         this.phase   = 1;

--- a/src/scenes/ElementBookScene.js
+++ b/src/scenes/ElementBookScene.js
@@ -60,8 +60,8 @@ class ElementBookScene extends Phaser.Scene {
 
         if (typeof PERIODIC_TABLE_LAYOUT === 'undefined') return;
 
-        // Lanthanide/actinide labels
-        const lantY = tableY + 9.5 * cellH;
+        // Lanthanide/actinide labels (grouped just below the main table with a small gap)
+        const lantY = tableY + 8.5 * cellH;
         this.add.text(tableX - 2, lantY, 'Ln', {
             fontSize: '10px', color: '#556644', fontFamily: 'monospace'
         });
@@ -87,10 +87,10 @@ class ElementBookScene extends Phaser.Scene {
 
             const isDiscovered = tracker && tracker.isDiscovered(entry.symbol);
 
-            // Map rows: 0-6 = periods 1-7, 8-9 = lanthanides/actinides
-            // Add a visible gap before rows 8+ to separate them from the main table
+            // Map rows: 0-6 = periods 1-7, 7 = lanthanides, 8 = actinides.
+            // Lanthanides and actinides sit together below the main table with a small gap.
             let yOffset = entry.row;
-            if (entry.row >= 8) yOffset = entry.row + 1.5;
+            if (entry.row >= 7) yOffset = entry.row + 1.5;
 
             const cellX = tableX + entry.col * cellW;
             const cellY = tableY + yOffset * cellH;

--- a/src/systems/CombatManager.js
+++ b/src/systems/CombatManager.js
@@ -414,6 +414,12 @@ class CombatManager {
             }
         }
 
+        // Demon burn chance – fiery melee leaves a lingering burn DoT
+        if (!died && monster.type === 'demon' && Math.random() < 0.30) {
+            scene.hero.applyBurn(3);
+            scene._floatingText(scene.hero.gridX, scene.hero.gridY, '🔥 Brent!', '#ff6600');
+        }
+
         // Theme-based status effects
         if (!died) {
             const deco = scene._theme.DECO;

--- a/src/systems/MonsterManager.js
+++ b/src/systems/MonsterManager.js
@@ -161,6 +161,11 @@ class MonsterManager {
             // Tick monster status effects (acid burn, stun)
             if (m.tickStatusEffects) m.tickStatusEffects();
             if (m.stunTurns > 0) continue; // stunned – skip turn
+            // Heavy/slow monsters (troll, golem) act on every Nth tick
+            if (!isBoss && (m.moveCadence || 1) > 1) {
+                m.tickCount = (m.tickCount || 0) + 1;
+                if (m.tickCount % m.moveCadence !== 0) continue;
+            }
             this._moveMonster(m);
         }
     }
@@ -174,6 +179,17 @@ class MonsterManager {
         if (dist === 1) {
             scene.combat.monsterAttack(m);
             return;
+        }
+
+        // Erratic (goblin) – occasionally hesitates instead of advancing
+        if (m.isErratic && Math.random() < 0.18) return;
+
+        // Skeleton archer – fire an arrow if hero is on the same row/column with clear line
+        if (m.isArcher && (m.gridX === hx || m.gridY === hy) && dist >= 2 && dist <= 4) {
+            if (this._hasClearShot(m.gridX, m.gridY, hx, hy)) {
+                this._fireArrow(m);
+                return;
+            }
         }
 
         // Attack pet if adjacent and can't reach hero
@@ -194,12 +210,38 @@ class MonsterManager {
             const nx = m.gridX + dx, ny = m.gridY + dy;
             if (nx < 0 || nx >= scene.tileW || ny < 0 || ny >= scene.tileH) continue;
             const t = scene.maze[ny][nx];
-            if (t === TILE.WALL || t === TILE.CRACKED_WALL || t === TILE.DOOR) continue;
+            // Wraiths phase through walls; everyone else is blocked
+            if (!m.canPhase && (t === TILE.WALL || t === TILE.CRACKED_WALL || t === TILE.DOOR)) continue;
             if (nx === hx && ny === hy) continue;
             if (this.monsterAt(nx, ny)) continue;
             if (scene.merchant && nx === scene.merchant.gridX && ny === scene.merchant.gridY) continue;
             m.moveTo(nx, ny); break;
         }
+    }
+
+    /** True if the straight line between (x1,y1) and (x2,y2) is unobstructed.
+     *  Assumes same row or same column. */
+    _hasClearShot(x1, y1, x2, y2) {
+        const scene = this.scene;
+        const dx = Math.sign(x2 - x1), dy = Math.sign(y2 - y1);
+        let x = x1 + dx, y = y1 + dy;
+        while (x !== x2 || y !== y2) {
+            const t = scene.maze[y][x];
+            if (t === TILE.WALL || t === TILE.CRACKED_WALL || t === TILE.DOOR) return false;
+            x += dx; y += dy;
+        }
+        return true;
+    }
+
+    _fireArrow(m) {
+        const scene = this.scene;
+        const dmg = Math.max(1, Math.floor(m.attack * 0.5));
+        const died = scene.hero.takeDamage(dmg);
+        if (typeof Audio !== 'undefined' && Audio.playHurt) Audio.playHurt();
+        scene._floatingText(scene.hero.gridX, scene.hero.gridY, `→ -${dmg}`, '#ddccaa');
+        scene.hero._drawSprite();
+        scene.cameras.main.shake(80, 0.004);
+        if (died) scene._heroDied();
     }
 
     monsterAt(gx, gy) {


### PR DESCRIPTION
#127 ElementBookScene: lanthanide row was placed directly under the main
table while actinides sat 1.5 rows below. Both rows now share the same
+1.5 row offset so they group together with a small gap above, matching
the standard periodic-table layout. Ln/An labels follow.

#128 Monster variety:
- Goblin: erratic – 18% chance to hesitate
- Skeleton: archer – fires arrow for half-attack damage when hero is on
  the same row/column at distance 2-4 with clear line of sight
- Troll & Golem: heavy/slow – move every other tick
- Wraith: phaser – moves through walls
- Demon: 30% chance to apply 3-turn burn on melee hit

#128 XP scaling: monster XP now scales with worldNum using
1 + 0.30*(V-1) + 0.20*max(0, V-8). Yields ~11.6x XP at world 25 vs
world 1 so skill unlocks keep up with the exponential XP_GROWTH curve.
Boss XP also scales now (was flat 150 regardless of world).