### PR TITLE
Add intro popup, mineral wiki, and updated welcome screen

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ---
 
+## v0.49 – 2026-04-28
+
+### Nye funksjoner
+- **Utvidet velkomstskjerm:** Hovedmenyen viser nå et info-panel med tre faner – `BAKGRUNN` (spillets premiss og soner), `MÅL` (boss-progresjon og 118-grunnstoffsamling) og `SLIK SPILLER DU` (kontroller og kjernemekanikk) – slik at nye spillere får en kort introduksjon før eventyret starter
+- **Mineral-wiki:** Ny scene `MineralWikiScene` som lister alle 60+ mineraler og krystaller med formel, tier, hvilke grunnstoffer de gir og hvor de spawner. Faner for `ALLE` / `T1`–`T6` / `KRYSTALLER` og en `MANGLENDE`-fane som viser hvilke grunnstoffer helten ennå ikke har oppdaget – og hvilke mineraler som er kjente kilder. Tilgjengelig fra ny `[ MINERAL-WIKI ]`-knapp i hovedmenyen og som overlay-knapp i inventaret
+
+### Tekniske endringer
+- MenuScene.js: Nye metoder `_buildLorePanel()` og `_selectInfoTab()`. `[ LEDERTAVLE ]`-knappen flyttes til venstre og deler rad med ny `[ MINERAL-WIKI ]`-knapp
+- MineralWikiScene.js: Ny scene som leser `MINERAL_DEFS`, `MINERAL_TIER_COLORS` og `ELEMENTS` direkte. Spawn-lokasjoner avledes ved å transkribere reglene fra `ItemSpawner.js` i en lokal `_getMineralLocations()` – ingen endringer i mineraldata kreves
+- InventoryScene.js: Ny `Mineral-wiki`-knapp ved siden av `Elementbok [B]`
+- main.js + index.html: Registrerer `MineralWikiScene`
+
+---
+
 ## v0.48 – 2026-04-25
 
 ### Nye funksjoner

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,14 +5,16 @@
 ## v0.49 – 2026-04-28
 
 ### Nye funksjoner
-- **Utvidet velkomstskjerm:** Hovedmenyen viser nå et info-panel med tre faner – `BAKGRUNN` (spillets premiss og soner), `MÅL` (boss-progresjon og 118-grunnstoffsamling) og `SLIK SPILLER DU` (kontroller og kjernemekanikk) – slik at nye spillere får en kort introduksjon før eventyret starter
+- **Velkomst-popup ved første besøk:** Ny `WelcomeScene` åpnes automatisk første gang en spiller besøker hovedmenyen, og kan gjenåpnes med `[ INTRO ]`-knappen. Popup-en har fire stemnings­ladde sider — `LABYRINT HERO` (premiss og atmosfære), `HELTEN` (raser, startbonuser og ferdighetstre), `LABYRINTEN` (verdens­struktur, spesialrom og smelter/lab/akselerator) og `SLIK SPILLER DU` (detaljerte kontroller og spilltips). Lukkes med `[ START EVENTYRET ]`, `[×]`, ESC, eller ved klikk utenfor panelet — og «sett»-tilstanden lagres i `localStorage` slik at popup-en ikke dukker opp igjen automatisk
 - **Mineral-wiki:** Ny scene `MineralWikiScene` som lister alle 60+ mineraler og krystaller med formel, tier, hvilke grunnstoffer de gir og hvor de spawner. Faner for `ALLE` / `T1`–`T6` / `KRYSTALLER` og en `MANGLENDE`-fane som viser hvilke grunnstoffer helten ennå ikke har oppdaget – og hvilke mineraler som er kjente kilder. Tilgjengelig fra ny `[ MINERAL-WIKI ]`-knapp i hovedmenyen og som overlay-knapp i inventaret
 
 ### Tekniske endringer
-- MenuScene.js: Nye metoder `_buildLorePanel()` og `_selectInfoTab()`. `[ LEDERTAVLE ]`-knappen flyttes til venstre og deler rad med ny `[ MINERAL-WIKI ]`-knapp
+- WelcomeScene.js: Ny scene med `_pages`-array og `_renderPage()`-løkke. Naviger med Pil/SPACE/Klikk; ESC eller klikk utenfor lukker. Skip-hint vises kun ved første-gangs auto-åpning
+- SaveManager.js: Nye metoder `hasSeenIntro()` og `markIntroSeen()` (separat `INTRO_KEY` slik at intro-flagget overlever `clear()`)
+- MenuScene.js: Fjernet det gamle innebygde info-panelet. Auto-launcher `WelcomeScene` når `!SaveManager.hasSeenIntro()`. Bunnknapp-raden utvidet til tre: `[ INTRO ]` / `[ LEDERTAVLE ]` / `[ MINERAL-WIKI ]`
 - MineralWikiScene.js: Ny scene som leser `MINERAL_DEFS`, `MINERAL_TIER_COLORS` og `ELEMENTS` direkte. Spawn-lokasjoner avledes ved å transkribere reglene fra `ItemSpawner.js` i en lokal `_getMineralLocations()` – ingen endringer i mineraldata kreves
 - InventoryScene.js: Ny `Mineral-wiki`-knapp ved siden av `Elementbok [B]`
-- main.js + index.html: Registrerer `MineralWikiScene`
+- main.js + index.html: Registrerer `WelcomeScene` og `MineralWikiScene`
 
 ---
 

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -24,7 +24,8 @@ Et top-down 2D labyrint-RPG i nettleser. Spilleren navigerer en prosedyre-genere
 - **Lyd:** Web Audio API – prosedyremusikk og SFX, ingen lydfiler
 - **Lagring:** localStorage via SaveManager
 - **Multi-scene pattern:** GameScene + UIScene parallelt; SkillScene, InventoryScene og SettingsScene som overlays. UIScene har HUD-knapper for Elementbok, Skilltre og Inventar øverst til høyre
-- **Velkomstskjerm (MenuScene, v0.49):** Hovedmenyen viser et info-panel til venstre med tre faner – `BAKGRUNN`, `MÅL` og `SLIK SPILLER DU` – pluss vanskelighetsvalg, fortsett/nytt spill og knapper for `[ LEDERTAVLE ]` og `[ MINERAL-WIKI ]`
+- **Velkomstskjerm (MenuScene, v0.49):** Ren meny med tittel, vanskelighetsvalg, fortsett/nytt spill, og bunnrad med `[ INTRO ]` / `[ LEDERTAVLE ]` / `[ MINERAL-WIKI ]`. Den utfyllende introduksjonen ligger i en egen popup (`WelcomeScene`)
+- **Velkomst-popup (WelcomeScene, v0.49):** Fire-siders popup som åpnes automatisk første gang en spiller besøker menyen, og kan gjenåpnes via `[ INTRO ]`. Sider: `LABYRINT HERO` (lore/atmosfære), `HELTEN` (rasevalg, startbonuser, ferdighetstre), `LABYRINTEN` (verdens­struktur, spesialrom, smelter/lab/akselerator), `SLIK SPILLER DU` (kontroller og tips). Skip via klikk-utenfor / ESC / `[×]`. «Sett»-flagg lagres i `localStorage` med egen nøkkel slik at det overlever `SaveManager.clear()`
 - **Mineral-wiki (MineralWikiScene, v0.49):** Browseable katalog over alle mineraler/krystaller med formel, tier, yields og spawn-lokasjoner. `MANGLENDE`-fanen kobler udekkede grunnstoffer til mineraler som inneholder dem. Tilgjengelig fra menyen og fra inventarscenen
 
 ### Filstruktur

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,6 +1,6 @@
 # Labyrint Hero – Game Design Document
-**Versjon:** 0.47
-**Sist oppdatert:** 2026-04-25 (v0.48)
+**Versjon:** 0.49
+**Sist oppdatert:** 2026-04-28 (v0.49)
 
 ---
 
@@ -24,6 +24,8 @@ Et top-down 2D labyrint-RPG i nettleser. Spilleren navigerer en prosedyre-genere
 - **Lyd:** Web Audio API – prosedyremusikk og SFX, ingen lydfiler
 - **Lagring:** localStorage via SaveManager
 - **Multi-scene pattern:** GameScene + UIScene parallelt; SkillScene, InventoryScene og SettingsScene som overlays. UIScene har HUD-knapper for Elementbok, Skilltre og Inventar øverst til høyre
+- **Velkomstskjerm (MenuScene, v0.49):** Hovedmenyen viser et info-panel til venstre med tre faner – `BAKGRUNN`, `MÅL` og `SLIK SPILLER DU` – pluss vanskelighetsvalg, fortsett/nytt spill og knapper for `[ LEDERTAVLE ]` og `[ MINERAL-WIKI ]`
+- **Mineral-wiki (MineralWikiScene, v0.49):** Browseable katalog over alle mineraler/krystaller med formel, tier, yields og spawn-lokasjoner. `MANGLENDE`-fanen kobler udekkede grunnstoffer til mineraler som inneholder dem. Tilgjengelig fra menyen og fra inventarscenen
 
 ### Filstruktur
 ```

--- a/index.html
+++ b/index.html
@@ -79,6 +79,7 @@
 <script src="src/scenes/GameOverScene.js"></script>
 <script src="src/scenes/SettingsScene.js"></script>
 <script src="src/scenes/ElementBookScene.js"></script>
+<script src="src/scenes/MineralWikiScene.js"></script>
 <script src="src/scenes/SmelteryScene.js"></script>
 <script src="src/scenes/ChemLabScene.js"></script>
 <script src="src/scenes/AcceleratorScene.js"></script>

--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
 
 <!-- Scenes -->
 <script src="src/scenes/MenuScene.js"></script>
+<script src="src/scenes/WelcomeScene.js"></script>
 <script src="src/scenes/CharacterCreatorScene.js"></script>
 <script src="src/scenes/GameScene.js"></script>
 <script src="src/scenes/UIScene.js"></script>

--- a/src/main.js
+++ b/src/main.js
@@ -25,6 +25,7 @@ const config = {
         GameOverScene,
         SettingsScene,
         ElementBookScene,
+        MineralWikiScene,
         SmelteryScene,
         ChemLabScene,
         AcceleratorScene

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,7 @@ const config = {
     },
     scene: [
         MenuScene,
+        WelcomeScene,
         CharacterCreatorScene,
         GameScene,
         UIScene,

--- a/src/scenes/InventoryScene.js
+++ b/src/scenes/InventoryScene.js
@@ -70,6 +70,18 @@ class InventoryScene extends Phaser.Scene {
             }
         });
 
+        // Mineral wiki button
+        const mwBtn = this.add.text(cx - panelW / 2 + 20 + ebBtn.width + 16,
+            cy - panelH / 2 + 18, 'Mineral-wiki', {
+            fontSize: '12px', color: '#997755', fontFamily: 'monospace'
+        }).setOrigin(0, 0.5).setInteractive({ useHandCursor: true });
+        mwBtn.on('pointerover', () => mwBtn.setColor('#ccaa77'));
+        mwBtn.on('pointerout',  () => mwBtn.setColor('#997755'));
+        mwBtn.on('pointerdown', () => {
+            const gs = this.scene.get('GameScene');
+            this.scene.launch('MineralWikiScene', { heroRef: gs?.hero || null });
+        });
+
         // Close button (touch-friendly)
         const closeBtn = this.add.text(cx + panelW / 2 - 20, cy - panelH / 2 + 18, '✕', {
             fontSize: '20px', color: '#667788', fontFamily: 'monospace'

--- a/src/scenes/MenuScene.js
+++ b/src/scenes/MenuScene.js
@@ -40,6 +40,9 @@ class MenuScene extends Phaser.Scene {
 
         this.add.rectangle(cx, cy - 67, 320, 1, 0x333355);
 
+        // ── Lore / tutorial info panel (left side) ────────────────────────────
+        this._buildLorePanel(190, cy + 30);
+
         // ── Difficulty selector (main menu – prominent) ────────────────────────
         this._buildDifficultyPanel(cx, cy);
 
@@ -82,9 +85,14 @@ class MenuScene extends Phaser.Scene {
             this.tweens.add({ targets: start, alpha: 0.45, duration: 750, yoyo: true, repeat: -1 });
         }
 
-        // ── Leaderboard button ────────────────────────────────────────────────
-        const lbBtn = this._btn(cx, cy + 175, '[ LEDERTAVLE ]', '#8899bb', 14);
+        // ── Leaderboard + Mineral-wiki buttons ────────────────────────────────
+        const lbBtn = this._btn(cx - 90, cy + 175, '[ LEDERTAVLE ]', '#8899bb', 14);
         lbBtn.on('pointerdown', () => this.scene.start('LeaderboardScene'));
+
+        const wikiBtn = this._btn(cx + 90, cy + 175, '[ MINERAL-WIKI ]', '#ccaa77', 14);
+        wikiBtn.on('pointerdown', () =>
+            this.scene.start('MineralWikiScene', { fromMenu: true })
+        );
 
         // ── Footer tips ───────────────────────────────────────────────────────
         const ts = { fontSize: '13px', color: '#445566', fontFamily: 'monospace' };
@@ -93,6 +101,95 @@ class MenuScene extends Phaser.Scene {
 
         // Version
         this.add.text(8, H - 16, 'v0.9', { fontSize: '12px', color: '#222244', fontFamily: 'monospace' });
+    }
+
+    // ── Lore / tutorial panel ─────────────────────────────────────────────────
+
+    _buildLorePanel(panelX, panelY) {
+        const panelW = 360, panelH = 340;
+
+        this.add.rectangle(panelX, panelY, panelW, panelH, 0x110f22, 0.7)
+            .setStrokeStyle(1, 0x2a1a4a);
+
+        // Header
+        this.add.text(panelX, panelY - panelH / 2 + 14, 'INFO', {
+            fontSize: '12px', color: '#997755', fontFamily: 'monospace', fontStyle: 'bold'
+        }).setOrigin(0.5);
+        this.add.rectangle(panelX, panelY - panelH / 2 + 26, panelW - 30, 1, 0x2a1a4a);
+
+        // Tab definitions
+        const TABS = [
+            { id: 'bakgrunn', label: 'BAKGRUNN' },
+            { id: 'mal',      label: 'MÅL' },
+            { id: 'tutorial', label: 'SLIK SPILLER DU' },
+        ];
+        const INFO_TABS = {
+            bakgrunn:
+                'Du er en geolog-helt sendt ned i de eldgamle labyrintene under verden.\n\n' +
+                'Fem geologiske soner — skog, grunnfjell, dyplag, underverden og kjernen — ' +
+                'skjuler 25 verdener fulle av monstre, feller og mineraler.\n\n' +
+                'Hver bergart inneholder ett eller flere av de 118 grunnstoffene fra det ' +
+                'periodiske system.',
+            mal:
+                'Mål:\n\n' +
+                '• Beseir bossen i hver verden for å gå videre.\n' +
+                '• Beseir sone-bossene for å låse opp Smelter, Kjemilab og Akselerator.\n' +
+                '• Samle, smelt og syntetiser alle 118 grunnstoffene.\n\n' +
+                'Endelig prestasjon: «Guds periodiske system» — samle alle 118.',
+            tutorial:
+                'WASD / Piltaster : Beveg\n' +
+                'SPACE / F        : Angrep\n' +
+                'R                : Skyt pil\n' +
+                'E                : Inventar (åpner mineral-wiki)\n' +
+                'M                : Kart\n' +
+                'B                : Elementbok\n' +
+                'T                : Ferdighetstre\n\n' +
+                'Plukk opp mineraler ved å gå over dem. Lær Geolog-skill for å ' +
+                'identifisere dem. Leir-rom (telt-ikon) lar deg smelte og hvile.',
+        };
+
+        // Tab buttons
+        const tabH = 22, tabGap = 4;
+        const tabW = (panelW - 30 - tabGap * (TABS.length - 1)) / TABS.length;
+        const tabY = panelY - panelH / 2 + 46;
+        this._infoTabs = {};
+        TABS.forEach(({ id, label }, i) => {
+            const tx = panelX - panelW / 2 + 15 + i * (tabW + tabGap) + tabW / 2;
+            const bg = this.add.rectangle(tx, tabY, tabW, tabH, 0x111122)
+                .setStrokeStyle(1, 0x334466)
+                .setInteractive({ useHandCursor: true });
+            const txt = this.add.text(tx, tabY, label, {
+                fontSize: '10px', color: '#aaaacc', fontFamily: 'monospace', fontStyle: 'bold'
+            }).setOrigin(0.5);
+            bg.on('pointerdown', () => this._selectInfoTab(id));
+            bg.on('pointerover', () => { if (this._activeInfoTab !== id) bg.setFillStyle(0x1a1a33); });
+            bg.on('pointerout',  () => { if (this._activeInfoTab !== id) bg.setFillStyle(0x111122); });
+            this._infoTabs[id] = { bg, txt };
+        });
+
+        // Body text
+        this._infoBody = this.add.text(
+            panelX - panelW / 2 + 15,
+            tabY + tabH / 2 + 12,
+            '',
+            {
+                fontSize: '12px', color: '#bbaa99', fontFamily: 'monospace',
+                wordWrap: { width: panelW - 30 }, lineSpacing: 2
+            }
+        );
+        this._infoTabContent = INFO_TABS;
+        this._selectInfoTab('bakgrunn');
+    }
+
+    _selectInfoTab(id) {
+        this._activeInfoTab = id;
+        for (const [tid, { bg, txt }] of Object.entries(this._infoTabs)) {
+            const sel = tid === id;
+            bg.setFillStyle(sel ? 0x2a1a4a : 0x111122);
+            bg.setStrokeStyle(sel ? 2 : 1, sel ? 0xccaa77 : 0x334466);
+            txt.setColor(sel ? '#ccaa77' : '#778899');
+        }
+        this._infoBody?.setText(this._infoTabContent[id] || '');
     }
 
     // ── Difficulty panel ──────────────────────────────────────────────────────

--- a/src/scenes/MenuScene.js
+++ b/src/scenes/MenuScene.js
@@ -40,9 +40,6 @@ class MenuScene extends Phaser.Scene {
 
         this.add.rectangle(cx, cy - 67, 320, 1, 0x333355);
 
-        // ── Lore / tutorial info panel (left side) ────────────────────────────
-        this._buildLorePanel(190, cy + 30);
-
         // ── Difficulty selector (main menu – prominent) ────────────────────────
         this._buildDifficultyPanel(cx, cy);
 
@@ -85,11 +82,14 @@ class MenuScene extends Phaser.Scene {
             this.tweens.add({ targets: start, alpha: 0.45, duration: 750, yoyo: true, repeat: -1 });
         }
 
-        // ── Leaderboard + Mineral-wiki buttons ────────────────────────────────
-        const lbBtn = this._btn(cx - 90, cy + 175, '[ LEDERTAVLE ]', '#8899bb', 14);
+        // ── Bottom navigation row: Intro / Ledertavle / Mineral-wiki ──────────
+        const introBtn = this._btn(cx - 180, cy + 175, '[ INTRO ]', '#f5e642', 14);
+        introBtn.on('pointerdown', () => this.scene.launch('WelcomeScene'));
+
+        const lbBtn = this._btn(cx, cy + 175, '[ LEDERTAVLE ]', '#8899bb', 14);
         lbBtn.on('pointerdown', () => this.scene.start('LeaderboardScene'));
 
-        const wikiBtn = this._btn(cx + 90, cy + 175, '[ MINERAL-WIKI ]', '#ccaa77', 14);
+        const wikiBtn = this._btn(cx + 180, cy + 175, '[ MINERAL-WIKI ]', '#ccaa77', 14);
         wikiBtn.on('pointerdown', () =>
             this.scene.start('MineralWikiScene', { fromMenu: true })
         );
@@ -101,95 +101,11 @@ class MenuScene extends Phaser.Scene {
 
         // Version
         this.add.text(8, H - 16, 'v0.9', { fontSize: '12px', color: '#222244', fontFamily: 'monospace' });
-    }
 
-    // ── Lore / tutorial panel ─────────────────────────────────────────────────
-
-    _buildLorePanel(panelX, panelY) {
-        const panelW = 360, panelH = 340;
-
-        this.add.rectangle(panelX, panelY, panelW, panelH, 0x110f22, 0.7)
-            .setStrokeStyle(1, 0x2a1a4a);
-
-        // Header
-        this.add.text(panelX, panelY - panelH / 2 + 14, 'INFO', {
-            fontSize: '12px', color: '#997755', fontFamily: 'monospace', fontStyle: 'bold'
-        }).setOrigin(0.5);
-        this.add.rectangle(panelX, panelY - panelH / 2 + 26, panelW - 30, 1, 0x2a1a4a);
-
-        // Tab definitions
-        const TABS = [
-            { id: 'bakgrunn', label: 'BAKGRUNN' },
-            { id: 'mal',      label: 'MÅL' },
-            { id: 'tutorial', label: 'SLIK SPILLER DU' },
-        ];
-        const INFO_TABS = {
-            bakgrunn:
-                'Du er en geolog-helt sendt ned i de eldgamle labyrintene under verden.\n\n' +
-                'Fem geologiske soner — skog, grunnfjell, dyplag, underverden og kjernen — ' +
-                'skjuler 25 verdener fulle av monstre, feller og mineraler.\n\n' +
-                'Hver bergart inneholder ett eller flere av de 118 grunnstoffene fra det ' +
-                'periodiske system.',
-            mal:
-                'Mål:\n\n' +
-                '• Beseir bossen i hver verden for å gå videre.\n' +
-                '• Beseir sone-bossene for å låse opp Smelter, Kjemilab og Akselerator.\n' +
-                '• Samle, smelt og syntetiser alle 118 grunnstoffene.\n\n' +
-                'Endelig prestasjon: «Guds periodiske system» — samle alle 118.',
-            tutorial:
-                'WASD / Piltaster : Beveg\n' +
-                'SPACE / F        : Angrep\n' +
-                'R                : Skyt pil\n' +
-                'E                : Inventar (åpner mineral-wiki)\n' +
-                'M                : Kart\n' +
-                'B                : Elementbok\n' +
-                'T                : Ferdighetstre\n\n' +
-                'Plukk opp mineraler ved å gå over dem. Lær Geolog-skill for å ' +
-                'identifisere dem. Leir-rom (telt-ikon) lar deg smelte og hvile.',
-        };
-
-        // Tab buttons
-        const tabH = 22, tabGap = 4;
-        const tabW = (panelW - 30 - tabGap * (TABS.length - 1)) / TABS.length;
-        const tabY = panelY - panelH / 2 + 46;
-        this._infoTabs = {};
-        TABS.forEach(({ id, label }, i) => {
-            const tx = panelX - panelW / 2 + 15 + i * (tabW + tabGap) + tabW / 2;
-            const bg = this.add.rectangle(tx, tabY, tabW, tabH, 0x111122)
-                .setStrokeStyle(1, 0x334466)
-                .setInteractive({ useHandCursor: true });
-            const txt = this.add.text(tx, tabY, label, {
-                fontSize: '10px', color: '#aaaacc', fontFamily: 'monospace', fontStyle: 'bold'
-            }).setOrigin(0.5);
-            bg.on('pointerdown', () => this._selectInfoTab(id));
-            bg.on('pointerover', () => { if (this._activeInfoTab !== id) bg.setFillStyle(0x1a1a33); });
-            bg.on('pointerout',  () => { if (this._activeInfoTab !== id) bg.setFillStyle(0x111122); });
-            this._infoTabs[id] = { bg, txt };
-        });
-
-        // Body text
-        this._infoBody = this.add.text(
-            panelX - panelW / 2 + 15,
-            tabY + tabH / 2 + 12,
-            '',
-            {
-                fontSize: '12px', color: '#bbaa99', fontFamily: 'monospace',
-                wordWrap: { width: panelW - 30 }, lineSpacing: 2
-            }
-        );
-        this._infoTabContent = INFO_TABS;
-        this._selectInfoTab('bakgrunn');
-    }
-
-    _selectInfoTab(id) {
-        this._activeInfoTab = id;
-        for (const [tid, { bg, txt }] of Object.entries(this._infoTabs)) {
-            const sel = tid === id;
-            bg.setFillStyle(sel ? 0x2a1a4a : 0x111122);
-            bg.setStrokeStyle(sel ? 2 : 1, sel ? 0xccaa77 : 0x334466);
-            txt.setColor(sel ? '#ccaa77' : '#778899');
+        // ── Auto-show intro on first visit ────────────────────────────────────
+        if (!SaveManager.hasSeenIntro()) {
+            this.scene.launch('WelcomeScene');
         }
-        this._infoBody?.setText(this._infoTabContent[id] || '');
     }
 
     // ── Difficulty panel ──────────────────────────────────────────────────────

--- a/src/scenes/MineralWikiScene.js
+++ b/src/scenes/MineralWikiScene.js
@@ -1,0 +1,442 @@
+// ─── Labyrint Hero – Mineral Wiki ────────────────────────────────────────────
+// Browseable codex of all minerals + crystals with yields and spawn locations.
+// Opens from MenuScene (fromMenu: true → scene.start) or from InventoryScene
+// (scene.launch overlay, with optional heroRef for the MANGLENDE tab).
+
+class MineralWikiScene extends Phaser.Scene {
+    constructor() { super({ key: 'MineralWikiScene' }); }
+
+    init(data) {
+        this.heroRef  = data?.heroRef || null;
+        this.fromMenu = !!data?.fromMenu;
+    }
+
+    create() {
+        const { width: W, height: H } = this.cameras.main;
+        const cx = W / 2, cy = H / 2;
+
+        // ── Dim overlay ───────────────────────────────────────────────────────
+        this.add.rectangle(cx, cy, W, H, 0x000000, this.fromMenu ? 0.95 : 0.82)
+            .setInteractive();
+
+        // ── Panel ─────────────────────────────────────────────────────────────
+        const panelW = Math.min(W - 10, 940);
+        const panelH = Math.min(H - 10, 720);
+        const px = cx - panelW / 2;
+        const py = cy - panelH / 2;
+
+        const panel = this.add.graphics();
+        panel.fillStyle(0x080618, 0.97);
+        panel.fillRoundedRect(px, py, panelW, panelH, 8);
+        panel.lineStyle(2, 0x997755);
+        panel.strokeRoundedRect(px, py, panelW, panelH, 8);
+
+        // Title
+        this.add.text(cx, py + 18, 'MINERAL-WIKI  –  Geologens lommebok', {
+            fontSize: '14px', color: '#997755', fontFamily: 'monospace', fontStyle: 'bold',
+            stroke: '#4a3a22', strokeThickness: 1
+        }).setOrigin(0.5);
+
+        const totalMinerals = (typeof MINERAL_DEFS !== 'undefined') ? Object.keys(MINERAL_DEFS).length : 0;
+        const totalElements = (typeof TOTAL_ALL_ELEMENTS !== 'undefined') ? TOTAL_ALL_ELEMENTS
+                             : (typeof ELEMENTS !== 'undefined' ? Object.keys(ELEMENTS).length : 0);
+        const tracker = this.heroRef?.elementTracker || null;
+        const subStr = tracker
+            ? `${totalMinerals} mineraler  ·  Oppdaget ${tracker.discoveredCount}/${totalElements} grunnstoffer`
+            : `${totalMinerals} mineraler  ·  ${totalElements} grunnstoffer å samle`;
+        this.add.text(cx, py + 36, subStr, {
+            fontSize: '12px', color: '#887766', fontFamily: 'monospace'
+        }).setOrigin(0.5);
+
+        this.add.rectangle(cx, py + 50, panelW - 30, 1, 0x3a2a18);
+
+        // Close button (X)
+        const closeBtn = this.add.text(px + panelW - 22, py + 14, '✕', {
+            fontSize: '18px', color: '#887766', fontFamily: 'monospace'
+        }).setOrigin(0.5).setInteractive({ useHandCursor: true });
+        closeBtn.on('pointerover', () => closeBtn.setColor('#ff8866'));
+        closeBtn.on('pointerout',  () => closeBtn.setColor('#887766'));
+        closeBtn.on('pointerdown', () => this._close());
+
+        // ── Tabs ──────────────────────────────────────────────────────────────
+        const TABS = [
+            { id: 'all', label: 'ALLE' },
+            { id: 't1',  label: 'T1' },
+            { id: 't2',  label: 'T2' },
+            { id: 't3',  label: 'T3' },
+            { id: 't4',  label: 'T4' },
+            { id: 't5',  label: 'T5' },
+            { id: 't6',  label: 'T6' },
+            { id: 'crystals', label: 'KRYSTALLER' },
+            { id: 'missing',  label: 'MANGLENDE' },
+        ];
+
+        const tabH = 24;
+        const tabY = py + 70;
+        let tabX = px + 18;
+        this._tabs = {};
+        TABS.forEach(({ id, label }) => {
+            const w = label.length * 8 + 14;
+            const bg = this.add.rectangle(tabX + w / 2, tabY, w, tabH, 0x111122)
+                .setStrokeStyle(1, 0x334466)
+                .setInteractive({ useHandCursor: true });
+            const txt = this.add.text(tabX + w / 2, tabY, label, {
+                fontSize: '11px', color: '#aaaacc', fontFamily: 'monospace', fontStyle: 'bold'
+            }).setOrigin(0.5);
+            bg.on('pointerdown', () => this._selectTab(id));
+            bg.on('pointerover', () => { if (this._activeTab !== id) bg.setFillStyle(0x1a1a33); });
+            bg.on('pointerout',  () => { if (this._activeTab !== id) bg.setFillStyle(0x111122); });
+            this._tabs[id] = { bg, txt };
+            tabX += w + 4;
+        });
+
+        // ── Scrollable list area ──────────────────────────────────────────────
+        this._listArea = {
+            x: px + 18,
+            y: py + 92,
+            w: panelW - 36,
+            h: panelH - 92 - 50, // leave room for back button row
+        };
+        this._listContainer = this.add.container(this._listArea.x, this._listArea.y);
+
+        // Mask so list content doesn't bleed past panel
+        const maskShape = this.make.graphics({ x: 0, y: 0, add: false });
+        maskShape.fillStyle(0xffffff);
+        maskShape.fillRect(this._listArea.x, this._listArea.y, this._listArea.w, this._listArea.h);
+        this._listContainer.setMask(maskShape.createGeometryMask());
+
+        // Drag-scroll on list area
+        this._scrollY = 0;
+        this._contentH = 0;
+        const scrollHit = this.add.rectangle(
+            this._listArea.x + this._listArea.w / 2,
+            this._listArea.y + this._listArea.h / 2,
+            this._listArea.w, this._listArea.h, 0x000000, 0.001
+        ).setInteractive({ useHandCursor: false });
+        let dragging = false, dragStartY = 0, dragStartScroll = 0;
+        scrollHit.on('pointerdown', (p) => {
+            dragging = true;
+            dragStartY = p.y;
+            dragStartScroll = this._scrollY;
+        });
+        scrollHit.on('pointermove', (p) => {
+            if (!dragging) return;
+            this._setScroll(dragStartScroll + (p.y - dragStartY));
+        });
+        scrollHit.on('pointerup',   () => { dragging = false; });
+        scrollHit.on('pointerout',  () => { dragging = false; });
+
+        // Mouse wheel
+        this.input.on('wheel', (_pointer, _objs, _dx, dy) => {
+            this._setScroll(this._scrollY - dy);
+        });
+
+        // ── Footer: back button + hint ────────────────────────────────────────
+        const backBtn = this.add.text(px + 24, py + panelH - 24,
+            this.fromMenu ? '[ TILBAKE ]' : '[ LUKK ]', {
+            fontSize: '14px', color: '#ccaa77', fontFamily: 'monospace'
+        }).setOrigin(0, 0.5).setInteractive({ useHandCursor: true });
+        backBtn.on('pointerover', () => backBtn.setColor('#eecc99'));
+        backBtn.on('pointerout',  () => backBtn.setColor('#ccaa77'));
+        backBtn.on('pointerdown', () => this._close());
+
+        this.add.text(px + panelW - 24, py + panelH - 24, 'ESC: lukk  ·  Hjul/dra: scroll', {
+            fontSize: '11px', color: '#556677', fontFamily: 'monospace'
+        }).setOrigin(1, 0.5);
+
+        // ESC handler
+        this.input.keyboard.on('keydown-ESC', () => this._close());
+
+        // ── Initial tab ───────────────────────────────────────────────────────
+        this._selectTab('all');
+    }
+
+    // ── Scrolling ─────────────────────────────────────────────────────────────
+
+    _setScroll(value) {
+        const minY = Math.min(0, this._listArea.h - this._contentH);
+        this._scrollY = Phaser.Math.Clamp(value, minY, 0);
+        this._listContainer.y = this._listArea.y + this._scrollY;
+    }
+
+    // ── Tab handling ──────────────────────────────────────────────────────────
+
+    _selectTab(id) {
+        this._activeTab = id;
+        for (const [tid, { bg, txt }] of Object.entries(this._tabs)) {
+            const sel = tid === id;
+            bg.setFillStyle(sel ? 0x2a1a4a : 0x111122);
+            bg.setStrokeStyle(sel ? 2 : 1, sel ? 0xccaa77 : 0x334466);
+            txt.setColor(sel ? '#ccaa77' : '#778899');
+        }
+        this._rebuildList(id);
+    }
+
+    _rebuildList(tabId) {
+        this._listContainer.removeAll(true);
+        this._scrollY = 0;
+        this._listContainer.y = this._listArea.y;
+
+        if (tabId === 'missing') {
+            this._buildMissingList();
+        } else {
+            this._buildMineralList(tabId);
+        }
+    }
+
+    // ── Mineral list (ALLE / T1-T6 / KRYSTALLER) ──────────────────────────────
+
+    _buildMineralList(tabId) {
+        if (typeof MINERAL_DEFS === 'undefined') return;
+
+        // Collect mineral defs to display
+        let defs = Object.values(MINERAL_DEFS);
+        if (tabId === 'crystals')          defs = defs.filter(d => d.subtype === 'crystal');
+        else if (tabId.startsWith('t'))    defs = defs.filter(d => d.tier === parseInt(tabId.slice(1), 10));
+        // 'all' shows everything
+
+        // Sort: tier asc, then subtype (ore before crystal), then name
+        defs.sort((a, b) => (a.tier - b.tier) || a.name.localeCompare(b.name, 'no'));
+
+        if (defs.length === 0) {
+            const empty = this.add.text(0, 0, 'Ingen mineraler i denne kategorien.', {
+                fontSize: '13px', color: '#556677', fontFamily: 'monospace'
+            });
+            this._listContainer.add(empty);
+            this._contentH = 30;
+            return;
+        }
+
+        const rowH = 78;
+        defs.forEach((def, idx) => {
+            const rowY = idx * rowH;
+            this._buildMineralRow(def, rowY);
+        });
+        this._contentH = defs.length * rowH;
+    }
+
+    _buildMineralRow(def, rowY) {
+        const w = this._listArea.w;
+        const cont = this._listContainer;
+
+        // Row separator
+        if (rowY > 0) {
+            const sep = this.add.rectangle(w / 2, rowY - 2, w - 8, 1, 0x2a2018);
+            cont.add(sep);
+        }
+
+        // Color swatch (filled circle)
+        const swatch = this.add.graphics();
+        swatch.fillStyle(def.color, 1);
+        swatch.fillCircle(14, rowY + 16, 8);
+        swatch.lineStyle(1, 0x000000, 0.5);
+        swatch.strokeCircle(14, rowY + 16, 8);
+        cont.add(swatch);
+
+        // Name + formula
+        const nameTxt = this.add.text(32, rowY + 8, def.name, {
+            fontSize: '14px', color: '#ddccaa', fontFamily: 'monospace', fontStyle: 'bold'
+        });
+        cont.add(nameTxt);
+        const formula = def.formula || '';
+        if (formula) {
+            const formulaTxt = this.add.text(32 + nameTxt.width + 10, rowY + 10, formula, {
+                fontSize: '12px', color: '#887766', fontFamily: 'monospace'
+            });
+            cont.add(formulaTxt);
+        }
+
+        // Tier badge (right side)
+        const tierColors = (typeof MINERAL_TIER_COLORS !== 'undefined') ? MINERAL_TIER_COLORS : {};
+        const tierCol = tierColors[def.tier] || 0x888888;
+        const tierHex = '#' + tierCol.toString(16).padStart(6, '0');
+        const tierLabel = def.subtype === 'crystal' ? `KRYSTALL T${def.tier}` : `T${def.tier}`;
+        const tierBadge = this.add.text(w - 8, rowY + 10, tierLabel, {
+            fontSize: '11px', color: tierHex, fontFamily: 'monospace', fontStyle: 'bold'
+        }).setOrigin(1, 0);
+        cont.add(tierBadge);
+
+        // Yields line
+        const yieldsLine = this._formatYields(def);
+        const yields = this.add.text(32, rowY + 28, '→ Gir: ', {
+            fontSize: '12px', color: '#778877', fontFamily: 'monospace'
+        });
+        cont.add(yields);
+        const yieldsTxt = this.add.text(32 + yields.width, rowY + 28, yieldsLine, {
+            fontSize: '12px', color: '#aabbaa', fontFamily: 'monospace'
+        });
+        cont.add(yieldsTxt);
+
+        // Found-in line
+        const foundIn = this._getMineralLocations(def);
+        const foundTxt = this.add.text(32, rowY + 44, `Funnet i: ${foundIn}`, {
+            fontSize: '11px', color: '#7a8899', fontFamily: 'monospace',
+            wordWrap: { width: w - 40 }
+        });
+        cont.add(foundTxt);
+
+        // Description
+        const descTxt = this.add.text(32, rowY + 60, `"${def.desc || ''}"`, {
+            fontSize: '11px', color: '#665544', fontFamily: 'monospace',
+            wordWrap: { width: w - 40 }
+        });
+        cont.add(descTxt);
+    }
+
+    _formatYields(def) {
+        if (!def.yields || def.yields.length === 0) return 'ingen';
+        const elements = (typeof ELEMENTS !== 'undefined') ? ELEMENTS : {};
+        return def.yields.map(y => {
+            const e = elements[y.symbol];
+            const symStr = e ? e.symbol : y.symbol;
+            let suffix = '';
+            if (y.chance < 0.3)      suffix = ' (svært sjelden)';
+            else if (y.chance < 0.6) suffix = ' (sjelden)';
+            else if (y.chance < 1.0) suffix = ' (variabel)';
+            return `${symStr}×${y.amount}${suffix}`;
+        }).join(', ');
+    }
+
+    // ── Where is the mineral found? ──────────────────────────────────────────
+    // Derived from spawn rules in src/systems/ItemSpawner.js:
+    //   quarry        – any tier, world matches
+    //   crystal_cave  – crystals only
+    //   ore_chamber   – minerals tier 3+
+    //   hydrothermal  – minerals tier 4+
+    //   magma_chamber – minerals tier 5-6 (boss-grade)
+    //   gas_pocket    – noble gases (He/Ne/Ar/Kr/Xe) directly, world 10+
+    // Plus regular floor scatter and boss drops (tier 4+).
+    _getMineralLocations(def) {
+        const t = def.tier;
+        const isCrystal = def.subtype === 'crystal';
+        const minWorld = ({ 1: 1, 2: 1, 3: 2, 4: 4, 5: 6, 6: 8 })[t] || 1;
+        const rooms = [];
+
+        if (isCrystal) {
+            rooms.push('Krystallhule');
+        } else {
+            rooms.push('Steinbrudd');
+            if (t >= 3) rooms.push('Malmkammer');
+            if (t >= 4) rooms.push('Hydrotermisk åre');
+            if (t >= 5) rooms.push('Magmakammer');
+        }
+        rooms.push('spredt i tunneler');
+        if (!isCrystal && t >= 4) rooms.push('boss-drop');
+
+        return `${rooms.join(', ')} (Verden ${minWorld}+)`;
+    }
+
+    // ── Missing elements tab ──────────────────────────────────────────────────
+
+    _buildMissingList() {
+        const cont = this._listContainer;
+        const tracker = this.heroRef?.elementTracker || null;
+
+        if (!tracker) {
+            const hint = this.add.text(0, 0,
+                'Start et eventyr for å se hvilke grunnstoffer du mangler.\n\n' +
+                'Wiki-en bruker din nåværende helts oppdagelses-status til å vise ' +
+                'hvilke mineraler du bør lete etter.',
+                {
+                    fontSize: '13px', color: '#887766', fontFamily: 'monospace',
+                    wordWrap: { width: this._listArea.w - 16 }
+                }
+            );
+            cont.add(hint);
+            this._contentH = 80;
+            return;
+        }
+
+        if (typeof ELEMENTS === 'undefined') return;
+
+        // For each undiscovered element, list minerals that yield it
+        const missing = Object.values(ELEMENTS).filter(e => !tracker.isDiscovered(e.symbol));
+
+        if (missing.length === 0) {
+            const done = this.add.text(0, 0,
+                '★ Du har oppdaget alle grunnstoffene! ★\n\nGuds periodiske system venter…',
+                {
+                    fontSize: '14px', color: '#ffcc44', fontFamily: 'monospace', fontStyle: 'bold',
+                    align: 'center'
+                }
+            );
+            cont.add(done);
+            this._contentH = 60;
+            return;
+        }
+
+        // Sort missing by atomic number for predictable order
+        missing.sort((a, b) => a.atomicNumber - b.atomicNumber);
+
+        // Pre-build mineral index: symbol -> [mineralDef, ...]
+        const mineralsBySymbol = {};
+        if (typeof MINERAL_DEFS !== 'undefined') {
+            for (const def of Object.values(MINERAL_DEFS)) {
+                for (const y of (def.yields || [])) {
+                    (mineralsBySymbol[y.symbol] = mineralsBySymbol[y.symbol] || []).push(def);
+                }
+            }
+        }
+
+        const w = this._listArea.w;
+        const rowH = 56;
+        const NOBLE_GASES = new Set(['He', 'Ne', 'Ar', 'Kr', 'Xe']);
+        // Synthetic elements (Tc, Pm, Np-Og) — symbols whose atomic number is 43, 61, or >= 93
+        const isSynthetic = (e) => e.atomicNumber === 43 || e.atomicNumber === 61 || e.atomicNumber >= 93;
+
+        missing.forEach((elem, idx) => {
+            const rowY = idx * rowH;
+
+            if (rowY > 0) {
+                const sep = this.add.rectangle(w / 2, rowY - 2, w - 8, 1, 0x2a2018);
+                cont.add(sep);
+            }
+
+            // Element header: "Wolfram (W) – atomic 74"
+            const header = this.add.text(8, rowY + 6,
+                `${elem.name} (${elem.symbol})  ·  atomnr ${elem.atomicNumber}`, {
+                fontSize: '13px', color: '#ddccaa', fontFamily: 'monospace', fontStyle: 'bold'
+            });
+            cont.add(header);
+
+            // Source line
+            let sourceLine;
+            if (isSynthetic(elem)) {
+                sourceLine = 'Syntetisk – lages i Akselerator-rommet (kjernefysikk).';
+            } else if (NOBLE_GASES.has(elem.symbol)) {
+                sourceLine = 'Direkte fra gasslomme (Verden 10+).';
+            } else {
+                const ms = mineralsBySymbol[elem.symbol] || [];
+                if (ms.length === 0) {
+                    sourceLine = 'Ingen kjent kilde – sjekk smelter/kjemilab.';
+                } else {
+                    // Pick lowest-tier mineral as primary, mention up to 3
+                    ms.sort((a, b) => a.tier - b.tier);
+                    const primary = ms.slice(0, 3)
+                        .map(d => `${d.name} (T${d.tier})`)
+                        .join(', ');
+                    const minTier = ms[0].tier;
+                    const minWorld = ({ 1: 1, 2: 1, 3: 2, 4: 4, 5: 6, 6: 8 })[minTier] || 1;
+                    sourceLine = `Finnes i: ${primary} – fra Verden ${minWorld}+`;
+                }
+            }
+            const src = this.add.text(8, rowY + 26, sourceLine, {
+                fontSize: '11px', color: '#7a8899', fontFamily: 'monospace',
+                wordWrap: { width: w - 20 }
+            });
+            cont.add(src);
+        });
+
+        this._contentH = missing.length * rowH;
+    }
+
+    // ── Close handling ────────────────────────────────────────────────────────
+
+    _close() {
+        if (this.fromMenu) {
+            this.scene.start('MenuScene');
+        } else {
+            this.scene.stop();
+        }
+    }
+}

--- a/src/scenes/WelcomeScene.js
+++ b/src/scenes/WelcomeScene.js
@@ -1,0 +1,280 @@
+// ─── Labyrint Hero – WelcomeScene ────────────────────────────────────────────
+// Multi-page intro overlay launched the first time the player visits the
+// main menu. Auto-marks itself as seen on dismissal. Can be re-opened from
+// MenuScene's [ INTRO ]-button at any time.
+//
+// Pages:
+//   1. Atmospheric lore — who you are and where you have descended
+//   2. The hero — race, level, ability tree
+//   3. The labyrinth — worlds, special rooms, mineral collection
+//   4. Controls and basic mechanics
+//
+// Closes via [ START EVENTYRET ] on the last page, the [×] button, ESC,
+// or by clicking outside the panel. Every dismissal calls
+// SaveManager.markIntroSeen() so the popup stops auto-opening.
+
+class WelcomeScene extends Phaser.Scene {
+    constructor() { super({ key: 'WelcomeScene' }); }
+
+    create() {
+        const { width: W, height: H } = this.cameras.main;
+        const cx = W / 2, cy = H / 2;
+
+        this._currentPage = 0;
+        this._pages = this._buildPageContent();
+
+        // ── Dim backdrop (click-outside dismisses) ────────────────────────────
+        this.add.rectangle(cx, cy, W, H, 0x000000, 0.85)
+            .setInteractive()
+            .on('pointerdown', () => this._close());
+
+        // ── Panel ─────────────────────────────────────────────────────────────
+        const panelW = Math.min(W - 60, 760);
+        const panelH = Math.min(H - 60, 620);
+        const px = cx - panelW / 2;
+        const py = cy - panelH / 2;
+
+        // Block click-through inside the panel
+        const panelHit = this.add.rectangle(cx, cy, panelW, panelH, 0x000000, 0.001)
+            .setInteractive();
+        panelHit.on('pointerdown', (p, _x, _y, ev) => ev.stopPropagation());
+
+        const panel = this.add.graphics();
+        panel.fillStyle(0x0c0a1c, 0.98);
+        panel.fillRoundedRect(px, py, panelW, panelH, 10);
+        panel.lineStyle(2, 0xb89766);
+        panel.strokeRoundedRect(px, py, panelW, panelH, 10);
+
+        // Decorative inner border
+        panel.lineStyle(1, 0x6a4a22, 0.6);
+        panel.strokeRoundedRect(px + 8, py + 8, panelW - 16, panelH - 16, 8);
+
+        // Decorative corner runes (mirrors MenuScene aesthetic)
+        const drawRune = (rx, ry) => {
+            panel.fillStyle(0x6a4a22, 0.55);
+            panel.fillRect(rx - 6, ry - 1, 12, 2);
+            panel.fillRect(rx - 1, ry - 6, 2, 12);
+        };
+        drawRune(px + 22, py + 22);
+        drawRune(px + panelW - 22, py + 22);
+        drawRune(px + 22, py + panelH - 22);
+        drawRune(px + panelW - 22, py + panelH - 22);
+
+        // ── Header (title + close X) ──────────────────────────────────────────
+        this._titleText = this.add.text(cx, py + 30, '', {
+            fontSize: '20px', color: '#f5e642', fontFamily: 'monospace',
+            fontStyle: 'bold', stroke: '#5a4a00', strokeThickness: 2
+        }).setOrigin(0.5);
+
+        this._subtitleText = this.add.text(cx, py + 56, '', {
+            fontSize: '12px', color: '#b89766', fontFamily: 'monospace', fontStyle: 'italic'
+        }).setOrigin(0.5);
+
+        this.add.rectangle(cx, py + 76, panelW - 80, 1, 0x6a4a22);
+
+        const closeBtn = this.add.text(px + panelW - 24, py + 24, '✕', {
+            fontSize: '20px', color: '#887766', fontFamily: 'monospace'
+        }).setOrigin(0.5).setInteractive({ useHandCursor: true });
+        closeBtn.on('pointerover', () => closeBtn.setColor('#ff8866'));
+        closeBtn.on('pointerout',  () => closeBtn.setColor('#887766'));
+        closeBtn.on('pointerdown', (p, _x, _y, ev) => { ev.stopPropagation(); this._close(); });
+
+        // ── Body text area ────────────────────────────────────────────────────
+        this._bodyArea = {
+            x: px + 32,
+            y: py + 90,
+            w: panelW - 64,
+            h: panelH - 90 - 70, // leave room for nav row
+        };
+        this._bodyText = this.add.text(this._bodyArea.x, this._bodyArea.y, '', {
+            fontSize: '14px', color: '#ddd2b8', fontFamily: 'monospace',
+            wordWrap: { width: this._bodyArea.w }, lineSpacing: 6
+        });
+
+        // ── Page-dot indicator ────────────────────────────────────────────────
+        this._dotsGfx = this.add.graphics();
+
+        // ── Navigation buttons ────────────────────────────────────────────────
+        const navY = py + panelH - 32;
+        this._prevBtn = this.add.text(px + 28, navY, '< FORRIGE', {
+            fontSize: '14px', color: '#8899bb', fontFamily: 'monospace'
+        }).setOrigin(0, 0.5).setInteractive({ useHandCursor: true });
+        this._prevBtn.on('pointerover', () => { if (this._currentPage > 0) this._prevBtn.setColor('#bbccdd'); });
+        this._prevBtn.on('pointerout',  () => this._prevBtn.setColor(this._currentPage > 0 ? '#8899bb' : '#33445a'));
+        this._prevBtn.on('pointerdown', (p, _x, _y, ev) => { ev.stopPropagation(); this._prev(); });
+
+        this._nextBtn = this.add.text(px + panelW - 28, navY, 'NESTE >', {
+            fontSize: '14px', color: '#ccaa77', fontFamily: 'monospace', fontStyle: 'bold'
+        }).setOrigin(1, 0.5).setInteractive({ useHandCursor: true });
+        this._nextBtn.on('pointerover', () => this._nextBtn.setAlpha(0.7));
+        this._nextBtn.on('pointerout',  () => this._nextBtn.setAlpha(1));
+        this._nextBtn.on('pointerdown', (p, _x, _y, ev) => { ev.stopPropagation(); this._next(); });
+
+        // Skip hint (only shown when intro auto-opened on first visit)
+        const wasFirstVisit = !SaveManager.hasSeenIntro();
+        if (wasFirstVisit) {
+            this.add.text(cx, py + panelH + 18, 'Klikk utenfor eller trykk ESC for å hoppe over',
+                { fontSize: '11px', color: '#556677', fontFamily: 'monospace' }
+            ).setOrigin(0.5);
+        }
+
+        // ── Keyboard navigation ───────────────────────────────────────────────
+        this.input.keyboard.on('keydown-ESC',   () => this._close());
+        this.input.keyboard.on('keydown-RIGHT', () => this._next());
+        this.input.keyboard.on('keydown-LEFT',  () => this._prev());
+        this.input.keyboard.on('keydown-SPACE', () => this._next());
+
+        // ── Render initial page ───────────────────────────────────────────────
+        this._renderPage();
+    }
+
+    // ── Page navigation ───────────────────────────────────────────────────────
+
+    _next() {
+        if (this._currentPage < this._pages.length - 1) {
+            this._currentPage++;
+            this._renderPage();
+        } else {
+            this._close();
+        }
+    }
+
+    _prev() {
+        if (this._currentPage > 0) {
+            this._currentPage--;
+            this._renderPage();
+        }
+    }
+
+    _renderPage() {
+        const page = this._pages[this._currentPage];
+        this._titleText.setText(page.title);
+        this._subtitleText.setText(page.subtitle || '');
+        this._bodyText.setText(page.body);
+
+        // Prev button enabled state
+        const canPrev = this._currentPage > 0;
+        this._prevBtn.setColor(canPrev ? '#8899bb' : '#33445a');
+        this._prevBtn.input.cursor = canPrev ? 'pointer' : 'default';
+
+        // Next button label changes on last page
+        const isLast = this._currentPage === this._pages.length - 1;
+        this._nextBtn.setText(isLast ? '[ START EVENTYRET ]' : 'NESTE >');
+
+        // Page dots
+        this._renderDots();
+    }
+
+    _renderDots() {
+        this._dotsGfx.clear();
+        const cx = this.cameras.main.width / 2;
+        const y = this.cameras.main.height / 2 + 270;
+        const total = this._pages.length;
+        const spacing = 14;
+        const startX = cx - ((total - 1) * spacing) / 2;
+        for (let i = 0; i < total; i++) {
+            const active = i === this._currentPage;
+            this._dotsGfx.fillStyle(active ? 0xccaa77 : 0x554433, 1);
+            this._dotsGfx.fillCircle(startX + i * spacing, y, active ? 4 : 3);
+        }
+    }
+
+    _close() {
+        SaveManager.markIntroSeen();
+        this.scene.stop();
+    }
+
+    // ── Page content (Norwegian) ──────────────────────────────────────────────
+
+    _buildPageContent() {
+        return [
+            {
+                title: 'LABYRINT HERO',
+                subtitle: 'Et eventyr i stein, ild og grunnstoffer',
+                body:
+                    'Langt under verdens grønne overflate ligger de eldgamle ' +
+                    'labyrintene. Fjellet selv puster — sprekker hvisker, ' +
+                    'krystaller gløder svakt, og skygger beveger seg der ingen ' +
+                    'fakkel når.\n\n' +
+                    'Du er en geolog-helt: en eventyrer som har studert berg ' +
+                    'og malm i årevis, og som nå går ned for å samle alt det ' +
+                    'periodiske systemet kan tilby.\n\n' +
+                    'Fem geologiske soner skiller deg fra kjernen — ' +
+                    'skoglabyrinten, grunnfjellet, dyplagene, underverden og ' +
+                    'kjernens hjerte. Hver sone har sin egen estetikk, sine ' +
+                    'monstre, og sine sjeldne mineraler.\n\n' +
+                    'Bare den som henter alle 118 grunnstoffene blir kronet ' +
+                    'med «Guds periodiske system».'
+            },
+            {
+                title: 'HELTEN',
+                subtitle: 'Velg rase, voks i kraft',
+                body:
+                    'Før du stiger ned velger du hvem du vil være. Fire raser, ' +
+                    'fire spillestiler:\n\n' +
+                    '  • Menneske  — balansert, +25% XP\n' +
+                    '  • Dverg     — ekstra forsvar, ser malm lettere\n' +
+                    '  • Alv       — lengre synsfelt, lettere på foten\n' +
+                    '  • Hobbit    — motstand mot feller, raskere fottrinn\n\n' +
+                    'Du velger også en startbonus (et ekstra hjerte, mer angrep ' +
+                    'eller bedre syn) og vanskelighetsgrad.\n\n' +
+                    'Etter hvert som du dreper monstre stiger du i nivå, og hver ' +
+                    'gang får du velge én av tre tilfeldige evner fra seks tre: ' +
+                    'Kriger, Villmarksjeger, Geolog, Metallurg, Kjemiker eller ' +
+                    'Fysiker. Geologen ser mineraler tydeligere; kjemikeren lager ' +
+                    'bomber og giftpiler; fysikeren bygger akseleratoren som ' +
+                    'syntetiserer de tyngste grunnstoffene.\n\n' +
+                    'Helten din lever videre mellom forsøk: død nullstiller bare ' +
+                    'verden — nivå, evner, gull og inventar består.'
+            },
+            {
+                title: 'LABYRINTEN',
+                subtitle: '25 verdener · 5 soner · uendelige mineraler',
+                body:
+                    'Hver verden er en prosedyregenerert labyrint. Du leter deg ' +
+                    'frem til utgangen — men før du kan gå videre må verdens ' +
+                    'boss falle.\n\n' +
+                    'Underveis møter du spesielle rom som belønner utforsking:\n\n' +
+                    '  • Steinbrudd        — vanlige malmer (T1–T2)\n' +
+                    '  • Krystallhule      — gemstones med passive bonuser\n' +
+                    '  • Malmkammer        — sjeldne malmer (T3+)\n' +
+                    '  • Hydrotermisk åre  — episke mineraler (T4+)\n' +
+                    '  • Magmakammer       — legendariske/mytiske (T5–T6)\n' +
+                    '  • Gasslomme         — fanger edelgasser direkte (V10+)\n' +
+                    '  • Leir              — smelt malm, hvil ut, lag kjemi\n\n' +
+                    'Plukk opp mineraler ved å gå over dem. I leiren kan du ' +
+                    'smelte dem til rene grunnstoffer, lage legeringer (Smelter), ' +
+                    'kjemiske forbindelser (Kjemilab) og — etter hvert — ' +
+                    'syntetisere transurane grunnstoffer (Akselerator).\n\n' +
+                    'Hver sone-boss du beseirer låser opp et nytt verksted og ' +
+                    'fører deg dypere mot kjernen.'
+            },
+            {
+                title: 'SLIK SPILLER DU',
+                subtitle: 'Kontroller, kjernemekanikk og snarveier',
+                body:
+                    'Bevegelse:\n' +
+                    '  WASD eller Piltaster   — gå ett tile om gangen\n' +
+                    '  Mus / touch            — klikk en tile for å gå dit\n\n' +
+                    'Kamp:\n' +
+                    '  SPACE eller F          — angrep nærkamp / hakk vegg\n' +
+                    '  R                      — skyt pil (krever piler)\n' +
+                    '  Bump-angrep            — gå inn i monster = angrep\n\n' +
+                    'Inventar og fremgang:\n' +
+                    '  E                      — åpne inventar (med mineral-wiki)\n' +
+                    '  T                      — ferdighetstre\n' +
+                    '  B                      — elementbok (periodisk system)\n' +
+                    '  M                      — toggle minikart\n' +
+                    '  ESC                    — meny / lukke overlay\n\n' +
+                    'Tips:\n' +
+                    '  • Alle endringer lagres automatisk når du går til neste verden\n' +
+                    '  • Sjekk MINERAL-WIKI fra hovedmenyen for å se hvilke ' +
+                    'mineraler som gir hvilke grunnstoffer\n' +
+                    '  • MANGLENDE-fanen i wikien viser hvilke grunnstoffer du ' +
+                    'fortsatt jakter på\n' +
+                    '  • Geolog-evner identifiserer ukjente mineraler\n' +
+                    '  • Brann, gift og frost varer i flere ticks — bruk dem på bosser'
+            }
+        ];
+    }
+}

--- a/src/utils/SaveManager.js
+++ b/src/utils/SaveManager.js
@@ -3,6 +3,7 @@
 
 const SaveManager = {
     KEY: 'labyrint_hero_v1',
+    INTRO_KEY: 'labyrint_hero_intro_seen',
 
     save(worldNum, heroStats) {
         try {
@@ -23,5 +24,13 @@ const SaveManager = {
 
     clear() {
         try { localStorage.removeItem(this.KEY); } catch (e) {}
+    },
+
+    hasSeenIntro() {
+        try { return localStorage.getItem(this.INTRO_KEY) === '1'; } catch (e) { return false; }
+    },
+
+    markIntroSeen() {
+        try { localStorage.setItem(this.INTRO_KEY, '1'); } catch (e) {}
     }
 };


### PR DESCRIPTION
## Summary

Help new players understand the game's premise and surface the long-term goal of collecting all 118 elements.

- **`WelcomeScene`** — a four-page popup that auto-opens on first visit and can be re-opened any time via the new `[ INTRO ]` button. Pages: `LABYRINT HERO` (atmospheric premise + the five geological zones), `HELTEN` (race choice, level/skill progression), `LABYRINTEN` (worlds, special rooms, smelter/lab/accelerator), `SLIK SPILLER DU` (detailed controls and tips). Dismissed via `[ START EVENTYRET ]`, `[×]`, ESC, or click-outside; the seen-flag is stored in `localStorage` under a separate key so it survives `SaveManager.clear()`.
- **`MineralWikiScene`** — browseable codex of all 60+ minerals and crystals with formula, tier, yields, and spawn locations. Tabs for `ALLE` / `T1`–`T6` / `KRYSTALLER`, plus a `MANGLENDE` tab that maps undiscovered elements back to the minerals that produce them. Reachable from the menu and from a new button in the inventory overlay. Spawn locations are derived at runtime by transcribing the rules from `ItemSpawner.js` — no mineral data needed new fields.
- **`MenuScene`** — bottom row reorganised to `[ INTRO ]  [ LEDERTAVLE ]  [ MINERAL-WIKI ]`. The previous inline info panel was removed; its content lives in the popup now.

## Test plan

- [ ] Open `index.html` with a fresh `localStorage` → `WelcomeScene` opens automatically; click through all four pages, last page shows `[ START EVENTYRET ]`.
- [ ] Reload → popup does not auto-open. Click `[ INTRO ]` → it opens; ESC / `[×]` / click outside all close it.
- [ ] `[ MINERAL-WIKI ]` from menu shows mineral list; tabs `T1`–`T6`, `KRYSTALLER`, `MANGLENDE` all render; `[ TILBAKE ]` returns to menu with difficulty selection intact.
- [ ] In-game: `E` → inventory shows new `Mineral-wiki` button next to `Elementbok [B]`; clicking opens the wiki as overlay; ESC returns to inventory without freezing the game.
- [ ] Existing flows (`[ FORTSETT ]`, `[ NYTT SPILL ]`, difficulty selection, leaderboard) still work after the menu changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017kufswgtjKBWgmE1FMS16L)_