### PR TITLE
Fix energy economy and unlock semiconductor crafting (v0.50)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ---
 
+## v0.50 – 2026-04-28
+
+### Feilrettinger
+- **Halvleder-crafting var utilgjengelig:** Datamodellen for halvledere har tre lag — raffinering (`pure_si`/`pure_ge`/…), halvledermateriale (`silicon_wafer`, `germanium_crystal`, …) og teknologiinstallasjon — men Smeltery-UIet hadde bare faner for første og siste lag. Mellomsteget i `craftSemiconductor()` hadde null callsites, så `hero.alloyInventory[semiId]` vokste aldri og alle teknologi-installasjoner stod permanent på `(0/1)`. Lagt til ny **Halvleder**-fane som bygger bro mellom raffinerte deler og teknologi-fanen
+- **Helium uoppnåelig før verden 22:** Gasslomme-spawneren brukte `Math.min(rand, (wn-10)/3)` til å bestemme indeks i edelgass-listen, noe som gjorde He effektivt ulåselig før verden 22. Akselerator-oppskriftene Cm/Bk/Cf/Md krever He som projektil og åpner i verden 13 — clampen blokkerte hele synteseprogresjonen mellom Pu og tunge transurane. Indeksvalget er nå uniformt over tilgjengelige edelgasser
+- **Fusjons-energi var additiv, ikke kombinatorisk:** `calculateFuelEnergy()` la H- og Li-energi sammen uavhengig (`hCount * 80 + liCount * 150`), så en spiller med null hydrogen og bare litium fikk fortsatt fusjons-energi. Endret til `min(H, Li)` per par à 230 base-energi — i tråd med skill-teksten *"D-T fusjon: H + Li → He + energi"*
+- **Virtuelt drivstoff ble aldri brukt opp:** U/Th/H/Li gav energi-headroom uten å bli trukket fra `elementTracker`, så én enkelt U-atom ga uendelig +50 energi til alltid. `consumeFuel()` trekker nå fra virtuelt drivstoff etter at fysisk drivstoff (tre/kull/olje/gass) er tomt: Th først, så U for fisjon, og H+Li-par til slutt for fusjon
+- **`fusionUnlocked` var en død flag:** Edelgass-fullføringsbonusen satte `hero.fusionUnlocked = true` men ingenting brukte flagget. `calculateFuelEnergy()` og `consumeFuel()` aksepterer den nå som en alternativ vei til D-T fusjons-energi (uten ×5-multiplikatoren fra Fysiker T4 — flagget gir base-rate)
+
+### Tekniske endringer
+- SmeltingSystem.js: Nye statiske konstanter `FISSION_U_ENERGY`, `FISSION_TH_ENERGY`, `FUSION_PAIR_ENERGY`. Ny privat metode `_consumeVirtualFuel()`. Fusjon i `calculateFuelEnergy()` aksepterer nå både `fusionMastered` og `fusionUnlocked` (sistnevnte med multiplikator 1.0). Fusjon produserer He som biprodukt — i tråd med tidligere kommentar i koden
+- SmelteryScene.js: Ny `_drawSemiTab()` som lister alle 6 SEMICONDUCTOR_DEFS, viser raffinerte og rå-element-ingredienser hver for seg, og trigger `craftSemiconductor()` + `consumeFuel()`. Tab-bredde justert fra 100 til 92 piksler for å rommer 7 faner
+- ItemSpawner.js: Fjernet `Math.min((wn-10)/3)` clamp fra gasslomme-edelgassvalg
+- tests/test-smelting.js: 6 nye tester for fusjon-min, virtuelt brensel-forbruk, He-biprodukt, fusionUnlocked-vei, og halvleder-crafting (totalt 96 tester, alle grønne)
+
+---
+
 ## v0.49 – 2026-04-28
 
 ### Nye funksjoner

--- a/docs/Elements-mod.md
+++ b/docs/Elements-mod.md
@@ -1,7 +1,9 @@
 # Labyrint Hero – Elements-modifikasjon
-**Versjon:** 0.5 (fase 1–5 implementert)
-**Sist oppdatert:** 2026-04-16
+**Versjon:** 0.51 (fase 1–5 implementert + energi-/halvleder-fixes)
+**Sist oppdatert:** 2026-04-28
 **Status:** Alle 5 faser implementert. 118 grunnstoffer, 28 transuranske synteseoppskrifter, partikkelakselerator, fysiker-skillsti, fisjon/fusjon-energi og «Guds periodiske system»-endgame.
+
+**v0.50-oppdatering:** Halvleder-fane lagt til i Smeltery (bygger bro mellom raffinerte deler og teknologi-installasjon — tidligere var hele tech-sporet låst). He kan nå faktisk samles fra gasslommer fra verden 10 (uniform fordeling). D-T fusjon krever nå både H og Li samtidig (`min(H, Li)` per par à 230 energi) og produserer He som biprodukt. Virtuelt brensel (U/Th/H/Li) blir faktisk forbrukt fra elementtelleren ved bruk. Edelgass-fullføring gir nå reell fusjons-energi (base-rate, uten Fysiker T4-multiplikator).
 
 **v0.40-oppdatering:** 2 nye mineraler (molybdenitt, barytt) og 5 nye legeringer + 8 nye molekyler gir praktisk bruk for Mn, Mo, W, Ta, Ba, B, Ce, La, Nd, Zn. Bombeskade er separert fra potionskala og skalerer +60% per verden (mot +40% før) med flat bombgulv; radius +1 fra verden 5 og +2 fra verden 8. Geolog/Metallurg/Kjemiker har fått T4-ferdigheter (Geode-splitter, Reforge, Volatil mestring) og en 3-sti-synergi Transmutasjon (5 → 1 nabo på atomnummer). Se CHANGELOG v0.40 for full diff.
 
@@ -234,8 +236,8 @@ Energi er en ressurs som kreves for smelteprosesser og avansert teknologi. Spill
 | Trekull | 1 | 2 | Ingen | Laget av tre i begrenset luft |
 | Olje (råolje) | 2 | 8 | Bore-skill | Finnes i dype lag |
 | Naturgass | 2 | 10 | Bore-skill | Finnes med olje |
-| Fisjon (U/Th) | 3 | 50/40 per enhet | Fysiker T3 | U og Th gir virtuell energi (×2 med skill) |
-| Fusjon (D-T) | 4 | H:80, Li:150 | Fysiker T4 | Deuterium + Li (tritiumkilde), ×5 med skill |
+| Fisjon (U/Th) | 3 | 50/40 per enhet | Fysiker T3 | U og Th gir virtuell energi (×2 med skill). Forbrukes fra elementtelleren når brukt |
+| Fusjon (D-T) | 4 | 230 per (H+Li)-par | Fysiker T4 / Edelgasser | Krever 1 H + 1 Li per par (`min(H, Li)`). Produserer 1 He som biprodukt. ×5 med Fysiker T4-skill, ×1 via edelgass-fullføring |
 
 ### 7.2 Energiteknologi-tre
 

--- a/src/scenes/SmelteryScene.js
+++ b/src/scenes/SmelteryScene.js
@@ -78,9 +78,10 @@ class SmelteryScene extends Phaser.Scene {
         ];
         if (this.heroRef.semiconductorUnlocked) {
             tabs.push({ id: 'refine', label: 'Raffiner' });
-            tabs.push({ id: 'tech', label: 'Teknologi' });
+            tabs.push({ id: 'semi',   label: 'Halvleder' });
+            tabs.push({ id: 'tech',   label: 'Teknologi' });
         }
-        const tabW = tabs.length > 4 ? 100 : 130;
+        const tabW = tabs.length > 4 ? 92 : 130;
         const tabY = this.py + 62;
         tabs.forEach((tab, i) => {
             const tx = this.px + 30 + i * (tabW + 10) + tabW / 2;
@@ -107,8 +108,8 @@ class SmelteryScene extends Phaser.Scene {
         // ── Content area ──────────────────────────────────────────────────────
         this._baseContentY = tabY + 30;
         this.contentY = this._baseContentY;
-        this._scrollOffsets = { stash: 0, smelt: 0, alloy: 0, forge: 0, refine: 0, tech: 0 };
-        this._maxScrolls = { stash: 0, smelt: 0, alloy: 0, forge: 0, refine: 0, tech: 0 };
+        this._scrollOffsets = { stash: 0, smelt: 0, alloy: 0, forge: 0, refine: 0, semi: 0, tech: 0 };
+        this._maxScrolls = { stash: 0, smelt: 0, alloy: 0, forge: 0, refine: 0, semi: 0, tech: 0 };
         this._elementFilter = null; // null = show all, or element symbol string
 
         // Mouse wheel scrolling (per-tab offset)
@@ -162,7 +163,7 @@ class SmelteryScene extends Phaser.Scene {
 
         // Update tab button colors
         const tabIds = ['stash', 'smelt', 'alloy', 'forge'];
-        if (this.heroRef.semiconductorUnlocked) { tabIds.push('refine', 'tech'); }
+        if (this.heroRef.semiconductorUnlocked) { tabIds.push('refine', 'semi', 'tech'); }
         UIHelper.updateTabButtons(this._tabBtns, tabIds, this._tab, '#ff7722', '#554433');
 
         // Update fuel text
@@ -188,6 +189,7 @@ class SmelteryScene extends Phaser.Scene {
                 }
                 break;
             case 'refine': this._drawRefineTab(); break;
+            case 'semi':   this._drawSemiTab();   break;
             case 'tech':   this._drawTechTab();   break;
         }
 
@@ -1131,6 +1133,108 @@ class SmelteryScene extends Phaser.Scene {
             }
         });
         this._contentEndY = y + REFINING_RECIPES.length * rowStep;
+    }
+
+    // ── SEMI TAB: Refined elements + raw → Semiconductor materials ──────────
+    // Bridges the refining step (REFINING_RECIPES) and the technology step
+    // (TECH_UPGRADES). Without this, hero.alloyInventory[semiId] never grows
+    // and tech installs are unreachable.
+
+    _drawSemiTab() {
+        const hero = this.heroRef;
+        const cx = this.px + this.panelW / 2;
+        let y = this.contentY;
+        const scrollOff = this._scrollOffsets.semi || 0;
+        const visBot = this.py + this.panelH - 40;
+        const fuel = this.smelter.calculateFuelEnergy(hero);
+        const colW = Math.min(560, this.panelW - 40);
+        const startX = this.px + 20;
+
+        this._d(this.add.text(cx, y, 'Lag halvledermateriale fra raffinerte deler:', {
+            fontSize: '14px', color: '#8866ff', fontFamily: 'monospace'
+        }).setOrigin(0.5));
+        y += 22;
+
+        // Show current semiconductor inventory
+        const semiInv = hero.alloyInventory || {};
+        const semiEntries = Object.entries(semiInv).filter(([id, v]) =>
+            v > 0 && SEMICONDUCTOR_DEFS && SEMICONDUCTOR_DEFS[id]
+        );
+        if (semiEntries.length > 0) {
+            let rx = startX;
+            for (const [id, count] of semiEntries) {
+                const def = SEMICONDUCTOR_DEFS[id];
+                const col = '#' + (def.color || 0x8866ff).toString(16).padStart(6, '0');
+                const badge = this._d(this.add.text(rx, y, `${def.name}: ${count}`, {
+                    fontSize: '13px', color: col, fontFamily: 'monospace',
+                    backgroundColor: '#0a0818', padding: { x: 3, y: 1 }
+                }));
+                rx += badge.width + 8;
+                if (rx > startX + colW - 50) { rx = startX; y += 20; }
+            }
+            y += 22;
+        }
+
+        if (typeof SEMICONDUCTOR_DEFS === 'undefined') { this._contentEndY = y; return; }
+        const semis = Object.values(SEMICONDUCTOR_DEFS);
+        const rowStep = 56;
+
+        semis.forEach((semi, idx) => {
+            const baseY = y + idx * rowStep;
+            const ry = baseY - scrollOff;
+            if (ry > visBot || ry < this.contentY - rowStep) return;
+
+            const check = this.smelter.canCraftSemiconductor(semi.id, hero, fuel);
+            const col = check.canCraft ? 0x8866ff : 0x332244;
+            const hexCol = '#' + col.toString(16).padStart(6, '0');
+
+            const bg = this._d(this.add.graphics());
+            bg.fillStyle(col, 0.08);
+            bg.fillRoundedRect(startX, ry, colW, 50, 4);
+            bg.lineStyle(1, col, 0.3);
+            bg.strokeRoundedRect(startX, ry, colW, 50, 4);
+
+            this._d(this.add.text(startX + 8, ry + 4, `${semi.name} (T${semi.tier})`, {
+                fontSize: '15px', color: hexCol, fontFamily: 'monospace', fontStyle: 'bold'
+            }));
+
+            // Recipe display: refined ingredients show their refined name + count,
+            // raw element ingredients show the element symbol + collected count.
+            const inputStr = semi.recipe.map(ing => {
+                if (ing.refined) {
+                    const r = REFINING_RECIPES.find(rec => rec.id === ing.refined);
+                    const have = (hero.refinedElements || {})[ing.refined] || 0;
+                    return `${r ? r.name : ing.refined}:${have}/${ing.amount}`;
+                }
+                const have = hero.elementTracker.getCount(ing.symbol);
+                return `${ing.symbol}:${have}/${ing.amount}`;
+            }).join('  ');
+            this._d(this.add.text(startX + 8, ry + 22, inputStr, {
+                fontSize: '12px', color: '#665588', fontFamily: 'monospace',
+                wordWrap: { width: colW - 100 }
+            }));
+            this._d(this.add.text(startX + 8, ry + 36, `${check.energyCost} energi`, {
+                fontSize: '12px', color: '#554477', fontFamily: 'monospace'
+            }));
+
+            if (check.canCraft) {
+                const btn = this._d(this.add.text(startX + colW - 70, ry + 16, '[ Lag ]', {
+                    fontSize: '14px', color: '#8866ff', fontFamily: 'monospace', fontStyle: 'bold'
+                }).setInteractive({ useHandCursor: true }));
+                btn.on('pointerover', () => btn.setColor('#aa88ff'));
+                btn.on('pointerout', () => btn.setColor('#8866ff'));
+                btn.on('pointerdown', () => {
+                    const result = this.smelter.craftSemiconductor(semi.id, hero);
+                    if (result.success) {
+                        this.smelter.consumeFuel(hero, result.energyCost);
+                        EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `Laget: ${semi.name}`, color: '#8866ff' });
+                        Audio.playPickup();
+                        this._refresh();
+                    }
+                });
+            }
+        });
+        this._contentEndY = y + semis.length * rowStep;
     }
 
     // ── TECH TAB: Install permanent technology upgrades ─────────────────────

--- a/src/systems/ItemSpawner.js
+++ b/src/systems/ItemSpawner.js
@@ -304,12 +304,15 @@ class ItemSpawner {
                             this._spawnFuelAt(tile.x, tile.y, fuel);
                         }
                     }
-                    // Noble gas collection: each gas pocket awards 1-2 random noble gases
+                    // Noble gas collection: each gas pocket awards 1-2 random noble gases.
+                    // Distribution is uniform over the available list. Previously a
+                    // Math.min((wn-10)/3) clamp on the index made He effectively
+                    // unreachable until world 22, blocking accelerator recipes
+                    // (Cm/Bk/Cf/Md all require He as projectile).
                     if (nobleGases && scene.hero && scene.hero.elementTracker) {
                         const count = 1 + Math.floor(Math.random() * 2);
                         for (let gi = 0; gi < count; gi++) {
-                            const gasIdx = Math.min(Math.floor(Math.random() * nobleGases.length), Math.floor((wn - 10) / 3));
-                            const gas = nobleGases[Math.min(gasIdx, nobleGases.length - 1)];
+                            const gas = nobleGases[Math.floor(Math.random() * nobleGases.length)];
                             scene.hero.elementTracker.collect(gas, 1);
                             scene.hero.elementTracker.discover(gas);
                             EventBus.emit('floatingText', { gx: room.tiles[0].x, gy: room.tiles[0].y, msg: `Edelgass samlet: ${gas}`, color: '#aaccff' });

--- a/src/systems/SmeltingSystem.js
+++ b/src/systems/SmeltingSystem.js
@@ -5,6 +5,14 @@
 class SmeltingSystem {
     constructor() {}
 
+    // Virtual fuel energy values (per unit, before multipliers).
+    // Single source of truth for both calculateFuelEnergy and consumeFuel.
+    static FISSION_U_ENERGY  = 50;
+    static FISSION_TH_ENERGY = 40;
+    // D-T fusion consumes 1 H + 1 Li per pair. Sum of the previous additive
+    // values (80 + 150 = 230) preserves the rough total when both are stocked.
+    static FUSION_PAIR_ENERGY = 230;
+
     // ── Smelting: Mineral → Pure Elements ────────────────────────────────────
 
     /**
@@ -249,15 +257,20 @@ class SmeltingSystem {
             const fMul = hero.fissionEnergyMul || 1.0;
             const uCount = hero.elementTracker ? hero.elementTracker.getCount('U') : 0;
             const thCount = hero.elementTracker ? hero.elementTracker.getCount('Th') : 0;
-            total += Math.round((uCount * 50 + thCount * 40) * fMul);
+            total += Math.round((uCount * SmeltingSystem.FISSION_U_ENERGY + thCount * SmeltingSystem.FISSION_TH_ENERGY) * fMul);
         }
         // Fusion bonus: D-T fusion consumes H (deuterium) + Li (tritium bred
-        // from Li-6 + neutron). He is a byproduct, not fuel.
-        if (hero.fusionMastered) {
-            const fuMul = hero.fusionEnergyMul || 1.0;
+        // from Li-6 + neutron). Both are required per fusion event, so the
+        // available fuel is bounded by min(H, Li). He is a byproduct, not fuel.
+        // Granted via Fysiker T4 (full ×5) or via Edelgass-completion (×1 base).
+        if (hero.fusionMastered || hero.fusionUnlocked) {
+            const fuMul = hero.fusionMastered
+                ? (hero.fusionEnergyMul || 1.0)
+                : 1.0;
             const hCount = hero.elementTracker ? hero.elementTracker.getCount('H') : 0;
             const liCount = hero.elementTracker ? hero.elementTracker.getCount('Li') : 0;
-            total += Math.round((hCount * 80 + liCount * 150) * fuMul);
+            const pairs = Math.min(hCount, liCount);
+            total += Math.round(pairs * SmeltingSystem.FUSION_PAIR_ENERGY * fuMul);
         }
         // Semiconductor energy techs
         if (hero.techSolarPanel) total += 30;
@@ -312,11 +325,58 @@ class SmeltingSystem {
                 if (entry.count <= 0) hero.campStash.splice(i, 1);
             }
         }
+        // Virtual reactor fuel: U/Th (fission) and H+Li pairs (fusion) are
+        // consumed last, after physical fuel is exhausted. Mirrors the
+        // generation logic in calculateFuelEnergy so totals stay in sync.
+        if (remaining > 0) {
+            remaining = this._consumeVirtualFuel(hero, remaining);
+        }
         // Store leftover energy in reserve for next operation
         if (remaining < 0) {
             hero.fuelReserve = (hero.fuelReserve || 0) + Math.abs(remaining);
         }
         return remaining <= 0;
+    }
+
+    _consumeVirtualFuel(hero, remaining) {
+        if (!hero.elementTracker) return remaining;
+
+        // Fission first (cheaper per unit) — Th before U so U is preserved
+        // for high-tier transuranic recipes that target U directly.
+        if (hero.fissionMastered || hero.fissionUpgraded) {
+            const fMul = hero.fissionEnergyMul || 1.0;
+            const thYield = SmeltingSystem.FISSION_TH_ENERGY * fMul;
+            const uYield  = SmeltingSystem.FISSION_U_ENERGY  * fMul;
+            while (remaining > 0 && hero.elementTracker.getCount('Th') > 0) {
+                hero.elementTracker.collected.Th -= 1;
+                if (hero.elementTracker.collected.Th <= 0) delete hero.elementTracker.collected.Th;
+                remaining -= thYield;
+            }
+            while (remaining > 0 && hero.elementTracker.getCount('U') > 0) {
+                hero.elementTracker.collected.U -= 1;
+                if (hero.elementTracker.collected.U <= 0) delete hero.elementTracker.collected.U;
+                remaining -= uYield;
+            }
+        }
+        // Fusion last (highest yield) — consumes 1 H + 1 Li per pair.
+        if ((hero.fusionMastered || hero.fusionUnlocked) && remaining > 0) {
+            const fuMul = hero.fusionMastered ? (hero.fusionEnergyMul || 1.0) : 1.0;
+            const pairYield = SmeltingSystem.FUSION_PAIR_ENERGY * fuMul;
+            while (remaining > 0
+                   && hero.elementTracker.getCount('H') > 0
+                   && hero.elementTracker.getCount('Li') > 0) {
+                hero.elementTracker.collected.H -= 1;
+                if (hero.elementTracker.collected.H <= 0) delete hero.elementTracker.collected.H;
+                hero.elementTracker.collected.Li -= 1;
+                if (hero.elementTracker.collected.Li <= 0) delete hero.elementTracker.collected.Li;
+                remaining -= pairYield;
+                // Fusion produces He as a byproduct (matches the design doc
+                // and the in-game skill description "H + Li → He + energi").
+                hero.elementTracker.collect('He', 1);
+                hero.elementTracker.discover('He');
+            }
+        }
+        return remaining;
     }
 
     _getFuelDef(entry) {

--- a/tests/test-smelting.js
+++ b/tests/test-smelting.js
@@ -87,3 +87,115 @@ describe('SmeltingSystem – fuel calculation', () => {
         }
     });
 });
+
+describe('SmeltingSystem – fusion energy', () => {
+    function makeHero() {
+        return {
+            inventory: new Inventory(),
+            campStash: [],
+            smeltingEfficiency: 0,
+            fusionMastered: true,
+            fusionEnergyMul: 5.0,
+            elementTracker: new ElementTracker()
+        };
+    }
+
+    it('requires both H and Li (min, not sum)', () => {
+        const smelter = new SmeltingSystem();
+        const hero = makeHero();
+        // Only Li — fusion should yield zero energy from virtual fuel.
+        hero.elementTracker.collect('Li', 10);
+        expect(smelter.calculateFuelEnergy(hero)).toBe(0);
+
+        // Add H — energy now bounded by min(H, Li) pairs.
+        hero.elementTracker.collect('H', 3);
+        const energy = smelter.calculateFuelEnergy(hero);
+        // 3 pairs × 230 base × 5.0 mul = 3450
+        expect(energy).toBe(3 * 230 * 5);
+    });
+
+    it('consumes 1 H + 1 Li per pair and produces He as byproduct', () => {
+        const smelter = new SmeltingSystem();
+        const hero = makeHero();
+        hero.elementTracker.collect('H', 4);
+        hero.elementTracker.collect('Li', 4);
+
+        // Each pair = 230 * 5 = 1150 energy. Drain ~2 pairs.
+        const ok = smelter.consumeFuel(hero, 2300);
+        expect(ok).toBeTrue();
+        expect(hero.elementTracker.getCount('H')).toBe(2);
+        expect(hero.elementTracker.getCount('Li')).toBe(2);
+        expect(hero.elementTracker.getCount('He')).toBeGreaterThan(0);
+    });
+
+    it('grants fusion energy via fusionUnlocked at base multiplier', () => {
+        const smelter = new SmeltingSystem();
+        const hero = makeHero();
+        hero.fusionMastered = false;
+        hero.fusionEnergyMul = 1.0;
+        hero.fusionUnlocked = true;
+        hero.elementTracker.collect('H', 2);
+        hero.elementTracker.collect('Li', 2);
+        // 2 pairs × 230 × 1.0 = 460
+        expect(smelter.calculateFuelEnergy(hero)).toBe(460);
+    });
+});
+
+describe('SmeltingSystem – fission virtual fuel', () => {
+    it('consumes Th before U when both are available', () => {
+        const smelter = new SmeltingSystem();
+        const hero = {
+            inventory: new Inventory(),
+            campStash: [],
+            smeltingEfficiency: 0,
+            fissionMastered: true,
+            fissionEnergyMul: 2.0,
+            elementTracker: new ElementTracker()
+        };
+        hero.elementTracker.collect('U', 2);
+        hero.elementTracker.collect('Th', 2);
+
+        // Drain enough to consume both Th but keep U intact (Th yields 80 each).
+        smelter.consumeFuel(hero, 160);
+        expect(hero.elementTracker.getCount('Th')).toBe(0);
+        expect(hero.elementTracker.getCount('U')).toBe(2);
+    });
+});
+
+describe('SmeltingSystem – semiconductor crafting', () => {
+    it('crafts a silicon wafer from refined Si + raw B + raw P', () => {
+        const smelter = new SmeltingSystem();
+        const tracker = new ElementTracker();
+        const hero = {
+            smeltingEfficiency: 0,
+            elementTracker: tracker,
+            refinedElements: { pure_si: 1 },
+            alloyInventory: {}
+        };
+        tracker.collect('B', 1);
+        tracker.collect('P', 1);
+
+        const check = smelter.canCraftSemiconductor('silicon_wafer', hero, 999);
+        expect(check.canCraft).toBeTrue();
+
+        const result = smelter.craftSemiconductor('silicon_wafer', hero);
+        expect(result.success).toBeTrue();
+        expect(hero.alloyInventory.silicon_wafer).toBe(1);
+        expect(hero.refinedElements.pure_si || 0).toBe(0);
+        expect(tracker.getCount('B')).toBe(0);
+        expect(tracker.getCount('P')).toBe(0);
+    });
+
+    it('blocks germanium crystal craft without pure_si', () => {
+        const smelter = new SmeltingSystem();
+        const hero = {
+            smeltingEfficiency: 0,
+            elementTracker: new ElementTracker(),
+            refinedElements: { pure_ge: 5 },
+            alloyInventory: {}
+        };
+        const check = smelter.canCraftSemiconductor('germanium_crystal', hero, 999);
+        expect(check.canCraft).toBeFalse();
+        expect(check.missing.length).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
Five gameplay-consistency fixes uncovered during energy/heavy-element review:

1. Add Halvleder tab to Smeltery — closes the broken loop between refining
   (pure_si/pure_ge/...) and tech installation (silicon_wafer/...).
   craftSemiconductor() existed but had zero callsites, so alloyInventory[semiId]
   never grew and every tech upgrade was permanently stuck on (0/1).

2. Remove He scarcity clamp in gas pockets. The Math.min((wn-10)/3) bias made
   He effectively unreachable until world 22, blocking all accelerator recipes
   from Cm onward (which open at world 13). Now uniform over the available list.

3. Fusion energy uses min(H, Li) per pair (230 base) instead of additive
   80*H + 150*Li. Matches the skill description "D-T fusjon: H + Li → He".

4. Virtual reactor fuel (U/Th/H/Li) is actually consumed by consumeFuel after
   physical fuel exhausts — Th first, then U, then H+Li pairs. Each fusion
   pair produces 1 He as byproduct, matching the in-code design comment.

5. fusionUnlocked (set by collecting all five noble gases) now grants D-T
   fusion energy at base rate, so the Edelgass bonus is no longer a dead flag.

Tests: 6 new specs cover fusion-min, byproduct He, virtual fuel consumption,
fusionUnlocked path, and semiconductor recipe gating. 96/96 green.

https://claude.ai/code/session_01RhJ9UpsVD5RRSpjkrZTyEJ