### PR TITLE
Fix skill tree tier unlock requirements

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ---
 
-## v0.51 – 2026-05-02
+## v0.51 – 2026-05-03
 
 ### Feilrettinger
+- **Ferdighetstreet krevde maks stack i forrige tier for å gå videre (#135):** `isSkillUnlocked()` i `src/data/skills.js` krevde `_countSkill(hero, prevSkill.id) >= prevSkill.maxStack`, noe som med f.eks. Geolog T1 "Malmøye" (maxStack 3) tvang spilleren til å bruke tre ferdighetspunkter på samme ferdighet før T2 ble tilgjengelig. Betingelsen er endret til `>= 1`: ett punkt i forrige tier er nå nok til å låse opp neste tier, men man kan fortsatt stable for de ekstra bonusene
 - **Smelting av mineraler ga ikke alle forventede grunnstoffer (#138):** Sekundære yields i `MINERAL_DEFS` hadde for lave sjanser (0.3–0.5), slik at viktige grunnstoffer som C fra kalkstein, Fe fra ilmenitt og S fra pyritt uteble ved de fleste smeltinger. Alle ore-mineraler er gjennomgått: sjanser for elementer som er tydelig representert i mineralformelen er hevet til 0.7–1.0, mens rene sporstoff-yields (Ag i galena, alle PGM-yields) beholdes lave som tiltenkt "lotteri-belønning". Eksempler på nøkkelendringer:
   - Kalkstein (CaCO₃): C-sjanse 0.8 → **1.0**, lagt til O (0.7)
   - Olivin (Mg,Fe)₂SiO₄: Fe-sjanse 0.5 → **0.85**, Si-sjanse 0.3 → **0.7**, lagt til O (0.6)
@@ -19,6 +20,7 @@
   - 30+ øvrige mineraler: tilsvarende oppjusteringer av secondary yields
 
 ### Tekniske endringer
+- skills.js: `isSkillUnlocked()` — betingelse for tier-fremdrift endret fra `>= prevSkill.maxStack` til `>= 1`. Fil- og funksjonskommentarer oppdatert tilsvarende
 - minerals.js: Secondary yield-sjanser revidert for samtlige 45 ore-mineraler. Krystaller uendret (lave element-sjanser er tilsiktet da effektbonusen er primærverdien). PGM-ore og sporstoff-yields som Ag i galena beholdes uendret
 
 ---

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -1,7 +1,7 @@
 // ─── Labyrint Hero – Skill Tree ───────────────────────────────────────────────
 // Consolidated specialization paths, each with 3 tiers.
-// Tier 1 is always unlocked. Tier 2 requires T1 maxed from same path.
-// Tier 3 requires T2 maxed from same path.
+// Tier 1 is always unlocked. Tier 2 requires ≥1 stack in T1 from same path.
+// Tier 3 requires ≥1 stack in T2 from same path.
 // Each skill can generally be stacked 2–3× (maxStack), T3 skills only 1×.
 
 // ── Legacy skill migration ───────────────────────────────────────────────────
@@ -342,8 +342,8 @@ function _countSkill(hero, id) {
 /**
  * Check whether a skill slot in the tree is available to pick.
  *   tier 0 (T1) – always available (if not maxed)
- *   tier 1 (T2) – need T1 maxed from same path
- *   tier 2 (T3) – need T2 maxed from same path
+ *   tier 1 (T2) – need ≥1 stack in T1 from same path
+ *   tier 2 (T3) – need ≥1 stack in T2 from same path
  */
 function isSkillUnlocked(hero, pathIndex, tierIndex) {
     const path  = SKILL_TREE_PATHS[pathIndex];
@@ -369,9 +369,9 @@ function isSkillUnlocked(hero, pathIndex, tierIndex) {
 
     if (tierIndex === 0) return true;   // T1 always unlocked
 
-    // Needs previous tier to be fully maxed before advancing
+    // Needs at least 1 stack in the previous tier before advancing
     const prevSkill = path.tiers[tierIndex - 1];
-    return _countSkill(hero, prevSkill.id) >= prevSkill.maxStack;
+    return _countSkill(hero, prevSkill.id) >= 1;
 }
 
 /**


### PR DESCRIPTION
## Summary
Changed the skill tree tier unlock logic to require only 1 stack in the previous tier instead of requiring the previous tier to be fully maxed out. This makes skill progression more accessible while still maintaining a meaningful unlock requirement.

## Changes
- **`isSkillUnlocked()` logic**: Modified the condition for unlocking T2 and T3 tiers from `_countSkill(hero, prevSkill.id) >= prevSkill.maxStack` to `_countSkill(hero, prevSkill.id) >= 1`
- **Documentation updates**: Updated comments in `src/data/skills.js` to reflect the new requirement (≥1 stack instead of maxed tier)
- **Changelog**: Added entry documenting the fix for issue #135

## Details
Previously, players were forced to invest the maximum number of skill points into a tier 1 skill (e.g., 3 points for "Malmøye") before unlocking tier 2 skills in that path. Now, investing just 1 point in a tier is sufficient to unlock the next tier, while players can still choose to invest additional points for the bonus benefits.

This change improves the skill tree's accessibility and player agency without removing the progression gating entirely.

https://claude.ai/code/session_01ShpayQtNxJy93Ek3T3fDkG