### PR TITLE
Fix element filter row sorting and scrolling overlap issues

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ---
 
-## v0.51 – 2026-05-03
+## v0.51 – 2026-05-05
 
 ### Feilrettinger
-- **Ferdighetstreet krevde maks stack i forrige tier for å gå videre (#135):** `isSkillUnlocked()` i `src/data/skills.js` krevde `_countSkill(hero, prevSkill.id) >= prevSkill.maxStack`, noe som med f.eks. Geolog T1 "Malmøye" (maxStack 3) tvang spilleren til å bruke tre ferdighetspunkter på samme ferdighet før T2 ble tilgjengelig. Betingelsen er endret til `>= 1`: ett punkt i forrige tier er nå nok til å låse opp neste tier, men man kan fortsatt stable for de ekstra bonusene
 - **Smelting av mineraler ga ikke alle forventede grunnstoffer (#138):** Sekundære yields i `MINERAL_DEFS` hadde for lave sjanser (0.3–0.5), slik at viktige grunnstoffer som C fra kalkstein, Fe fra ilmenitt og S fra pyritt uteble ved de fleste smeltinger. Alle ore-mineraler er gjennomgått: sjanser for elementer som er tydelig representert i mineralformelen er hevet til 0.7–1.0, mens rene sporstoff-yields (Ag i galena, alle PGM-yields) beholdes lave som tiltenkt "lotteri-belønning". Eksempler på nøkkelendringer:
   - Kalkstein (CaCO₃): C-sjanse 0.8 → **1.0**, lagt til O (0.7)
   - Olivin (Mg,Fe)₂SiO₄: Fe-sjanse 0.5 → **0.85**, Si-sjanse 0.3 → **0.7**, lagt til O (0.6)
@@ -18,10 +17,13 @@
   - Kassiteritt (SnO₂): lagt til O (0.85)
   - Apatitt: Ca-sjanse 0.5 → **1.0**, lagt til O (0.7)
   - 30+ øvrige mineraler: tilsvarende oppjusteringer av secondary yields
+- **Ferdighetstreet krevde maks stack i forrige tier for å gå videre (#135):** `isSkillUnlocked()` i `src/data/skills.js` krevde `_countSkill(hero, prevSkill.id) >= prevSkill.maxStack`, noe som med f.eks. Geolog T1 "Malmøye" (maxStack 3) tvang spilleren til å bruke tre ferdighetspunkter på samme ferdighet før T2 ble tilgjengelig. Betingelsen er endret til `>= 1`: ett punkt i forrige tier er nå nok til å låse opp neste tier, men man kan fortsatt stable for de ekstra bonusene
+- **Smelteovn-filterrad: feil rekkefølge og overlapp ved scrolling (#141):** Grunnstoff-filterknappene øverst i Smelt/Legering/Smi-fanene var sortert etter Set-iterasjonsrekkefølge (ALLOY_DEFS-rekkefølge etterfulgt av oppdagede grunnstoffer), ikke etter atomnummer. Når raden brøt over flere linjer kunne rullbart innhold under scrolle opp og overlappe filterknappene visuelt fordi tab-innhold ble tegnet etter filteret og dermed lå høyere i z-order. Symbolene sorteres nå etter atomnummer (`ELEMENTS[symbol].atomicNumber`), og filterraden tegnes med en opak bakgrunns-cover på `setDepth(9)` med selve knappene på `setDepth(10)` slik at de alltid ligger over scrollet innhold
 
 ### Tekniske endringer
-- skills.js: `isSkillUnlocked()` — betingelse for tier-fremdrift endret fra `>= prevSkill.maxStack` til `>= 1`. Fil- og funksjonskommentarer oppdatert tilsvarende
 - minerals.js: Secondary yield-sjanser revidert for samtlige 45 ore-mineraler. Krystaller uendret (lave element-sjanser er tilsiktet da effektbonusen er primærverdien). PGM-ore og sporstoff-yields som Ag i galena beholdes uendret
+- skills.js: `isSkillUnlocked()` — betingelse for tier-fremdrift endret fra `>= prevSkill.maxStack` til `>= 1`. Fil- og funksjonskommentarer oppdatert tilsvarende
+- SmelteryScene.js: `_drawElementFilterRow()` konverterer `recipeElements`-Set til array og sorterer etter atomnummer før rendering. Bakgrunns-cover (Graphics) tegnes til slutt med `setDepth(9)`, og «Alle»-knapp + alle symbol-badges får `setDepth(10)` — uavhengig av om filteret tegnes før eller etter tab-innhold
 
 ---
 

--- a/src/scenes/SmelteryScene.js
+++ b/src/scenes/SmelteryScene.js
@@ -245,7 +245,8 @@ class SmelteryScene extends Phaser.Scene {
         const collected = hero.elementTracker.collected;
         const leftX = this.px + 10;
         const maxW = this.panelW - 40;
-        let y = this.contentY;
+        const filterStartY = this.contentY;
+        let y = filterStartY;
         let bx = leftX;
 
         // "Alle" reset button
@@ -269,7 +270,15 @@ class SmelteryScene extends Phaser.Scene {
             recipeElements.add(symbol);
         }
 
-        for (const symbol of recipeElements) {
+        // Sort by atomic number so the filter row follows periodic-table order
+        const sortedSymbols = Array.from(recipeElements).sort((a, b) => {
+            const an = (typeof ELEMENTS !== 'undefined' && ELEMENTS[a]) ? ELEMENTS[a].atomicNumber : 999;
+            const bn = (typeof ELEMENTS !== 'undefined' && ELEMENTS[b]) ? ELEMENTS[b].atomicNumber : 999;
+            return an - bn;
+        });
+
+        const badges = [];
+        for (const symbol of sortedSymbols) {
             const count = collected[symbol] || 0;
             const elem = typeof ELEMENTS !== 'undefined' ? ELEMENTS[symbol] : null;
             const col = elem ? elem.color : 0xaaaaaa;
@@ -290,11 +299,28 @@ class SmelteryScene extends Phaser.Scene {
                 this._scrollOffsets[this._tab] = 0;
                 this._refresh();
             });
+            badges.push(badge);
             bx += badge.width + 3;
             if (bx > leftX + maxW) { bx = leftX; y += 18; }
         }
 
         this.contentY = y + 22;
+
+        // Draw an opaque cover behind the filter row so scrolled content cannot
+        // bleed through it. The cover is drawn AFTER tab content in z-order
+        // because _drawElementFilterRow() is called last in _refresh() for
+        // smelt/alloy/forge tabs — keeping the filter always on top.
+        const coverH = this.contentY - filterStartY;
+        const cover = this._d(this.add.graphics());
+        cover.fillStyle(0x0a0608, 1.0);
+        cover.fillRect(this.px + 6, filterStartY, this.panelW - 12, coverH);
+        cover.lineStyle(1, 0x221100, 1.0);
+        cover.lineBetween(this.px + 6, filterStartY + coverH - 2, this.px + this.panelW - 6, filterStartY + coverH - 2);
+
+        // Raise all filter objects above the cover and above scrolled content
+        allBtn.setDepth(10);
+        for (const b of badges) b.setDepth(10);
+        cover.setDepth(9);
     }
 
     _drawLockedTab() {


### PR DESCRIPTION
## Summary
Fixed two issues in the Smeltery scene's element filter row: incorrect symbol ordering and visual overlap when tab content scrolls beneath the filter buttons.

## Key Changes
- **Symbol sorting:** Convert the `recipeElements` Set to an array and sort by atomic number (`ELEMENTS[symbol].atomicNumber`) instead of relying on Set iteration order, which was based on ALLOY_DEFS order followed by discovered elements
- **Z-order management:** Add an opaque background cover (Graphics object at `setDepth(9)`) behind the filter row to prevent scrolled content from bleeding through, with filter buttons (`setDepth(10)`) layered above it
- **Depth consistency:** Ensure the "Alle" reset button and all symbol badges are raised above both the cover and scrolled content, regardless of when `_drawElementFilterRow()` is called in the refresh cycle

## Implementation Details
- The cover is drawn after tab content in the rendering order but positioned at a lower depth, ensuring it always appears between scrolled content and filter buttons
- The sorting uses a fallback atomic number of 999 for elements not found in the ELEMENTS object, maintaining graceful degradation
- All filter UI elements are explicitly assigned `setDepth(10)` to guarantee they remain visible above any scrollable content

https://claude.ai/code/session_01ShpayQtNxJy93Ek3T3fDkG