### PR TITLE
PR1: UIHelper.attachHover/makeHoverButton + UITheme constants (#147, #148)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ---
 
+## v0.53 – 2026-05-07
+
+### Tekniske endringer
+- **UIHelper-utvidelse (#147):** Lagt til `UIHelper.attachHover()` og `UIHelper.makeHoverButton()` for å samle den gjentatte `pointerover`/`pointerout`/`pointerdown`-mønsteret som var duplisert 50+ ganger på tvers av scener. SmelteryScene (12 sites) og InventoryScene (3 sites) er migrert som første demonstrasjon. Resterende scener migreres inkrementelt
+- **UITheme-modul (#148):** Ny `src/utils/UITheme.js` med navngitte konstanter for `UI_COLORS`, `UI_TEXT` og `UI_FONTS`. Eksisterende kode bruker fremdeles inline hex-verdier; modulen er klar for inkrementell adopsjon i senere PR-er
+- Tester for `attachHover` lagt til i `tests/test-uihelper.js`
+
+---
+
 ## v0.52 – 2026-05-05
 
 ### Balanse

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
 <script src="src/utils/SaveManager.js"></script>
 <script src="src/utils/Leaderboard.js"></script>
 <script src="src/utils/GlobalLeaderboard.js"></script>
+<script src="src/utils/UITheme.js"></script>
 <script src="src/utils/UIHelper.js"></script>
 <script src="src/utils/EventBus.js"></script>
 

--- a/src/scenes/InventoryScene.js
+++ b/src/scenes/InventoryScene.js
@@ -61,13 +61,14 @@ class InventoryScene extends Phaser.Scene {
         const ebBtn = this.add.text(cx - panelW / 2 + 20, cy - panelH / 2 + 18, 'Elementbok [B]', {
             fontSize: '12px', color: '#997755', fontFamily: 'monospace'
         }).setOrigin(0, 0.5).setInteractive({ useHandCursor: true });
-        ebBtn.on('pointerover', () => ebBtn.setColor('#ccaa77'));
-        ebBtn.on('pointerout',  () => ebBtn.setColor('#997755'));
-        ebBtn.on('pointerdown', () => {
-            const gs = this.scene.get('GameScene');
-            if (gs && gs.hero) {
-                this.scene.launch('ElementBookScene', { heroRef: gs.hero });
-            }
+        UIHelper.attachHover(ebBtn, {
+            hoverColor: '#ccaa77', normalColor: '#997755',
+            onClick: () => {
+                const gs = this.scene.get('GameScene');
+                if (gs && gs.hero) {
+                    this.scene.launch('ElementBookScene', { heroRef: gs.hero });
+                }
+            },
         });
 
         // Mineral wiki button
@@ -75,20 +76,22 @@ class InventoryScene extends Phaser.Scene {
             cy - panelH / 2 + 18, 'Mineral-wiki', {
             fontSize: '12px', color: '#997755', fontFamily: 'monospace'
         }).setOrigin(0, 0.5).setInteractive({ useHandCursor: true });
-        mwBtn.on('pointerover', () => mwBtn.setColor('#ccaa77'));
-        mwBtn.on('pointerout',  () => mwBtn.setColor('#997755'));
-        mwBtn.on('pointerdown', () => {
-            const gs = this.scene.get('GameScene');
-            this.scene.launch('MineralWikiScene', { heroRef: gs?.hero || null });
+        UIHelper.attachHover(mwBtn, {
+            hoverColor: '#ccaa77', normalColor: '#997755',
+            onClick: () => {
+                const gs = this.scene.get('GameScene');
+                this.scene.launch('MineralWikiScene', { heroRef: gs?.hero || null });
+            },
         });
 
         // Close button (touch-friendly)
         const closeBtn = this.add.text(cx + panelW / 2 - 20, cy - panelH / 2 + 18, '✕', {
             fontSize: '20px', color: '#667788', fontFamily: 'monospace'
         }).setOrigin(0.5).setInteractive({ useHandCursor: true });
-        closeBtn.on('pointerover', () => closeBtn.setColor('#ff6666'));
-        closeBtn.on('pointerout',  () => closeBtn.setColor('#667788'));
-        closeBtn.on('pointerdown', () => this._tryClose());
+        UIHelper.attachHover(closeBtn, {
+            hoverColor: '#ff6666', normalColor: '#667788',
+            onClick: () => this._tryClose(),
+        });
 
         // ── Build dynamic slot UI ──────────────────────────────────────────────
         this._refresh();

--- a/src/scenes/SmelteryScene.js
+++ b/src/scenes/SmelteryScene.js
@@ -404,9 +404,10 @@ class SmelteryScene extends Phaser.Scene {
                 fontSize: '16px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
             }).setOrigin(1, 0).setInteractive({ useHandCursor: true }));
             const slotIdx = i;
-            btn.on('pointerover', () => btn.setColor('#ffaa44'));
-            btn.on('pointerout', () => btn.setColor('#ff7722'));
-            btn.on('pointerdown', () => this._depositItem(slotIdx));
+            UIHelper.attachHover(btn, {
+                hoverColor: '#ffaa44', normalColor: '#ff7722',
+                onClick: () => this._depositItem(slotIdx),
+            });
         }
         if (!hasDepositable) {
             const adjY = y - scrollOff;
@@ -474,9 +475,10 @@ class SmelteryScene extends Phaser.Scene {
                     fontSize: '16px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
                 }).setOrigin(1, 0).setInteractive({ useHandCursor: true }));
                 const idx = si;
-                btn.on('pointerover', () => btn.setColor('#ffaa44'));
-                btn.on('pointerout', () => btn.setColor('#ff7722'));
-                btn.on('pointerdown', () => this._withdrawItem(idx));
+                UIHelper.attachHover(btn, {
+                    hoverColor: '#ffaa44', normalColor: '#ff7722',
+                    onClick: () => this._withdrawItem(idx),
+                });
             }
         }
 
@@ -565,9 +567,10 @@ class SmelteryScene extends Phaser.Scene {
             const clearBtn = this._d(this.add.text(this.px + 110, y, '✕ Fjern filter', {
                 fontSize: '14px', color: '#886644', fontFamily: 'monospace'
             }).setInteractive({ useHandCursor: true }));
-            clearBtn.on('pointerover', () => clearBtn.setColor('#ffaa44'));
-            clearBtn.on('pointerout', () => clearBtn.setColor('#886644'));
-            clearBtn.on('pointerdown', () => { this._elementFilter = null; this._scrollOffsets.smelt = 0; this._refresh(); });
+            UIHelper.attachHover(clearBtn, {
+                hoverColor: '#ffaa44', normalColor: '#886644',
+                onClick: () => { this._elementFilter = null; this._scrollOffsets.smelt = 0; this._refresh(); },
+            });
             y += 20;
         }
 
@@ -675,13 +678,12 @@ class SmelteryScene extends Phaser.Scene {
                 const btn = this._d(this.add.text(startX + colW - 70, my + 14, '[ Smelt ]', {
                     fontSize: '15px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
                 }).setInteractive({ useHandCursor: true }));
-                btn.on('pointerover', () => btn.setColor('#ffaa44'));
-                btn.on('pointerout', () => btn.setColor('#ff7722'));
-                if (m.source === 'stash') {
-                    btn.on('pointerdown', () => this._doSmeltFromStash(m.slot, m.def));
-                } else {
-                    btn.on('pointerdown', () => this._doSmelt(m.slot, m.def));
-                }
+                UIHelper.attachHover(btn, {
+                    hoverColor: '#ffaa44', normalColor: '#ff7722',
+                    onClick: () => (m.source === 'stash')
+                        ? this._doSmeltFromStash(m.slot, m.def)
+                        : this._doSmelt(m.slot, m.def),
+                });
                 // Metallurg T1 max-stack: batch smelt button that processes up to batchSmeltSize
                 // at once. Only shown when hero has the batch capability and mineral count>1.
                 const batchN = hero.batchSmeltSize || 1;
@@ -690,8 +692,7 @@ class SmelteryScene extends Phaser.Scene {
                     const bbtn = this._d(this.add.text(startX + colW - 140, my + 14, label, {
                         fontSize: '14px', color: '#ffcc44', fontFamily: 'monospace', fontStyle: 'bold'
                     }).setInteractive({ useHandCursor: true }));
-                    bbtn.on('pointerover', () => bbtn.setColor('#ffee88'));
-                    bbtn.on('pointerout', () => bbtn.setColor('#ffcc44'));
+                    UIHelper.attachHover(bbtn, { hoverColor: '#ffee88', normalColor: '#ffcc44' });
                     bbtn.on('pointerdown', () => {
                         for (let i = 0; i < batchN; i++) {
                             // Re-read current count each iteration; stop if empty or out of fuel.
@@ -779,9 +780,10 @@ class SmelteryScene extends Phaser.Scene {
                     const btn = this._d(this.add.text(startX + colW - 100, adjY + 10, '[ Pyrolyse ]', {
                         fontSize: '13px', color: '#44aacc', fontFamily: 'monospace', fontStyle: 'bold'
                     }).setInteractive({ useHandCursor: true }));
-                    btn.on('pointerover', () => btn.setColor('#88ccee'));
-                    btn.on('pointerout', () => btn.setColor('#44aacc'));
-                    btn.on('pointerdown', () => this._doPyrolysis(pf));
+                    UIHelper.attachHover(btn, {
+                        hoverColor: '#88ccee', normalColor: '#44aacc',
+                        onClick: () => this._doPyrolysis(pf),
+                    });
                 }
             }
         }
@@ -938,9 +940,10 @@ class SmelteryScene extends Phaser.Scene {
                 const btn = this._d(this.add.text(startX + colW - 60, ay + 16, '[ Lag ]', {
                     fontSize: '15px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
                 }).setInteractive({ useHandCursor: true }));
-                btn.on('pointerover', () => btn.setColor('#ffaa44'));
-                btn.on('pointerout', () => btn.setColor('#ff7722'));
-                btn.on('pointerdown', () => this._doCraftAlloy(a.id));
+                UIHelper.attachHover(btn, {
+                    hoverColor: '#ffaa44', normalColor: '#ff7722',
+                    onClick: () => this._doCraftAlloy(a.id),
+                });
             }
         });
 
@@ -1003,9 +1006,10 @@ class SmelteryScene extends Phaser.Scene {
                 }));
                 if (eq && fuel >= 5) {
                     t.setInteractive({ useHandCursor: true });
-                    t.on('pointerover', () => t.setColor('#ffee88'));
-                    t.on('pointerout', () => t.setColor('#ffcc44'));
-                    t.on('pointerdown', () => this._doReforge(slot));
+                    UIHelper.attachHover(t, {
+                        hoverColor: '#ffee88', normalColor: '#ffcc44',
+                        onClick: () => this._doReforge(slot),
+                    });
                 }
             };
             makeBtn(0, 'weapon', 'Reforge våpen');
@@ -1068,9 +1072,11 @@ class SmelteryScene extends Phaser.Scene {
                 const btn = this._d(this.add.text(startX + colW - 70, adjY + 12, '[ Smi ]', {
                     fontSize: '14px', color: isPet ? '#ffaadd' : '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
                 }).setInteractive({ useHandCursor: true }));
-                btn.on('pointerover', () => btn.setColor(isPet ? '#ffccee' : '#ffaa44'));
-                btn.on('pointerout', () => btn.setColor(isPet ? '#ffaadd' : '#ff7722'));
-                btn.on('pointerdown', () => isPet ? this._doPetForge(alloyId, equip) : this._doForge(alloyId, equip.id));
+                UIHelper.attachHover(btn, {
+                    hoverColor:  isPet ? '#ffccee' : '#ffaa44',
+                    normalColor: isPet ? '#ffaadd' : '#ff7722',
+                    onClick: () => isPet ? this._doPetForge(alloyId, equip) : this._doForge(alloyId, equip.id),
+                });
             });
             rowY += 8;
         }
@@ -1232,8 +1238,7 @@ class SmelteryScene extends Phaser.Scene {
                 const btn = this._d(this.add.text(startX + colW - 70, ry + 10, '[ Raffiner ]', {
                     fontSize: '14px', color: '#8866ff', fontFamily: 'monospace', fontStyle: 'bold'
                 }).setInteractive({ useHandCursor: true }));
-                btn.on('pointerover', () => btn.setColor('#aa88ff'));
-                btn.on('pointerout', () => btn.setColor('#8866ff'));
+                UIHelper.attachHover(btn, { hoverColor: '#aa88ff', normalColor: '#8866ff' });
                 btn.on('pointerdown', () => {
                     const result = this.smelter.refine(recipe.id, hero);
                     if (result.success) {
@@ -1334,8 +1339,7 @@ class SmelteryScene extends Phaser.Scene {
                 const btn = this._d(this.add.text(startX + colW - 70, ry + 16, '[ Lag ]', {
                     fontSize: '14px', color: '#8866ff', fontFamily: 'monospace', fontStyle: 'bold'
                 }).setInteractive({ useHandCursor: true }));
-                btn.on('pointerover', () => btn.setColor('#aa88ff'));
-                btn.on('pointerout', () => btn.setColor('#8866ff'));
+                UIHelper.attachHover(btn, { hoverColor: '#aa88ff', normalColor: '#8866ff' });
                 btn.on('pointerdown', () => {
                     const result = this.smelter.craftSemiconductor(semi.id, hero);
                     if (result.success) {
@@ -1405,8 +1409,7 @@ class SmelteryScene extends Phaser.Scene {
                 const btn = this._d(this.add.text(startX + colW - 80, ty + 12, '[ Installer ]', {
                     fontSize: '14px', color: '#8866ff', fontFamily: 'monospace', fontStyle: 'bold'
                 }).setInteractive({ useHandCursor: true }));
-                btn.on('pointerover', () => btn.setColor('#aa88ff'));
-                btn.on('pointerout', () => btn.setColor('#8866ff'));
+                UIHelper.attachHover(btn, { hoverColor: '#aa88ff', normalColor: '#8866ff' });
                 btn.on('pointerdown', () => {
                     if (this.smelter.installTech(tech.id, hero)) {
                         EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `Installert: ${tech.name}!`, color: '#8866ff' });

--- a/src/utils/UIHelper.js
+++ b/src/utils/UIHelper.js
@@ -31,5 +31,38 @@ const UIHelper = {
      */
     colorToHex(col) {
         return '#' + (col || 0).toString(16).padStart(6, '0');
+    },
+
+    /**
+     * Attach hover/out/click handlers to an existing interactive game object.
+     * Idempotent re. interactive flag. Returns the target for chaining.
+     * @param {Phaser.GameObjects.GameObject} target
+     * @param {object} opts - { hoverColor, normalColor, onClick }
+     */
+    attachHover(target, { hoverColor, normalColor, onClick } = {}) {
+        if (!target.input) target.setInteractive({ useHandCursor: true });
+        if (hoverColor && target.setColor) {
+            target.on('pointerover', () => target.setColor(hoverColor));
+        }
+        if (normalColor && target.setColor) {
+            target.on('pointerout', () => target.setColor(normalColor));
+        }
+        if (typeof onClick === 'function') {
+            target.on('pointerdown', onClick);
+        }
+        return target;
+    },
+
+    /**
+     * Create a Phaser Text button with hover/out/click handlers wired up.
+     * @param {Phaser.Scene} scene
+     * @param {object} opts - { x, y, text, style, hoverColor, normalColor, onClick, origin }
+     * @returns {Phaser.GameObjects.Text}
+     */
+    makeHoverButton(scene, { x, y, text, style = {}, hoverColor, normalColor, onClick, origin }) {
+        const txt = scene.add.text(x, y, text, style);
+        if (origin) txt.setOrigin(origin.x ?? origin, origin.y ?? origin);
+        const normal = normalColor || style.color;
+        return UIHelper.attachHover(txt, { hoverColor, normalColor: normal, onClick });
     }
 };

--- a/src/utils/UITheme.js
+++ b/src/utils/UITheme.js
@@ -1,0 +1,50 @@
+// ─── Labyrint Hero – UI Theme ─────────────────────────────────────────────────
+// Shared visual constants for overlay scenes. Use these instead of inlining
+// hex literals so the look-and-feel can be tuned in one place.
+
+const UI_COLORS = {
+    // Panel backgrounds
+    panelBgDark:    0x0a0608,   // smeltery / forge
+    panelBgBlue:    0x0a0918,   // chem lab / accelerator
+    panelBgPurple:  0x1a1830,   // skill tree
+    panelBgAlpha:   0.82,
+    overlayDim:     0x000000,
+    overlayDimAlpha: 0.78,
+
+    // Accents (numeric, for Phaser fillStyle / Rectangle)
+    accentOrange:   0xff7722,
+    accentYellow:   0xffcc44,
+    accentBlue:     0x44aacc,
+    accentGreen:    0x44cc88,
+    accentRed:      0xcc4444,
+    accentPurple:   0x8866ff,
+    border:         0x44332a,
+    borderLight:    0x665544,
+};
+
+// CSS hex strings, for Phaser Text style.color
+const UI_TEXT = {
+    primary:    '#ff7722',
+    primaryHover: '#ffaa44',
+    secondary:  '#ffcc44',
+    secondaryHover: '#ffee88',
+    info:       '#44aacc',
+    infoHover:  '#88ccee',
+    success:    '#44cc88',
+    danger:     '#cc4444',
+    muted:      '#667788',
+    mutedDim:   '#556677',
+    label:      '#887766',
+    disabled:   '#445566',
+    white:      '#ffffff',
+};
+
+const UI_FONTS = {
+    family:     'monospace',
+    title:      '20px',
+    heading:    '18px',
+    label:      '14px',
+    body:       '13px',
+    small:      '12px',
+    tiny:       '11px',
+};

--- a/tests/test-runner.html
+++ b/tests/test-runner.html
@@ -23,6 +23,7 @@
 <script src="../src/constants.js"></script>
 <script src="../src/maze.js"></script>
 <script src="../src/utils/SaveManager.js"></script>
+<script src="../src/utils/UITheme.js"></script>
 <script src="../src/utils/UIHelper.js"></script>
 <script src="../src/data/skills.js"></script>
 <script src="../src/data/elements.js"></script>

--- a/tests/test-uihelper.js
+++ b/tests/test-uihelper.js
@@ -38,6 +38,42 @@ describe('UIHelper – colorToHex', () => {
     });
 });
 
+describe('UIHelper – attachHover', () => {
+    function fakeText(initialColor) {
+        return {
+            input: null,
+            _color: initialColor,
+            _handlers: {},
+            setInteractive() { this.input = {}; return this; },
+            setColor(c) { this._color = c; return this; },
+            on(evt, fn) { this._handlers[evt] = fn; return this; },
+            fire(evt) { if (this._handlers[evt]) this._handlers[evt](); }
+        };
+    }
+
+    it('makes target interactive and wires hover/out/click', () => {
+        const t = fakeText('#ff7722');
+        let clicks = 0;
+        UIHelper.attachHover(t, {
+            hoverColor: '#ffaa44',
+            normalColor: '#ff7722',
+            onClick: () => clicks++,
+        });
+        expect(t.input).not.toBe(null);
+        t.fire('pointerover'); expect(t._color).toBe('#ffaa44');
+        t.fire('pointerout');  expect(t._color).toBe('#ff7722');
+        t.fire('pointerdown'); expect(clicks).toBe(1);
+    });
+
+    it('skips hover handlers when colors not provided', () => {
+        const t = fakeText('#ff7722');
+        UIHelper.attachHover(t, { onClick: () => {} });
+        expect(t._handlers.pointerover).toBe(undefined);
+        expect(t._handlers.pointerout).toBe(undefined);
+        expect(typeof t._handlers.pointerdown).toBe('function');
+    });
+});
+
 describe('UIHelper – updateTabButtons', () => {
     it('sets active button color and bold style', () => {
         const buttons = [

--- a/tests/test-uihelper.js
+++ b/tests/test-uihelper.js
@@ -59,7 +59,7 @@ describe('UIHelper – attachHover', () => {
             normalColor: '#ff7722',
             onClick: () => clicks++,
         });
-        expect(t.input).not.toBe(null);
+        expect(t.input !== null).toBe(true);
         t.fire('pointerover'); expect(t._color).toBe('#ffaa44');
         t.fire('pointerout');  expect(t._color).toBe('#ff7722');
         t.fire('pointerdown'); expect(clicks).toBe(1);


### PR DESCRIPTION
Closes #147. Lays the foundation for #148 (kept open for the broader migration).

## Summary
- New `UIHelper.attachHover()` and `UIHelper.makeHoverButton()` collapse the 3-line `pointerover`/`pointerout`/`pointerdown` pattern that was duplicated 50+ times across scenes.
- Migrated 15 call sites: 12 in `SmelteryScene.js` (stash, smelt, alloy, forge, refine, semi, tech tabs) and 3 in `InventoryScene.js` (Elementbok / Mineral-wiki / close buttons).
- Sites with multi-line tooltip handlers are intentionally left untouched — they'll be addressed by the upcoming TooltipManager (#151).
- New `src/utils/UITheme.js` with `UI_COLORS`, `UI_TEXT`, `UI_FONTS` constants. This is foundational; existing scenes still inline hex values. #148 remains open for the full migration in follow-up PRs.
- Added unit tests for `attachHover`.

## Test plan
- [x] `node --check` passes for all source files
- [ ] Open `tests/test-runner.html` in a browser → all suites green (UIHelper tests now include `attachHover` cases)
- [ ] Open `index.html`, enter Smeltery → exercise stash deposit/withdraw, smelt button, alloy/forge/refine/semi/tech buttons; hover colors should swap as before
- [ ] Open Inventory → Elementbok, Mineral-wiki, close button hover/click still work

https://claude.ai/code/session_01UBNPFro5RLpyaXmg3mw7ER

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBNPFro5RLpyaXmg3mw7ER)_