### PR TITLE
PR2: TooltipManager + InventoryScene slot dedupe (#146, #151)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,9 @@
 ### Tekniske endringer
 - **UIHelper-utvidelse (#147):** Lagt til `UIHelper.attachHover()` og `UIHelper.makeHoverButton()` for å samle den gjentatte `pointerover`/`pointerout`/`pointerdown`-mønsteret som var duplisert 50+ ganger på tvers av scener. SmelteryScene (12 sites) og InventoryScene (3 sites) er migrert som første demonstrasjon. Resterende scener migreres inkrementelt
 - **UITheme-modul (#148):** Ny `src/utils/UITheme.js` med navngitte konstanter for `UI_COLORS`, `UI_TEXT` og `UI_FONTS`. Eksisterende kode bruker fremdeles inline hex-verdier; modulen er klar for inkrementell adopsjon i senere PR-er
-- Tester for `attachHover` lagt til i `tests/test-uihelper.js`
+- **TooltipManager (#151):** Ny `src/utils/TooltipManager.js` som eier én tooltip per scene, automatisk avbryter forrige tooltip ved ny `show()` og rydder opp på `scene.shutdown`. Fjerner risikoen for foreldreløse Phaser.Text-objekter etter rask hover eller scene-lukking. InventoryScene og SmelteryScene migrert
+- **Inventar-slot dedup (#146):** `InventoryScene._makeEquipSlot`/`_makeQuickUseSlot`/`_makeBackpackSlot`/`_makePetBackpackSlot` brukte tilnærmet identisk long-press- og pointer-håndtering. Felles helper `_attachSlotInteraction(bg, opts)` introdusert; ~80 linjer duplisering fjernet (InventoryScene 781 → 736 linjer)
+- Tester for `attachHover` og `TooltipManager` lagt til i `tests/`
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
 <script src="src/utils/GlobalLeaderboard.js"></script>
 <script src="src/utils/UITheme.js"></script>
 <script src="src/utils/UIHelper.js"></script>
+<script src="src/utils/TooltipManager.js"></script>
 <script src="src/utils/EventBus.js"></script>
 
 <!-- Data -->

--- a/src/scenes/InventoryScene.js
+++ b/src/scenes/InventoryScene.js
@@ -14,6 +14,7 @@ class InventoryScene extends Phaser.Scene {
         this.pet  = gs.pet;
 
         this._dyn = [];  // dynamic objects – destroyed on _refresh()
+        this.tooltips = new TooltipManager(this);
 
         // ── Static background & title ──────────────────────────────────────────
         const cx = W / 2, cy = H / 2;
@@ -234,34 +235,17 @@ class InventoryScene extends Phaser.Scene {
                 fontSize: '11px', color: this._rarityTextColor(item), fontFamily: 'monospace'
             }).setOrigin(0.5));
 
-            bg.setInteractive({ useHandCursor: true });
-            bg.on('pointerdown', (pointer) => {
-                if (pointer.rightButtonDown()) {
-                    const dropped = this.inv.dropEquipped(slot, this.hero);
-                    if (dropped) EventBus.emit('spawnItem', { gx: this.hero.gridX, gy: this.hero.gridY, item: dropped });
-                    this._refresh();
-                    return;
-                }
-                // Long-press (touch) = drop, short tap = unequip
-                bg._lpTimer = this.time.delayedCall(500, () => {
-                    bg._lpTimer = null;
-                    const dropped = this.inv.dropEquipped(slot, this.hero);
-                    if (dropped) EventBus.emit('spawnItem', { gx: this.hero.gridX, gy: this.hero.gridY, item: dropped });
-                    this._refresh();
-                });
-            });
-            bg.on('pointerup', () => {
-                if (bg._lpTimer) {
-                    bg._lpTimer.remove();
-                    bg._lpTimer = null;
-                    this.inv.unequip(slot, this.hero);
-                    this._refresh();
-                }
-            });
-            bg.on('pointerover', () => { bg.setFillStyle(0x1a1830); this._showTooltip(x, y - size/2 - 20, item); });
-            bg.on('pointerout',  () => {
-                bg.setFillStyle(0x0a0918); this._hideTooltip();
-                if (bg._lpTimer) { bg._lpTimer.remove(); bg._lpTimer = null; }
+            const dropEquipped = () => {
+                const dropped = this.inv.dropEquipped(slot, this.hero);
+                if (dropped) EventBus.emit('spawnItem', { gx: this.hero.gridX, gy: this.hero.gridY, item: dropped });
+                this._refresh();
+            };
+            this._attachSlotInteraction(bg, {
+                hoverFill: 0x1a1830, normalFill: 0x0a0918,
+                tooltipItem: item, tooltipPos: { x, y: y - size/2 - 20 },
+                onTap: () => { this.inv.unequip(slot, this.hero); this._refresh(); },
+                onLongPress: dropEquipped,
+                onRightClick: dropEquipped,
             });
         } else {
             this._d(this.add.text(x, y, 'Tom', {
@@ -300,34 +284,17 @@ class InventoryScene extends Phaser.Scene {
                 fontSize: '11px', color: '#ccddff', fontFamily: 'monospace'
             }).setOrigin(0.5));
 
-            bg.setInteractive({ useHandCursor: true });
-            bg.on('pointerdown', (pointer) => {
-                if (pointer.rightButtonDown()) {
-                    const dropped = this.inv.dropQuickUse();
-                    if (dropped) EventBus.emit('spawnItem', { gx: this.hero.gridX, gy: this.hero.gridY, item: dropped });
-                    this._refresh();
-                    return;
-                }
-                bg._lpTimer = this.time.delayedCall(500, () => {
-                    bg._lpTimer = null;
-                    const dropped = this.inv.dropQuickUse();
-                    if (dropped) EventBus.emit('spawnItem', { gx: this.hero.gridX, gy: this.hero.gridY, item: dropped });
-                    this._refresh();
-                });
-            });
-            bg.on('pointerup', () => {
-                if (bg._lpTimer) {
-                    bg._lpTimer.remove();
-                    bg._lpTimer = null;
-                    // Tap: unequip back to backpack
-                    this.inv.unequipQuickUse();
-                    this._refresh();
-                }
-            });
-            bg.on('pointerover', () => { bg.setFillStyle(0x1a1830); this._showTooltip(x, y - size/2 - 20, itemDef); });
-            bg.on('pointerout',  () => {
-                bg.setFillStyle(0x0a0918); this._hideTooltip();
-                if (bg._lpTimer) { bg._lpTimer.remove(); bg._lpTimer = null; }
+            const dropQuick = () => {
+                const dropped = this.inv.dropQuickUse();
+                if (dropped) EventBus.emit('spawnItem', { gx: this.hero.gridX, gy: this.hero.gridY, item: dropped });
+                this._refresh();
+            };
+            this._attachSlotInteraction(bg, {
+                hoverFill: 0x1a1830, normalFill: 0x0a0918,
+                tooltipItem: itemDef, tooltipPos: { x, y: y - size/2 - 20 },
+                onTap: () => { this.inv.unequipQuickUse(); this._refresh(); },
+                onLongPress: dropQuick,
+                onRightClick: dropQuick,
             });
         } else {
             this._d(this.add.text(x, y, 'Tom', {
@@ -375,50 +342,23 @@ class InventoryScene extends Phaser.Scene {
                 }).setOrigin(1, 0));
             }
 
-            bg.setInteractive({ useHandCursor: true });
-            bg.on('pointerover', () => {
-                bg.setFillStyle(0x1a2030);
-                const tip = count > 1 ? { ...itemDef, name: `${itemDef.name} ×${count}` } : itemDef;
-                this._showTooltip(x, y - size / 2 - 4, tip);
-            });
-            bg.on('pointerout', () => {
-                bg.setFillStyle(0x0a0918);
-                this._hideTooltip();
-            });
-            bg.on('pointerdown', (pointer) => {
-                this._hideTooltip();
-                if (pointer.rightButtonDown()) {
-                    // Right-click: move to pet if possible, otherwise drop
-                    const item = this.inv._getItemDef(this.inv.backpack[index]);
-                    if (item && this.pet && this.pet.alive && this.pet.addItem(item)) {
-                        this.inv.dropSlot(index);
-                    } else {
-                        const dropped = this.inv.dropSlot(index);
-                        if (dropped) EventBus.emit('spawnItem', { gx: this.hero.gridX, gy: this.hero.gridY, item: dropped });
-                    }
-                    this._refresh();
-                    return;
+            const moveToPetOrDrop = () => {
+                const item = this.inv._getItemDef(this.inv.backpack[index]);
+                if (item && this.pet && this.pet.alive && this.pet.addItem(item)) {
+                    this.inv.dropSlot(index);
+                } else {
+                    const dropped = this.inv.dropSlot(index);
+                    if (dropped) EventBus.emit('spawnItem', { gx: this.hero.gridX, gy: this.hero.gridY, item: dropped });
                 }
-                bg._lpTimer = this.time.delayedCall(500, () => {
-                    bg._lpTimer = null;
-                    // Long press: move to pet if possible, otherwise drop
-                    const item = this.inv._getItemDef(this.inv.backpack[index]);
-                    if (item && this.pet && this.pet.alive && this.pet.addItem(item)) {
-                        this.inv.dropSlot(index);
-                    } else {
-                        const dropped = this.inv.dropSlot(index);
-                        if (dropped) EventBus.emit('spawnItem', { gx: this.hero.gridX, gy: this.hero.gridY, item: dropped });
-                    }
-                    this._refresh();
-                });
-            });
-            bg.on('pointerup', () => {
-                if (bg._lpTimer) {
-                    bg._lpTimer.remove();
-                    bg._lpTimer = null;
-                    this.inv.useSlot(index, this.hero);
-                    this._refresh();
-                }
+                this._refresh();
+            };
+            const tipItem = count > 1 ? { ...itemDef, name: `${itemDef.name} ×${count}` } : itemDef;
+            this._attachSlotInteraction(bg, {
+                hoverFill: 0x1a2030, normalFill: 0x0a0918,
+                tooltipItem: tipItem, tooltipPos: { x, y: y - size / 2 - 4 },
+                onTap: () => { this.inv.useSlot(index, this.hero); this._refresh(); },
+                onLongPress: moveToPetOrDrop,
+                onRightClick: moveToPetOrDrop,
             });
         }
     }
@@ -511,43 +451,22 @@ class InventoryScene extends Phaser.Scene {
                 }).setOrigin(1, 0));
             }
 
-            bg.setInteractive({ useHandCursor: true });
-            bg.on('pointerover', () => {
-                bg.setFillStyle(0x1a1830);
-                const tip = count > 1 ? { ...itemDef, name: `${itemDef.name} ×${count}` } : itemDef;
-                this._showTooltip(x, y - size / 2 - 4, tip);
-            });
-            bg.on('pointerout', () => {
-                bg.setFillStyle(0x120a18);
-                this._hideTooltip();
-            });
-            bg.on('pointerdown', (pointer) => {
-                this._hideTooltip();
-                if (pointer.rightButtonDown()) {
-                    // Drop from pet backpack to ground
-                    const dropped = pet.dropSlot(index);
-                    if (dropped) EventBus.emit('spawnItem', { gx: this.hero.gridX, gy: this.hero.gridY, item: dropped });
-                    this._refresh();
-                    return;
-                }
-                bg._lpTimer = this.time.delayedCall(500, () => {
-                    bg._lpTimer = null;
-                    const dropped = pet.dropSlot(index);
-                    if (dropped) EventBus.emit('spawnItem', { gx: this.hero.gridX, gy: this.hero.gridY, item: dropped });
-                    this._refresh();
-                });
-            });
-            bg.on('pointerup', () => {
-                if (bg._lpTimer) {
-                    bg._lpTimer.remove();
-                    bg._lpTimer = null;
-                    // Tap: move item from pet to hero backpack
+            const dropPetSlot = () => {
+                const dropped = pet.dropSlot(index);
+                if (dropped) EventBus.emit('spawnItem', { gx: this.hero.gridX, gy: this.hero.gridY, item: dropped });
+                this._refresh();
+            };
+            const tipItem = count > 1 ? { ...itemDef, name: `${itemDef.name} ×${count}` } : itemDef;
+            this._attachSlotInteraction(bg, {
+                hoverFill: 0x1a1830, normalFill: 0x120a18,
+                tooltipItem: tipItem, tooltipPos: { x, y: y - size / 2 - 4 },
+                onTap: () => {
                     const item = pet.getItemDef(pet.backpack[index]);
-                    if (item && this.inv.addItem(item)) {
-                        pet.dropSlot(index);
-                    }
+                    if (item && this.inv.addItem(item)) pet.dropSlot(index);
                     this._refresh();
-                }
+                },
+                onLongPress: dropPetSlot,
+                onRightClick: dropPetSlot,
             });
         } else {
             // Empty slot: allow moving from hero to pet by checking if hero inventory is the source
@@ -740,32 +659,65 @@ class InventoryScene extends Phaser.Scene {
     }
 
     _showTooltip(x, y, item) {
-        this._hideTooltip();
-        const { width: W, height: H } = this.cameras.main;
         const rarDef = item.rarity ? RARITY_BY_ID[item.rarity] : null;
         const rarTag = (rarDef && item.rarity !== 'common') ? `[${rarDef.label}]  ` : '';
         const dispName = (item.type === 'mineral' && typeof getMineralDisplayName !== 'undefined')
             ? getMineralDisplayName(item, this.hero) : item.name;
         const dispDesc = (item.type === 'mineral' && (this.hero.mineralIdentifyLevel || 0) <= 0)
             ? '' : (item.desc || '');
-        const lines = [rarTag + dispName, dispDesc];
-        const txtCol = this._rarityTextColor(item);
-        this._tooltip = this.add.text(x, y, lines.join('\n'), {
-            fontSize: '12px', color: txtCol, fontFamily: 'monospace',
-            backgroundColor: '#0a0918', padding: { x: 6, y: 4 },
-            stroke: '#334466', strokeThickness: 1,
-            wordWrap: { width: 300 }
-        }).setOrigin(0.5, 1).setDepth(30);
-
-        // Clamp tooltip within viewport
-        const b = this._tooltip.getBounds();
-        if (b.left < 4) this._tooltip.setX(x + (4 - b.left));
-        if (b.right > W - 4) this._tooltip.setX(x - (b.right - W + 4));
-        if (b.top < 4) this._tooltip.setOrigin(0.5, 0).setY(y + 8);
+        const text = [rarTag + dispName, dispDesc].join('\n');
+        this.tooltips.show(x, y, text, { color: this._rarityTextColor(item) });
     }
 
     _hideTooltip() {
-        if (this._tooltip) { this._tooltip.destroy(); this._tooltip = null; }
+        this.tooltips.hide();
+    }
+
+    /**
+     * Shared interactive slot handler. Wires up:
+     *  - hover/out (with tooltip if `tooltipItem` provided)
+     *  - long-press (500ms) → onLongPress
+     *  - tap (pointerup before timer) → onTap
+     *  - right-click (immediate) → onRightClick
+     * Caller passes the bg rectangle and color callbacks/handlers.
+     */
+    _attachSlotInteraction(bg, opts) {
+        const {
+            hoverFill, normalFill,
+            tooltipItem, tooltipPos,
+            onTap, onLongPress, onRightClick,
+        } = opts;
+        bg.setInteractive({ useHandCursor: true });
+
+        bg.on('pointerover', () => {
+            if (hoverFill !== undefined) bg.setFillStyle(hoverFill);
+            if (tooltipItem) this._showTooltip(tooltipPos.x, tooltipPos.y, tooltipItem);
+        });
+        bg.on('pointerout', () => {
+            if (normalFill !== undefined) bg.setFillStyle(normalFill);
+            if (tooltipItem) this._hideTooltip();
+            if (bg._lpTimer) { bg._lpTimer.remove(); bg._lpTimer = null; }
+        });
+        bg.on('pointerdown', (pointer) => {
+            this._hideTooltip();
+            if (pointer.rightButtonDown && pointer.rightButtonDown()) {
+                if (onRightClick) onRightClick();
+                return;
+            }
+            if (onLongPress) {
+                bg._lpTimer = this.time.delayedCall(500, () => {
+                    bg._lpTimer = null;
+                    onLongPress();
+                });
+            }
+        });
+        bg.on('pointerup', () => {
+            if (bg._lpTimer) {
+                bg._lpTimer.remove();
+                bg._lpTimer = null;
+                if (onTap) onTap();
+            }
+        });
     }
 
     _shortName(name) {

--- a/src/scenes/SmelteryScene.js
+++ b/src/scenes/SmelteryScene.js
@@ -15,6 +15,7 @@ class SmelteryScene extends Phaser.Scene {
         const cx = W / 2, cy = H / 2;
         this.smelter = new SmeltingSystem();
         this._dyn = [];
+        this.tooltips = new TooltipManager(this);
         this._tab = 'stash'; // 'stash' | 'smelt' | 'alloy' | 'forge'
 
         // ── Dim overlay ───────────────────────────────────────────────────────
@@ -389,15 +390,12 @@ class SmelteryScene extends Phaser.Scene {
             if (def.type === 'mineral' && def.yields) {
                 const yieldStr = def.yields.map(y => y.symbol).join(', ');
                 nameText.on('pointerover', () => {
-                    if (this._mineralTooltip) this._mineralTooltip.destroy();
-                    this._mineralTooltip = this._d(this.add.text(leftX + 4, adjY - 18, `T${def.tier} → ${yieldStr}`, {
-                        fontSize: '12px', color: '#bbaa88', fontFamily: 'monospace',
-                        backgroundColor: '#0a0608', padding: { x: 4, y: 2 }
-                    }));
+                    this.tooltips.show(leftX + 4, adjY - 18, `T${def.tier} → ${yieldStr}`, {
+                        color: '#bbaa88', backgroundColor: '#0a0608',
+                        padding: { x: 4, y: 2 }, stroke: '', strokeThickness: 0,
+                    }, { origin: { x: 0, y: 1 }, clampToCamera: false });
                 });
-                nameText.on('pointerout', () => {
-                    if (this._mineralTooltip) { this._mineralTooltip.destroy(); this._mineralTooltip = null; }
-                });
+                nameText.on('pointerout', () => this.tooltips.hide());
             }
 
             const btn = this._d(this.add.text(leftX + colW - 10, adjY, '→', {
@@ -460,15 +458,12 @@ class SmelteryScene extends Phaser.Scene {
                 if (def && def.type === 'mineral' && def.yields) {
                     const yieldStr = def.yields.map(y => y.symbol).join(', ');
                     stText.on('pointerover', () => {
-                        if (this._mineralTooltip) this._mineralTooltip.destroy();
-                        this._mineralTooltip = this._d(this.add.text(rightX + 4, adjY - 18, `T${def.tier} → ${yieldStr}`, {
-                            fontSize: '12px', color: '#bbaa88', fontFamily: 'monospace',
-                            backgroundColor: '#0a0608', padding: { x: 4, y: 2 }
-                        }));
+                        this.tooltips.show(rightX + 4, adjY - 18, `T${def.tier} → ${yieldStr}`, {
+                            color: '#bbaa88', backgroundColor: '#0a0608',
+                            padding: { x: 4, y: 2 }, stroke: '', strokeThickness: 0,
+                        }, { origin: { x: 0, y: 1 }, clampToCamera: false });
                     });
-                    stText.on('pointerout', () => {
-                        if (this._mineralTooltip) { this._mineralTooltip.destroy(); this._mineralTooltip = null; }
-                    });
+                    stText.on('pointerout', () => this.tooltips.hide());
                 }
 
                 const btn = this._d(this.add.text(rightX + colW - 10, adjY, '←', {
@@ -1471,21 +1466,17 @@ class SmelteryScene extends Phaser.Scene {
             const sym = symbol;
             badge.on('pointerover', () => {
                 badge.setBackgroundColor('#221100');
-                // Show mineral sources as tooltip-style text
                 const srcList = sources[sym];
                 if (srcList && srcList.length > 0) {
-                    this._tooltipText = this._d(this.add.text(startX, by + 24, `${sym} ← ${srcList.join(', ')}`, {
-                        fontSize: '12px', color: '#998877', fontFamily: 'monospace',
-                        backgroundColor: '#0a0608', padding: { x: 4, y: 2 }
-                    }));
+                    this.tooltips.show(startX, by + 24, `${sym} ← ${srcList.join(', ')}`, {
+                        color: '#998877', backgroundColor: '#0a0608',
+                        padding: { x: 4, y: 2 }, stroke: '', strokeThickness: 0,
+                    }, { origin: { x: 0, y: 0 }, clampToCamera: false });
                 }
             });
             badge.on('pointerout', () => {
                 badge.setBackgroundColor(isActive ? '#442200' : '#0a0818');
-                if (this._tooltipText) {
-                    this._tooltipText.destroy();
-                    this._tooltipText = null;
-                }
+                this.tooltips.hide();
             });
             badge.on('pointerdown', () => {
                 this._elementFilter = this._elementFilter === sym ? null : sym;

--- a/src/utils/TooltipManager.js
+++ b/src/utils/TooltipManager.js
@@ -1,0 +1,73 @@
+// ─── Labyrint Hero – TooltipManager ──────────────────────────────────────────
+// Owns a single tooltip Text per scene. Auto-cancels the previous tooltip
+// when a new one is shown, and auto-cleans on scene shutdown to prevent
+// orphaned text objects after rapid hover or scene close.
+//
+// Usage:
+//   this.tooltips = new TooltipManager(this);
+//   this.tooltips.show(x, y, 'Hello', { color: '#fff' });
+//   this.tooltips.hide();
+//
+// All styles default to the standard panel-tooltip look.
+
+class TooltipManager {
+    constructor(scene) {
+        this.scene = scene;
+        this._tip = null;
+        this._defaultStyle = {
+            fontSize: '12px',
+            fontFamily: 'monospace',
+            color: '#ccddff',
+            backgroundColor: '#0a0918',
+            padding: { x: 6, y: 4 },
+            stroke: '#334466',
+            strokeThickness: 1,
+            wordWrap: { width: 300 },
+        };
+        // Auto-cleanup on scene shutdown.
+        scene.events.once('shutdown', () => this.destroy());
+        scene.events.once('destroy',  () => this.destroy());
+    }
+
+    /**
+     * Show a tooltip at (x, y). Replaces any current tooltip.
+     * @param {number} x
+     * @param {number} y
+     * @param {string} text
+     * @param {object} styleOverrides - merged into default style
+     * @param {object} opts - { origin: {x,y}, depth, clampToCamera }
+     */
+    show(x, y, text, styleOverrides = {}, opts = {}) {
+        this.hide();
+        const style = { ...this._defaultStyle, ...styleOverrides };
+        const tip = this.scene.add.text(x, y, text, style);
+        const origin = opts.origin || { x: 0.5, y: 1 };
+        tip.setOrigin(origin.x, origin.y);
+        tip.setDepth(opts.depth ?? 30);
+
+        if (opts.clampToCamera !== false) {
+            const cam = this.scene.cameras.main;
+            const b = tip.getBounds();
+            if (b.left  < 4)            tip.setX(x + (4 - b.left));
+            if (b.right > cam.width - 4) tip.setX(x - (b.right - cam.width + 4));
+            if (b.top   < 4)            tip.setOrigin(origin.x, 0).setY(y + 8);
+        }
+
+        this._tip = tip;
+        return tip;
+    }
+
+    /** Hide the current tooltip if any. Idempotent. */
+    hide() {
+        if (this._tip) {
+            this._tip.destroy();
+            this._tip = null;
+        }
+    }
+
+    /** Tear down. Called automatically on scene shutdown. */
+    destroy() {
+        this.hide();
+        this.scene = null;
+    }
+}

--- a/tests/test-runner.html
+++ b/tests/test-runner.html
@@ -25,6 +25,7 @@
 <script src="../src/utils/SaveManager.js"></script>
 <script src="../src/utils/UITheme.js"></script>
 <script src="../src/utils/UIHelper.js"></script>
+<script src="../src/utils/TooltipManager.js"></script>
 <script src="../src/data/skills.js"></script>
 <script src="../src/data/elements.js"></script>
 <script src="../src/data/minerals.js"></script>
@@ -72,6 +73,7 @@
 <script src="test-maze.js"></script>
 <script src="test-smelting.js"></script>
 <script src="test-uihelper.js"></script>
+<script src="test-tooltip-manager.js"></script>
 <script src="test-hero.js"></script>
 <script src="test-eventbus.js"></script>
 <script src="test-chemistry.js"></script>

--- a/tests/test-tooltip-manager.js
+++ b/tests/test-tooltip-manager.js
@@ -1,0 +1,82 @@
+// ─── TooltipManager Tests ────────────────────────────────────────────────────
+
+function fakeScene() {
+    const tips = [];
+    const events = {};
+    return {
+        _tips: tips,
+        cameras: { main: { width: 800, height: 600 } },
+        add: {
+            text(x, y, t, style) {
+                const obj = {
+                    x, y, t, style,
+                    _depth: 0, _origin: { x: 0, y: 0 },
+                    destroyed: false,
+                    setOrigin(ox, oy) { this._origin = { x: ox, y: oy }; return this; },
+                    setDepth(d) { this._depth = d; return this; },
+                    setX(v) { this.x = v; return this; },
+                    setY(v) { this.y = v; return this; },
+                    getBounds() {
+                        return { left: this.x - 50, right: this.x + 50, top: this.y - 20, bottom: this.y };
+                    },
+                    destroy() { this.destroyed = true; },
+                };
+                tips.push(obj);
+                return obj;
+            }
+        },
+        events: {
+            once(name, fn) { events[name] = fn; },
+            _fire(name) { if (events[name]) events[name](); }
+        },
+    };
+}
+
+describe('TooltipManager – show/hide', () => {
+    it('creates a tooltip text on show', () => {
+        const s = fakeScene();
+        const tm = new TooltipManager(s);
+        tm.show(100, 100, 'Hi');
+        expect(s._tips.length).toBe(1);
+        expect(s._tips[0].t).toBe('Hi');
+        expect(s._tips[0].destroyed).toBe(false);
+    });
+
+    it('replaces previous tooltip on consecutive show', () => {
+        const s = fakeScene();
+        const tm = new TooltipManager(s);
+        tm.show(100, 100, 'first');
+        tm.show(200, 200, 'second');
+        expect(s._tips.length).toBe(2);
+        expect(s._tips[0].destroyed).toBe(true);
+        expect(s._tips[1].destroyed).toBe(false);
+    });
+
+    it('hide() destroys the active tooltip', () => {
+        const s = fakeScene();
+        const tm = new TooltipManager(s);
+        tm.show(100, 100, 'x');
+        tm.hide();
+        expect(s._tips[0].destroyed).toBe(true);
+    });
+
+    it('hide() is idempotent', () => {
+        const s = fakeScene();
+        const tm = new TooltipManager(s);
+        tm.hide();  // no-op
+        tm.show(100, 100, 'x');
+        tm.hide();
+        tm.hide();  // again
+        expect(s._tips[0].destroyed).toBe(true);
+    });
+});
+
+describe('TooltipManager – auto-cleanup', () => {
+    it('destroys active tooltip on scene shutdown', () => {
+        const s = fakeScene();
+        const tm = new TooltipManager(s);
+        tm.show(50, 50, 'foo');
+        s.events._fire('shutdown');
+        expect(s._tips[0].destroyed).toBe(true);
+    });
+});


### PR DESCRIPTION
**Stacked on PR #154** (PR1). Merge that first, then retarget this to `main`.

Closes #146, closes #151.

## Summary
- **TooltipManager** (`src/utils/TooltipManager.js`): single tooltip per scene, auto-cancels on consecutive `show()`, auto-cleans on `scene.shutdown` / `destroy`. Fixes orphaned `Phaser.Text` objects after rapid hover or scene close.
- Migrated tooltip usage in `InventoryScene` (replaces in-house `_tooltip`) and `SmelteryScene` (removes `_mineralTooltip` + `_tooltipText` ad-hoc state, 3 call sites).
- **`_attachSlotInteraction(bg, opts)`** centralizes the long-press / tap / right-click / hover-fill / tooltip pattern that was copied across `_makeEquipSlot`, `_makeQuickUseSlot`, `_makeBackpackSlot`, and `_makePetBackpackSlot`. Each slot method now passes callbacks instead of inlining wiring. ~80 LoC of duplication removed; `InventoryScene.js` 781 → 736 lines.
- Tests added for `TooltipManager` (show/hide, replacement, idempotent hide, shutdown cleanup).

## Test plan
- [x] `node --check` clean across all source
- [ ] Test runner: open `tests/test-runner.html` → all green (incl. new `TooltipManager` suite)
- [ ] Manual UI:
  - [ ] Inventory → hover equip / quick-use / backpack / pet backpack slots → tooltip appears, follows cursor, disappears on out
  - [ ] Inventory → tap equipped slot unequips; long-press drops; right-click drops
  - [ ] Inventory → tap backpack uses item; long-press / right-click moves to pet (or drops if no pet)
  - [ ] Inventory → close mid-hover; no orphan tooltip text remains
  - [ ] Smeltery → hover stash mineral → "Tx → yields" tooltip; hover element badge → sources tooltip; close scene mid-hover → no orphans

https://claude.ai/code/session_01UBNPFro5RLpyaXmg3mw7ER

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBNPFro5RLpyaXmg3mw7ER)_