### PR TITLE
Add discovery sound effects #160

### DIFF
--- a/src/entities/Hero.js
+++ b/src/entities/Hero.js
@@ -158,6 +158,17 @@ class Hero {
         this._drawSprite();
     }
 
+    _flashHit() {
+        const s  = TILE_SIZE;
+        const fg = this.scene.add.graphics().setDepth(9);
+        fg.fillStyle(0xff3300, 0.45);
+        fg.fillRect(this.graphics.x + 2, this.graphics.y + 2, s - 4, s - 4);
+        this.scene.tweens.add({
+            targets: fg, alpha: 0, duration: 150,
+            onComplete: () => { if (fg.scene) fg.destroy(); }
+        });
+    }
+
     clearAllEffects() {
         this.poisonTurns = 0;
         this.burnTurns   = 0;

--- a/src/scenes/DiscoveryPopupScene.js
+++ b/src/scenes/DiscoveryPopupScene.js
@@ -154,6 +154,12 @@ class DiscoveryPopupScene extends Phaser.Scene {
             ease:     'Back.easeOut',
         });
 
+        if (data.type === 'elementBonus') {
+            Audio.playGroupBonus();
+        } else {
+            Audio.playDiscovery();
+        }
+
         this._container = container;
         this._autoTimer = this.time.delayedCall(3500, () => this._dismiss());
     }

--- a/src/scenes/GameOverScene.js
+++ b/src/scenes/GameOverScene.js
@@ -64,16 +64,16 @@ class GameOverScene extends Phaser.Scene {
         g.fillRect(0, 0, W, H);
 
         this.add.text(cx, cy - 110, 'DU FALT', {
-            fontSize: '56px', color: '#ff2244', fontFamily: 'monospace',
+            fontSize: '56px', color: '#ff2244', fontFamily: UI_FONTS.family,
             fontStyle: 'bold', stroke: '#660011', strokeThickness: 5
         }).setOrigin(0.5);
 
         this.add.text(cx, cy - 48, `Verden ${this.worldNum}  ·  Nivå ${this.heroStats.level}`, {
-            fontSize: '18px', color: '#ccaaaa', fontFamily: 'monospace'
+            fontSize: UI_FONTS.heading, color: '#ccaaaa', fontFamily: UI_FONTS.family
         }).setOrigin(0.5);
 
         this.add.text(cx, cy - 18, 'Du beholder nivå og stats. Verden genereres på nytt.', {
-            fontSize: '12px', color: '#664444', fontFamily: 'monospace'
+            fontSize: UI_FONTS.small, color: '#664444', fontFamily: UI_FONTS.family
         }).setOrigin(0.5);
 
         this._statsPanel(cx, cy + 18);
@@ -102,12 +102,12 @@ class GameOverScene extends Phaser.Scene {
         g.fillRect(0, 0, W, H);
 
         this.add.text(cx, cy - 110, '✦ VERDEN KLAR ✦', {
-            fontSize: '40px', color: '#f5e642', fontFamily: 'monospace',
+            fontSize: '40px', color: '#f5e642', fontFamily: UI_FONTS.family,
             fontStyle: 'bold', stroke: '#7a6a00', strokeThickness: 4
         }).setOrigin(0.5);
 
         this.add.text(cx, cy - 60, `Du fullførte Verden ${this.worldNum}!`, {
-            fontSize: '20px', color: '#ffffff', fontFamily: 'monospace'
+            fontSize: '20px', color: '#ffffff', fontFamily: UI_FONTS.family
         }).setOrigin(0.5);
 
         let yOff = 0;
@@ -122,7 +122,7 @@ class GameOverScene extends Phaser.Scene {
         const DIFF_LABEL = { easy: 'LETT', normal: 'NORMAL', hard: 'VANSKELIG' };
         const DIFF_COL   = { easy: '#44bb44', normal: '#4488ff', hard: '#ff4444' };
         this.add.text(cx, cy + 56 + yOff, `Vanskelighetsgrad: ${DIFF_LABEL[this.difficulty] || 'NORMAL'}`, {
-            fontSize: '12px', color: DIFF_COL[this.difficulty] || '#4488ff', fontFamily: 'monospace'
+            fontSize: UI_FONTS.small, color: DIFF_COL[this.difficulty] || '#4488ff', fontFamily: UI_FONTS.family
         }).setOrigin(0.5);
 
         const next  = this._button(cx, cy + 86 + yOff, `[ VERDEN ${nextW} ]`, '#00e87a', 26);
@@ -153,7 +153,7 @@ class GameOverScene extends Phaser.Scene {
         if (!ss) return;
         const CW = 400, CH = 86;
         const bg = this.add.graphics();
-        bg.fillStyle(0x0a0608, 0.82);
+        bg.fillStyle(UI_COLORS.panelBgDark, UI_COLORS.panelBgAlpha);
         bg.fillRoundedRect(cx - CW / 2, cy - CH / 2, CW, CH, 8);
         bg.lineStyle(1, 0x554433, 1);
         bg.strokeRoundedRect(cx - CW / 2, cy - CH / 2, CW, CH, 8);
@@ -167,10 +167,10 @@ class GameOverScene extends Phaser.Scene {
         const lx = cx - 185, lv = cx - 5, rx = cx + 15, rv = cx + 185;
         rows.forEach((row, i) => {
             const ry = cy - CH / 2 + 14 + i * 24;
-            this.add.text(lx, ry, row[0], { fontSize: '11px', color: '#887766', fontFamily: 'monospace' }).setOrigin(0, 0);
-            this.add.text(lv, ry, String(row[1]), { fontSize: '11px', color: '#ffdd88', fontFamily: 'monospace', fontStyle: 'bold' }).setOrigin(1, 0);
-            this.add.text(rx, ry, row[2], { fontSize: '11px', color: '#887766', fontFamily: 'monospace' }).setOrigin(0, 0);
-            this.add.text(rv, ry, String(row[3]), { fontSize: '11px', color: '#ffdd88', fontFamily: 'monospace', fontStyle: 'bold' }).setOrigin(1, 0);
+            this.add.text(lx, ry, row[0], { fontSize: '11px', color: '#887766', fontFamily: UI_FONTS.family }).setOrigin(0, 0);
+            this.add.text(lv, ry, String(row[1]), { fontSize: '11px', color: '#ffdd88', fontFamily: UI_FONTS.family, fontStyle: 'bold' }).setOrigin(1, 0);
+            this.add.text(rx, ry, row[2], { fontSize: '11px', color: '#887766', fontFamily: UI_FONTS.family }).setOrigin(0, 0);
+            this.add.text(rv, ry, String(row[3]), { fontSize: '11px', color: '#ffdd88', fontFamily: UI_FONTS.family, fontStyle: 'bold' }).setOrigin(1, 0);
         });
     }
 
@@ -187,7 +187,7 @@ class GameOverScene extends Phaser.Scene {
         this._ftPanel = panel;
 
         this.add.text(cx, cy - 80, 'Velg sone:', {
-            fontSize: '16px', color: '#44aadd', fontFamily: 'monospace'
+            fontSize: '16px', color: '#44aadd', fontFamily: UI_FONTS.family
         }).setOrigin(0.5);
 
         const completedZones = this.heroStats.completedZones || [];
@@ -197,7 +197,7 @@ class GameOverScene extends Phaser.Scene {
             const col = completed ? '#44ff88' : '#555566';
             const label = completed ? `▸ ${zone.name} (Verden ${zone.worlds[0]})` : `  ${zone.name} (låst)`;
             const btn = this.add.text(cx, yOff, label, {
-                fontSize: '13px', color: col, fontFamily: 'monospace'
+                fontSize: UI_FONTS.body, color: col, fontFamily: UI_FONTS.family
             }).setOrigin(0.5);
             if (completed) {
                 btn.setInteractive({ useHandCursor: true });
@@ -232,11 +232,11 @@ class GameOverScene extends Phaser.Scene {
         const ngLabel = ngPlus > 0 ? `  NG+${ngPlus}` : '';
 
         this.add.text(cx, cy - 180, '✦ ✦ ✦', {
-            fontSize: '32px', color: '#ffcc00', fontFamily: 'monospace'
+            fontSize: '32px', color: '#ffcc00', fontFamily: UI_FONTS.family
         }).setOrigin(0.5);
 
         const titleText = this.add.text(cx, cy - 145, 'GUDS PERIODISKE SYSTEM', {
-            fontSize: '36px', color: '#f5e642', fontFamily: 'monospace',
+            fontSize: '36px', color: '#f5e642', fontFamily: UI_FONTS.family,
             fontStyle: 'bold', stroke: '#7a6a00', strokeThickness: 6
         }).setOrigin(0.5);
         this.tweens.add({
@@ -245,11 +245,11 @@ class GameOverScene extends Phaser.Scene {
         });
 
         this.add.text(cx, cy - 100, `Du har samlet alle 118 grunnstoffer!${ngLabel}`, {
-            fontSize: '18px', color: '#ffffff', fontFamily: 'monospace'
+            fontSize: UI_FONTS.heading, color: '#ffffff', fontFamily: UI_FONTS.family
         }).setOrigin(0.5);
 
         this.add.text(cx, cy - 76, 'Universets hemmeligheter er avslørt. Du er en sann mester!', {
-            fontSize: '12px', color: '#ccaa66', fontFamily: 'monospace'
+            fontSize: UI_FONTS.small, color: '#ccaa66', fontFamily: UI_FONTS.family
         }).setOrigin(0.5);
 
         this._drawMiniPeriodicTable(cx, cy - 30);
@@ -307,7 +307,7 @@ class GameOverScene extends Phaser.Scene {
         if (ngPlus > 0) lines.push(`New Game+ syklus: ${ngPlus}`);
         lines.forEach((line, i) => {
             this.add.text(cx, cy + i * 18, line, {
-                fontSize: '13px', color: '#aabb99', fontFamily: 'monospace'
+                fontSize: UI_FONTS.body, color: '#aabb99', fontFamily: UI_FONTS.family
             }).setOrigin(0.5);
         });
     }
@@ -382,14 +382,14 @@ class GameOverScene extends Phaser.Scene {
         ];
         lines.forEach((line, i) => {
             this.add.text(cx, cy + i * 18, line, {
-                fontSize: '13px', color: '#8899bb', fontFamily: 'monospace'
+                fontSize: UI_FONTS.body, color: '#8899bb', fontFamily: UI_FONTS.family
             }).setOrigin(0.5);
         });
     }
 
     _button(x, y, label, color, size) {
         const btn = this.add.text(x, y, label, {
-            fontSize: `${size}px`, color, fontFamily: 'monospace'
+            fontSize: `${size}px`, color, fontFamily: UI_FONTS.family
         }).setOrigin(0.5).setInteractive({ useHandCursor: true });
         btn.on('pointerover', () => btn.setAlpha(0.7));
         btn.on('pointerout',  () => btn.setAlpha(1));

--- a/src/scenes/GameOverScene.js
+++ b/src/scenes/GameOverScene.js
@@ -10,6 +10,7 @@ class GameOverScene extends Phaser.Scene {
         this.difficulty     = data.difficulty || 'normal';
         this.monstersKilled = data.monstersKilled || 0;
         this.timeSeconds    = data.timeSeconds || 0;
+        this.summaryStats   = data.summaryStats || null;
     }
 
     create() {
@@ -109,16 +110,22 @@ class GameOverScene extends Phaser.Scene {
             fontSize: '20px', color: '#ffffff', fontFamily: 'monospace'
         }).setOrigin(0.5);
 
-        this._statsPanel(cx, cy - 10);
+        let yOff = 0;
+        if (this.summaryStats) {
+            this._summaryCard(cx, cy - 10);
+            yOff = 100;
+        }
+
+        this._statsPanel(cx, cy - 10 + yOff);
 
         const nextW = this.worldNum + 1;
         const DIFF_LABEL = { easy: 'LETT', normal: 'NORMAL', hard: 'VANSKELIG' };
         const DIFF_COL   = { easy: '#44bb44', normal: '#4488ff', hard: '#ff4444' };
-        this.add.text(cx, cy + 56, `Vanskelighetsgrad: ${DIFF_LABEL[this.difficulty] || 'NORMAL'}`, {
+        this.add.text(cx, cy + 56 + yOff, `Vanskelighetsgrad: ${DIFF_LABEL[this.difficulty] || 'NORMAL'}`, {
             fontSize: '12px', color: DIFF_COL[this.difficulty] || '#4488ff', fontFamily: 'monospace'
         }).setOrigin(0.5);
 
-        const next  = this._button(cx, cy + 86, `[ VERDEN ${nextW} ]`, '#00e87a', 26);
+        const next  = this._button(cx, cy + 86 + yOff, `[ VERDEN ${nextW} ]`, '#00e87a', 26);
         next.on('pointerdown', () => {
             this.scene.start('GameScene', {
                 worldNum:   nextW,
@@ -130,15 +137,41 @@ class GameOverScene extends Phaser.Scene {
         // Fast travel (if player has completed multiple zones)
         const completedZones = this.heroStats.completedZones || [];
         if (completedZones.length > 0 && typeof ZONES !== 'undefined') {
-            const travelBtn = this._button(cx, cy + 126, '[ HURTIGREISE ]', '#44aadd', 14);
+            const travelBtn = this._button(cx, cy + 126 + yOff, '[ HURTIGREISE ]', '#44aadd', 14);
             travelBtn.on('pointerdown', () => this._showFastTravel(cx, cy));
         }
 
-        const menuY = completedZones.length > 0 ? cy + 160 : cy + 136;
+        const menuY = completedZones.length > 0 ? cy + 160 + yOff : cy + 136 + yOff;
         const menu = this._button(cx, menuY, '[ HOVED MENY ]', '#666688', 14);
         menu.on('pointerdown', () => this.scene.start('MenuScene'));
 
         this.tweens.add({ targets: next, alpha: 0.5, duration: 600, yoyo: true, repeat: -1 });
+    }
+
+    _summaryCard(cx, cy) {
+        const ss = this.summaryStats;
+        if (!ss) return;
+        const CW = 400, CH = 86;
+        const bg = this.add.graphics();
+        bg.fillStyle(0x0a0608, 0.82);
+        bg.fillRoundedRect(cx - CW / 2, cy - CH / 2, CW, CH, 8);
+        bg.lineStyle(1, 0x554433, 1);
+        bg.strokeRoundedRect(cx - CW / 2, cy - CH / 2, CW, CH, 8);
+
+        const fmt = s => s < 60 ? `${s}s` : `${Math.floor(s / 60)}m${s % 60}s`;
+        const rows = [
+            ['Monstre drept',    ss.monstersKilled,    'Mineraler plukket', ss.mineralsCollected],
+            ['Nye grunnstoffer', ss.newElements,        'Nye mineraler',     ss.newMinerals],
+            ['Gull samlet',      ss.gold + 'g',         'Tid brukt',         fmt(ss.timeSeconds)],
+        ];
+        const lx = cx - 185, lv = cx - 5, rx = cx + 15, rv = cx + 185;
+        rows.forEach((row, i) => {
+            const ry = cy - CH / 2 + 14 + i * 24;
+            this.add.text(lx, ry, row[0], { fontSize: '11px', color: '#887766', fontFamily: 'monospace' }).setOrigin(0, 0);
+            this.add.text(lv, ry, String(row[1]), { fontSize: '11px', color: '#ffdd88', fontFamily: 'monospace', fontStyle: 'bold' }).setOrigin(1, 0);
+            this.add.text(rx, ry, row[2], { fontSize: '11px', color: '#887766', fontFamily: 'monospace' }).setOrigin(0, 0);
+            this.add.text(rv, ry, String(row[3]), { fontSize: '11px', color: '#ffdd88', fontFamily: 'monospace', fontStyle: 'bold' }).setOrigin(1, 0);
+        });
     }
 
     _showFastTravel(cx, cy) {

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -82,6 +82,12 @@ class GameScene extends Phaser.Scene {
             this.hero._draw();
         }
 
+        // Snapshot discovery counts for world summary card (#162)
+        this._worldStartElementCount = this.hero.elementTracker
+            ? this.hero.elementTracker.discoveredCount : 0;
+        this._worldStartMineralCount = this.hero.discoveredMinerals
+            ? Object.keys(this.hero.discoveredMinerals).length : 0;
+
         // ── Technology effects on floor start ─────────────────────────────
         if (this.hero.techForceField) this.hero.techForceFieldHP = 15;
         if (this.hero.techEMP) this.hero.empCharges = Math.max(this.hero.empCharges || 0, 1);
@@ -494,6 +500,21 @@ class GameScene extends Phaser.Scene {
             this.hero.victoryAchieved = true;
         }
 
+        const newElements = Math.max(0,
+            (this.hero.elementTracker ? this.hero.elementTracker.discoveredCount : 0)
+            - this._worldStartElementCount);
+        const newMinerals = Math.max(0,
+            (this.hero.discoveredMinerals ? Object.keys(this.hero.discoveredMinerals).length : 0)
+            - this._worldStartMineralCount);
+        const summaryStats = {
+            monstersKilled:    this.monstersKilled,
+            mineralsCollected: this.hero.mineralsCollected || 0,
+            newElements,
+            newMinerals,
+            gold:        this.hero.gold || 0,
+            timeSeconds: worldTime,
+        };
+
         SaveManager.save(this.worldNum + 1, this._getFullStats());
         this.time.delayedCall(300, () => {
             this.scene.start('GameOverScene', {
@@ -501,7 +522,8 @@ class GameScene extends Phaser.Scene {
                 worldNum: this.worldNum,
                 heroStats: this._getFullStats(), difficulty: this.difficulty,
                 monstersKilled: this.monstersKilled,
-                timeSeconds: worldTime
+                timeSeconds: worldTime,
+                summaryStats: isGameComplete ? null : summaryStats,
             });
         });
     }

--- a/src/scenes/InventoryScene.js
+++ b/src/scenes/InventoryScene.js
@@ -32,22 +32,22 @@ class InventoryScene extends Phaser.Scene {
         // Title shifted right to make room for portrait
         const contentCX = cx + 100;
         this.add.text(contentCX, panelY - panelH / 2 + 18, 'INVENTAR', {
-            fontSize: '22px', color: '#ccddff', fontFamily: 'monospace', fontStyle: 'bold'
+            fontSize: '22px', color: '#ccddff', fontFamily: UI_FONTS.family, fontStyle: 'bold'
         }).setOrigin(0.5);
 
         this.add.rectangle(contentCX, panelY - panelH / 2 + 54, panelW - 250, 1, 0x223344);
 
         // Stats line – dynamic so it refreshes
         this._statsText = this.add.text(contentCX, panelY - panelH / 2 + 40, '', {
-            fontSize: '13px', color: '#667788', fontFamily: 'monospace'
+            fontSize: UI_FONTS.body, color: '#667788', fontFamily: UI_FONTS.family
         }).setOrigin(0.5);
 
         // Section labels (static) - shifted right
         this.add.text(contentCX - 220, panelY - panelH / 2 + 62, 'UTSTYR', {
-            fontSize: '13px', color: '#445566', fontFamily: 'monospace'
+            fontSize: UI_FONTS.body, color: '#445566', fontFamily: UI_FONTS.family
         });
         this.add.text(contentCX, panelY - panelH / 2 + 168, 'EVNER', {
-            fontSize: '13px', color: '#445566', fontFamily: 'monospace'
+            fontSize: UI_FONTS.body, color: '#445566', fontFamily: UI_FONTS.family
         }).setOrigin(0.5);
         // RYGGSEKK label is drawn dynamically in _refresh() to show slot count
 
@@ -55,12 +55,12 @@ class InventoryScene extends Phaser.Scene {
             ? '[Trykk] Bruk/utstyr  ·  [Hold] → Kjæledyr/Slipp  ·  [E/ESC] Lukk'
             : '[Trykk] Bruk/utstyr  ·  [Hold] Slipp  ·  [E/ESC] Lukk';
         this.add.text(cx, panelY + panelH / 2 - 14, helpText, {
-            fontSize: '13px', color: '#334455', fontFamily: 'monospace'
+            fontSize: UI_FONTS.body, color: '#334455', fontFamily: UI_FONTS.family
         }).setOrigin(0.5);
 
         // Element Book button
         const ebBtn = this.add.text(cx - panelW / 2 + 20, cy - panelH / 2 + 18, 'Elementbok [B]', {
-            fontSize: '12px', color: '#997755', fontFamily: 'monospace'
+            fontSize: UI_FONTS.small, color: '#997755', fontFamily: UI_FONTS.family
         }).setOrigin(0, 0.5).setInteractive({ useHandCursor: true });
         UIHelper.attachHover(ebBtn, {
             hoverColor: '#ccaa77', normalColor: '#997755',
@@ -75,7 +75,7 @@ class InventoryScene extends Phaser.Scene {
         // Mineral wiki button
         const mwBtn = this.add.text(cx - panelW / 2 + 20 + ebBtn.width + 16,
             cy - panelH / 2 + 18, 'Mineral-wiki', {
-            fontSize: '12px', color: '#997755', fontFamily: 'monospace'
+            fontSize: UI_FONTS.small, color: '#997755', fontFamily: UI_FONTS.family
         }).setOrigin(0, 0.5).setInteractive({ useHandCursor: true });
         UIHelper.attachHover(mwBtn, {
             hoverColor: '#ccaa77', normalColor: '#997755',
@@ -87,7 +87,7 @@ class InventoryScene extends Phaser.Scene {
 
         // Close button (touch-friendly)
         const closeBtn = this.add.text(cx + panelW / 2 - 20, cy - panelH / 2 + 18, '✕', {
-            fontSize: '20px', color: '#667788', fontFamily: 'monospace'
+            fontSize: '20px', color: '#667788', fontFamily: UI_FONTS.family
         }).setOrigin(0.5).setInteractive({ useHandCursor: true });
         UIHelper.attachHover(closeBtn, {
             hoverColor: '#ff6666', normalColor: '#667788',
@@ -150,7 +150,7 @@ class InventoryScene extends Phaser.Scene {
         // Pet portrait is drawn inline with pet inventory section (see _drawPetInventory)
         // Hero name under portrait
         this._d(this.add.text(portraitX + portraitSize / 2, portraitY + portraitSize + 10, h.heroName || 'Helten', {
-            fontSize: '13px', color: '#8899bb', fontFamily: 'monospace'
+            fontSize: UI_FONTS.body, color: '#8899bb', fontFamily: UI_FONTS.family
         }).setOrigin(0.5));
 
         // Equipment slots (shifted right to leave room for portrait)
@@ -165,7 +165,7 @@ class InventoryScene extends Phaser.Scene {
         // Backpack label with count
         this._d(this.add.text(contentCX + 80, panelY - panelH / 2 + 220,
             `(${this.inv.itemCount}/10)`, {
-            fontSize: '13px', color: '#334455', fontFamily: 'monospace'
+            fontSize: UI_FONTS.body, color: '#334455', fontFamily: UI_FONTS.family
         }));
 
         // Backpack slots (dynamic size – base 10 + skill expansions)
@@ -177,7 +177,7 @@ class InventoryScene extends Phaser.Scene {
 
         const bpLabel = `RYGGSEKK (${this.inv.itemCount}/${bpCount})`;
         this._d(this.add.text(contentCX - 220, bpY - 22, bpLabel, {
-            fontSize: '13px', color: '#445566', fontFamily: 'monospace'
+            fontSize: UI_FONTS.body, color: '#445566', fontFamily: UI_FONTS.family
         }));
 
         for (let i = 0; i < bpCount; i++) {
@@ -224,7 +224,7 @@ class InventoryScene extends Phaser.Scene {
         ));
 
         this._d(this.add.text(x, y + size / 2 + 10, label, {
-            fontSize: '12px', color: '#445566', fontFamily: 'monospace'
+            fontSize: UI_FONTS.small, color: '#445566', fontFamily: UI_FONTS.family
         }).setOrigin(0.5));
 
         if (item) {
@@ -232,7 +232,7 @@ class InventoryScene extends Phaser.Scene {
             const eqDispName = (item.type === 'mineral' && typeof getMineralDisplayName !== 'undefined')
                 ? getMineralDisplayName(item, this.hero) : item.name;
             this._d(this.add.text(x, y - size / 2 - 10, this._shortName(eqDispName), {
-                fontSize: '11px', color: this._rarityTextColor(item), fontFamily: 'monospace'
+                fontSize: '11px', color: this._rarityTextColor(item), fontFamily: UI_FONTS.family
             }).setOrigin(0.5));
 
             const dropEquipped = () => {
@@ -249,7 +249,7 @@ class InventoryScene extends Phaser.Scene {
             });
         } else {
             this._d(this.add.text(x, y, 'Tom', {
-                fontSize: '13px', color: '#223344', fontFamily: 'monospace'
+                fontSize: UI_FONTS.body, color: '#223344', fontFamily: UI_FONTS.family
             }).setOrigin(0.5));
         }
     }
@@ -271,7 +271,7 @@ class InventoryScene extends Phaser.Scene {
         ));
 
         this._d(this.add.text(x, y + size / 2 + 10, 'Hurtig (Q)', {
-            fontSize: '12px', color: '#33aa88', fontFamily: 'monospace'
+            fontSize: UI_FONTS.small, color: '#33aa88', fontFamily: UI_FONTS.family
         }).setOrigin(0.5));
 
         if (itemDef) {
@@ -281,7 +281,7 @@ class InventoryScene extends Phaser.Scene {
             const sn = this._shortName(quDispName);
             const label = qu.count > 1 ? `${sn} ×${qu.count}` : sn;
             this._d(this.add.text(x, y - size / 2 - 10, label, {
-                fontSize: '11px', color: '#ccddff', fontFamily: 'monospace'
+                fontSize: '11px', color: '#ccddff', fontFamily: UI_FONTS.family
             }).setOrigin(0.5));
 
             const dropQuick = () => {
@@ -298,7 +298,7 @@ class InventoryScene extends Phaser.Scene {
             });
         } else {
             this._d(this.add.text(x, y, 'Tom', {
-                fontSize: '13px', color: '#223344', fontFamily: 'monospace'
+                fontSize: UI_FONTS.body, color: '#223344', fontFamily: UI_FONTS.family
             }).setOrigin(0.5));
         }
     }
@@ -332,13 +332,13 @@ class InventoryScene extends Phaser.Scene {
             const bpDispName = (itemDef.type === 'mineral' && typeof getMineralDisplayName !== 'undefined')
                 ? getMineralDisplayName(itemDef, this.hero) : itemDef.name;
             this._d(this.add.text(x, y + size / 2 - 2, this._shortName(bpDispName), {
-                fontSize: '11px', color: nameCol, fontFamily: 'monospace'
+                fontSize: '11px', color: nameCol, fontFamily: UI_FONTS.family
             }).setOrigin(0.5, 1));
 
             // Stack count badge
             if (count > 1) {
                 this._d(this.add.text(x + size / 2 - 4, y - size / 2 + 2, `${count}`, {
-                    fontSize: '12px', color: '#ffee88', fontFamily: 'monospace', fontStyle: 'bold'
+                    fontSize: UI_FONTS.small, color: '#ffee88', fontFamily: UI_FONTS.family, fontStyle: 'bold'
                 }).setOrigin(1, 0));
             }
 
@@ -388,17 +388,17 @@ class InventoryScene extends Phaser.Scene {
         const defStr = pet.effectiveDef > 0 ? `  DEF: ${pet.effectiveDef}` : '';
         const hpText = `${pet.petName}  HP: ${pet.hp}/${pet.effectiveMaxHp}  ATK: ${pet.effectiveAttack}${defStr}`;
         this._d(this.add.text(labelX, baseY, `KJÆLEDYR  ·  ${hpText}`, {
-            fontSize: '13px', color: '#ffaadd', fontFamily: 'monospace'
+            fontSize: UI_FONTS.body, color: '#ffaadd', fontFamily: UI_FONTS.family
         }));
         this._d(this.add.text(cx + panelW / 2 - 20, baseY,
             `(${pet.backpackCount}/4)`, {
-            fontSize: '13px', color: '#334455', fontFamily: 'monospace'
+            fontSize: UI_FONTS.body, color: '#334455', fontFamily: UI_FONTS.family
         }).setOrigin(1, 0));
 
         // Pet equipment slots (weapon + armor)
         const eqY = baseY + 18;
         this._d(this.add.text(labelX, eqY, 'Utstyr:', {
-            fontSize: '12px', color: '#886688', fontFamily: 'monospace'
+            fontSize: UI_FONTS.small, color: '#886688', fontFamily: UI_FONTS.family
         }));
         const eqSlotSize = 42;
         this._makePetEquipSlot(labelX + 54, eqY + eqSlotSize / 2 + 2, eqSlotSize, 'weapon', pet);
@@ -442,12 +442,12 @@ class InventoryScene extends Phaser.Scene {
             const petDispName = (itemDef.type === 'mineral' && typeof getMineralDisplayName !== 'undefined')
                 ? getMineralDisplayName(itemDef, this.hero) : itemDef.name;
             this._d(this.add.text(x, y + size / 2 - 2, this._shortName(petDispName), {
-                fontSize: '11px', color: nameCol, fontFamily: 'monospace'
+                fontSize: '11px', color: nameCol, fontFamily: UI_FONTS.family
             }).setOrigin(0.5, 1));
 
             if (count > 1) {
                 this._d(this.add.text(x + size / 2 - 4, y - size / 2 + 2, `${count}`, {
-                    fontSize: '12px', color: '#ffee88', fontFamily: 'monospace', fontStyle: 'bold'
+                    fontSize: UI_FONTS.small, color: '#ffee88', fontFamily: UI_FONTS.family, fontStyle: 'bold'
                 }).setOrigin(1, 0));
             }
 
@@ -486,7 +486,7 @@ class InventoryScene extends Phaser.Scene {
         if (item) {
             this._drawItemIcon(x, y, item, size - 8);
             this._d(this.add.text(x, y + size / 2 - 2, item.name.length > 8 ? item.name.slice(0, 7) + '…' : item.name, {
-                fontSize: '10px', color: '#ffaadd', fontFamily: 'monospace'
+                fontSize: '10px', color: '#ffaadd', fontFamily: UI_FONTS.family
             }).setOrigin(0.5, 1));
             bg.setInteractive({ useHandCursor: true });
             bg.on('pointerover', () => {
@@ -507,7 +507,7 @@ class InventoryScene extends Phaser.Scene {
             });
         } else {
             this._d(this.add.text(x, y, label, {
-                fontSize: '11px', color: '#443344', fontFamily: 'monospace'
+                fontSize: '11px', color: '#443344', fontFamily: UI_FONTS.family
             }).setOrigin(0.5));
         }
     }
@@ -521,7 +521,7 @@ class InventoryScene extends Phaser.Scene {
         const entries = Object.entries(counts);
         if (entries.length === 0) {
             this._d(this.add.text(cx, y, 'Ingen evner ennå', {
-                fontSize: '13px', color: '#334455', fontFamily: 'monospace'
+                fontSize: UI_FONTS.body, color: '#334455', fontFamily: UI_FONTS.family
             }).setOrigin(0.5));
             return;
         }
@@ -536,7 +536,7 @@ class InventoryScene extends Phaser.Scene {
                 cx - totalW / 2 + 44 + (i % 5) * 90,
                 y + Math.floor(i / 5) * 16,
                 lbl,
-                { fontSize: '12px', fontFamily: 'monospace', color: col }
+                { fontSize: UI_FONTS.small, fontFamily: UI_FONTS.family, color: col }
             ));
         });
     }

--- a/src/scenes/SmelteryScene.js
+++ b/src/scenes/SmelteryScene.js
@@ -30,7 +30,7 @@ class SmelteryScene extends Phaser.Scene {
 
         // ── Camp background art (behind everything) ──────────────────────────
         const panel = this.add.graphics();
-        panel.fillStyle(0x0a0608, 0.97);
+        panel.fillStyle(UI_COLORS.panelBgDark, 0.97);
         panel.fillRoundedRect(this.px, this.py, this.panelW, this.panelH, 8);
         if (SceneBackgrounds.addCampBackground) {
             SceneBackgrounds.addCampBackground(this, this.px, this.py, this.panelW, this.panelH);
@@ -42,29 +42,29 @@ class SmelteryScene extends Phaser.Scene {
         const contentW = this.panelW - 12;
         const contentH = 60;
         const uiGfx = this.add.graphics();
-        uiGfx.fillStyle(0x0a0608, 0.82);
+        uiGfx.fillStyle(UI_COLORS.panelBgDark, 0.82);
         uiGfx.fillRoundedRect(contentLeft, contentTop, contentW, contentH, 6);
 
         // Panel border
-        panel.lineStyle(2, 0xff7722);
+        panel.lineStyle(2, UI_COLORS.accentOrange);
         panel.strokeRoundedRect(this.px, this.py, this.panelW, this.panelH, 8);
 
         // Title
         this.add.text(cx, this.py + 22, 'SMELTEOVN  –  Leirplass', {
-            fontSize: '18px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
+            fontSize: UI_FONTS.heading, color: UI_TEXT.primary, fontFamily: UI_FONTS.family, fontStyle: 'bold'
         }).setOrigin(0.5);
 
         // Fuel indicator
         const fuel = this.smelter.calculateFuelEnergy(this.heroRef);
         this._fuelText = this.add.text(this.px + this.panelW - 20, this.py + 22, `Brensel: ${fuel} energi`, {
-            fontSize: '14px', color: '#886633', fontFamily: 'monospace'
+            fontSize: UI_FONTS.label, color: '#886633', fontFamily: UI_FONTS.family
         }).setOrigin(1, 0.5);
 
         // Element counts summary
         const tracker = this.heroRef.elementTracker;
         const elemCount = Object.keys(tracker.collected).length;
         this._elemText = this.add.text(this.px + 20, this.py + 22, `Grunnstoffer: ${elemCount}`, {
-            fontSize: '14px', color: '#887766', fontFamily: 'monospace'
+            fontSize: UI_FONTS.label, color: '#887766', fontFamily: UI_FONTS.family
         }).setOrigin(0, 0.5);
 
         this.add.rectangle(cx, this.py + 42, this.panelW - 20, 1, 0x332200);
@@ -88,8 +88,8 @@ class SmelteryScene extends Phaser.Scene {
             const tx = this.px + 30 + i * (tabW + 10) + tabW / 2;
             const active = this._tab === tab.id;
             const btn = this.add.text(tx, tabY, tab.label, {
-                fontSize: '16px', color: active ? '#ff7722' : '#554433',
-                fontFamily: 'monospace', fontStyle: active ? 'bold' : 'normal'
+                fontSize: '16px', color: active ? UI_TEXT.primary : '#554433',
+                fontFamily: UI_FONTS.family, fontStyle: active ? 'bold' : 'normal'
             }).setOrigin(0.5).setInteractive({ useHandCursor: true });
             btn.on('pointerdown', () => { this._tab = tab.id; this._refresh(); });
             this._tabBtns.push(btn);
@@ -99,7 +99,7 @@ class SmelteryScene extends Phaser.Scene {
 
         // ── Close button ──────────────────────────────────────────────────────
         const closeBtn = this.add.text(this.px + this.panelW - 20, this.py + 10, '✕', {
-            fontSize: '22px', color: '#886644', fontFamily: 'monospace'
+            fontSize: '22px', color: '#886644', fontFamily: UI_FONTS.family
         }).setOrigin(0.5).setInteractive({ useHandCursor: true });
         closeBtn.on('pointerdown', () => this.scene.stop());
 
@@ -159,13 +159,13 @@ class SmelteryScene extends Phaser.Scene {
 
         // Dark backing behind content for readability
         const cbg = this._d(this.add.graphics());
-        cbg.fillStyle(0x0a0608, 0.78);
+        cbg.fillStyle(UI_COLORS.panelBgDark, 0.78);
         cbg.fillRoundedRect(this.px + 6, this.contentY - 4, this.panelW - 12, this.panelH - (this.contentY - this.py) - 10, 4);
 
         // Update tab button colors
         const tabIds = ['stash', 'smelt', 'alloy', 'forge'];
         if (this.heroRef.semiconductorUnlocked) { tabIds.push('refine', 'semi', 'tech'); }
-        UIHelper.updateTabButtons(this._tabBtns, tabIds, this._tab, '#ff7722', '#554433');
+        UIHelper.updateTabButtons(this._tabBtns, tabIds, this._tab, UI_TEXT.primary, '#554433');
 
         // Update fuel text
         const fuel = this.smelter.calculateFuelEnergy(this.heroRef);
@@ -206,12 +206,12 @@ class SmelteryScene extends Phaser.Scene {
         const maxScroll = this._maxScrolls[this._tab] || 0;
         if (scrollOff > 0) {
             this._d(this.add.text(this.px + this.panelW / 2, this.contentY - 2, '▲ mer ▲', {
-                fontSize: '12px', color: '#665544', fontFamily: 'monospace'
+                fontSize: UI_FONTS.small, color: '#665544', fontFamily: UI_FONTS.family
             }).setOrigin(0.5, 1));
         }
         if (maxScroll > 0 && scrollOff < maxScroll - 1) {
             this._d(this.add.text(this.px + this.panelW / 2, this.py + this.panelH - 14, '▼ mer ▼', {
-                fontSize: '12px', color: '#665544', fontFamily: 'monospace'
+                fontSize: UI_FONTS.small, color: '#665544', fontFamily: UI_FONTS.family
             }).setOrigin(0.5));
         }
         // Scrollbar thumb on right edge
@@ -224,7 +224,7 @@ class SmelteryScene extends Phaser.Scene {
             const bar = this._d(this.add.graphics());
             bar.fillStyle(0x332200, 0.6);
             bar.fillRoundedRect(trackX, trackY, 4, trackH, 2);
-            bar.fillStyle(0xff7722, 0.7);
+            bar.fillStyle(UI_COLORS.accentOrange, 0.7);
             bar.fillRoundedRect(trackX, thumbY, 4, thumbH, 2);
         }
     }
@@ -252,9 +252,9 @@ class SmelteryScene extends Phaser.Scene {
 
         // "Alle" reset button
         const allBtn = this._d(this.add.text(bx, y, 'Alle', {
-            fontSize: '12px',
-            color: this._elementFilter === null ? '#ff7722' : '#554433',
-            fontFamily: 'monospace', fontStyle: this._elementFilter === null ? 'bold' : 'normal',
+            fontSize: UI_FONTS.small,
+            color: this._elementFilter === null ? UI_TEXT.primary : '#554433',
+            fontFamily: UI_FONTS.family, fontStyle: this._elementFilter === null ? 'bold' : 'normal',
             backgroundColor: '#0a0608', padding: { x: 3, y: 1 }
         }).setInteractive({ useHandCursor: true }));
         allBtn.on('pointerdown', () => { this._elementFilter = null; this._scrollOffsets[this._tab] = 0; this._refresh(); });
@@ -288,9 +288,9 @@ class SmelteryScene extends Phaser.Scene {
             const dimmed = count === 0;
 
             const badge = this._d(this.add.text(bx, y, symbol, {
-                fontSize: '12px',
-                color: isActive ? '#ff7722' : (dimmed ? '#222222' : hexCol),
-                fontFamily: 'monospace',
+                fontSize: UI_FONTS.small,
+                color: isActive ? UI_TEXT.primary : (dimmed ? '#222222' : hexCol),
+                fontFamily: UI_FONTS.family,
                 fontStyle: isActive ? 'bold' : 'normal',
                 backgroundColor: isActive ? '#331100' : '#0a0608',
                 padding: { x: 3, y: 1 }
@@ -313,7 +313,7 @@ class SmelteryScene extends Phaser.Scene {
         // smelt/alloy/forge tabs — keeping the filter always on top.
         const coverH = this.contentY - filterStartY;
         const cover = this._d(this.add.graphics());
-        cover.fillStyle(0x0a0608, 1.0);
+        cover.fillStyle(UI_COLORS.panelBgDark, 1.0);
         cover.fillRect(this.px + 6, filterStartY, this.panelW - 12, coverH);
         cover.lineStyle(1, 0x221100, 1.0);
         cover.lineBetween(this.px + 6, filterStartY + coverH - 2, this.px + this.panelW - 6, filterStartY + coverH - 2);
@@ -329,13 +329,13 @@ class SmelteryScene extends Phaser.Scene {
         const cy = this.contentY + (this.panelH - (this.contentY - this.py)) / 2 - 40;
         this._d(this.add.text(cx, cy, '🔒', { fontSize: '36px' }).setOrigin(0.5));
         this._d(this.add.text(cx, cy + 34, 'Krever Metallurg-skill!', {
-            fontSize: '16px', color: '#ff7722', fontFamily: 'monospace', fontStyle: 'bold'
+            fontSize: '16px', color: UI_TEXT.primary, fontFamily: UI_FONTS.family, fontStyle: 'bold'
         }).setOrigin(0.5));
         const hint = this._hasGeologSkill()
             ? 'Lær Rask smelting i skilltreet\nfor å bruke smelteovnen.'
             : 'Du trenger Geolog-skill først,\nderetter Metallurg-skill.';
         this._d(this.add.text(cx, cy + 58, hint, {
-            fontSize: '14px', color: '#665544', fontFamily: 'monospace', align: 'center'
+            fontSize: UI_FONTS.label, color: '#665544', fontFamily: UI_FONTS.family, align: 'center'
         }).setOrigin(0.5));
         this._contentEndY = this.contentY;
     }
@@ -451,7 +451,7 @@ class SmelteryScene extends Phaser.Scene {
         }
 
         const elemStr = result.elements.map(e => `${e.symbol}×${e.amount}`).join(', ');
-        EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `Smeltet: ${elemStr}`, color: '#ff7722' });
+        EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `Smeltet: ${elemStr}`, color: UI_TEXT.primary });
 
         // Geolog T2 visible feedback when double-yield triggered.
         if (result.doubled) {
@@ -487,7 +487,7 @@ class SmelteryScene extends Phaser.Scene {
         if (!hero.alloyInventory) hero.alloyInventory = {};
         hero.alloyInventory[alloyId] = (hero.alloyInventory[alloyId] || 0) + 1;
 
-        EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `Laget: ${result.alloy.name}!`, color: '#ff7722' });
+        EventBus.emit('floatingText', { gx: hero.gridX, gy: hero.gridY, msg: `Laget: ${result.alloy.name}!`, color: UI_TEXT.primary });
 
         Audio.playPickup();
         this._refresh();
@@ -621,7 +621,7 @@ class SmelteryScene extends Phaser.Scene {
         if (entries.length === 0) return;
 
         this._d(this.add.text(startX, y, 'Lagrede grunnstoffer (klikk for å filtrere):', {
-            fontSize: '14px', color: '#665544', fontFamily: 'monospace'
+            fontSize: UI_FONTS.label, color: '#665544', fontFamily: UI_FONTS.family
         }));
         y += 20;
 
@@ -636,7 +636,7 @@ class SmelteryScene extends Phaser.Scene {
             const isActive = this._elementFilter === symbol;
 
             const badge = this._d(this.add.text(bx, by, `${symbol}:${count}`, {
-                fontSize: '14px', color: isActive ? '#ffffff' : hexCol, fontFamily: 'monospace',
+                fontSize: UI_FONTS.label, color: isActive ? '#ffffff' : hexCol, fontFamily: UI_FONTS.family,
                 backgroundColor: isActive ? '#442200' : '#0a0818',
                 padding: { x: 4, y: 2 }
             }).setInteractive({ useHandCursor: true }));
@@ -648,7 +648,7 @@ class SmelteryScene extends Phaser.Scene {
                 const srcList = sources[sym];
                 if (srcList && srcList.length > 0) {
                     this._tooltipText = this._d(this.add.text(startX, by + 24, `${sym} ← ${srcList.join(', ')}`, {
-                        fontSize: '12px', color: '#998877', fontFamily: 'monospace',
+                        fontSize: UI_FONTS.small, color: '#998877', fontFamily: UI_FONTS.family,
                         backgroundColor: '#0a0608', padding: { x: 4, y: 2 }
                     }));
                 }

--- a/src/systems/AudioManager.js
+++ b/src/systems/AudioManager.js
@@ -318,6 +318,23 @@ const Audio = (function () {
             _noise(0.12, sfxGain, 0.12, 0.1, 50);
         },
 
+        /** Short ascending chime for standard discoveries (mineral/element/molecule/alloy) */
+        playDiscovery() {
+            if (!ctx || !sfxEnabled) return;
+            [0, 4, 7].forEach((s, i) =>
+                _note(_freq(s + 12), 0.18, sfxGain, 'triangle', 0.22, i * 0.09)
+            );
+        },
+
+        /** Celebratory fanfare for element-group bonus discoveries */
+        playGroupBonus() {
+            if (!ctx || !sfxEnabled) return;
+            [0, 4, 7, 12, 16].forEach((s, i) =>
+                _note(_freq(s + 12), 0.25, sfxGain, 'triangle', 0.28, i * 0.10)
+            );
+            _noise(0.18, sfxGain, 0.10, 0.45, 1200);
+        },
+
         // ── Settings ────────────────────────────────────────────────────────
 
         get musicEnabled() { return musicEnabled; },

--- a/src/systems/CombatManager.js
+++ b/src/systems/CombatManager.js
@@ -436,11 +436,20 @@ class CombatManager {
             }
         }
 
+        const isBoss = monster.type === 'boss' || monster.type === 'zone_boss';
+
         if (died || !scene.hero.alive) {
             scene.cameras.main.shake(120, 0.008);
+            scene.hero._flashHit();
             scene._heroDied();
         } else {
-            scene.cameras.main.shake(100, 0.006);
+            if (isBoss) {
+                scene.cameras.main.shake(160, 0.010);
+                scene.cameras.main.flash(150, 180, 20, 20, false);
+            } else {
+                scene.cameras.main.shake(100, 0.006);
+            }
+            scene.hero._flashHit();
             // Thorns synergy
             if (scene.hero.thornsDamage > 0 && monster.alive) {
                 const thornsResult = monster.takeDamage(scene.hero.thornsDamage);


### PR DESCRIPTION
Play a 3-note ascending chime (playDiscovery) when any discovery popup
appears, and a longer 5-note fanfare with sparkle noise (playGroupBonus)
for element-group bonus cards. Both methods respect the existing SFX
mute/volume settings.

Closes #160