### PR TITLE
Add mineral sources for all naturally-occurring elements

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,16 @@
 - **Synsfelt følger korridorene på Normal/Vanskelig (#185):** `MapRenderer.updateFog` bruker Bresenham-line-of-sight innenfor radius, så vegger blokkerer sikten. Lett vanskelighet beholder den klassiske sirkulære radiusen
 
 ### Balanse
+- **Alle naturlig forekommende grunnstoff har nå en mineralkilde:** Tidligere kunne 22 grunnstoff aldri oppdages fordi ingen mineral listet dem i `yields`. Lagt til 6 nye mineraler og utvidet 2 eksisterende:
+  - `bismuthinite` (Bi₂S₃, T4) – vismut
+  - `clausthalite` (PbSe, T4) – selen i blyselenid
+  - `lorandite` (TlAsS₂, T5) – thallium
+  - `gadolinite` ((Y,Ce)₂FeBe₂Si₂O₁₀, T5) – tunge sjeldne jordarter, spor av Tb og Ho
+  - `euxenite` ((Y,Ce,U)(Nb,Ta,Ti)₂O₆, T5) – spor av Eu, Tm, Lu
+  - `bekblende` (uren UO₂, T6) – uran + spor av hele aktinid-henfallskjeden (Ra, Rn, Po, Pa, Ac, At, Fr)
+  - `zircon` gir nå også spor av Hf (geokjemisk korrekt)
+  - `molybdenite` gir nå også spor av Re (IRL kommersielt biprodukt)
+  - He, Ne, Ar, Kr, Xe dekkes uendret av eksisterende `gas_pocket`-rom
 - **Nye mineraler for Cr/Mn/Ni/Sn og F (#175, #182):** Lagt til `pyrolusite` (Mn, T2), `fluorite` (F, T2), `stannite` (Sn+Cu, T3), `siegenite` (Ni+Co, T3). Lagt inn i `MINERAL_POOL[2]` og `[3]` så de dukker opp i tidlige verdener
 - **Tier 6 dominansen til Uraninitt/Thoritt brutt (#182):** Lagt til `rhodochrosite` (Mn, T6) og `awaruite_ore` (Ni-Fe, T6) i `MINERAL_POOL[6]`. Halverer effektivt U/Th-frekvensen på høyere verdener
 - **Pris-skalering mot gull-inflasjon (#184):** `_itemPrice` ganger nå med `1 + worldNum * 0.10` (mineraler `1 + worldNum * 0.08`). Effektiv pris-dobling rundt verden 10, tre-dobling rundt verden 20

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,6 +1,6 @@
 # Labyrint Hero – Game Design Document
-**Versjon:** 0.54
-**Sist oppdatert:** 2026-05-14 (v0.54)
+**Versjon:** 0.55
+**Sist oppdatert:** 2026-05-16 (v0.55)
 
 ---
 
@@ -539,7 +539,7 @@ Elements-modifikasjonen fletter det periodiske system, geologi, metallurgi og kj
 
 ### Nye datafiler
 - `src/data/elements.js` – 90 naturlige grunnstoffer (H–U, unntatt Tc og Pm) med symbol, atomnummer, kategori, tier (1-6), farge. 15 elementbonuser for gruppe/periode/kategori-fullføringer
-- `src/data/minerals.js` – ~36 malmer og ~9 krystaller med utbyttetabell (yields), energikostnad, smeltetid
+- `src/data/minerals.js` – ~63 malmer og ~9 krystaller med utbyttetabell (yields), energikostnad, smeltetid. Alle 90 naturlig forekommende grunnstoff (Z 1–92, unntatt Tc og Pm) har minst én potensiell kilde — enten direkte i en `yields`-tabell eller via `gas_pocket`-spesialrom (He, Ne, Ar, Kr, Xe)
 - `src/systems/ElementTracker.js` – Sporer oppdagelser og gruppeprestasjoner
 
 ### Mineraler i labyrinten

--- a/src/data/minerals.js
+++ b/src/data/minerals.js
@@ -117,9 +117,9 @@ const MINERAL_DEFS = {
     zircon: {
         id: 'zircon', name: 'Zirkon', type: 'mineral', subtype: 'ore',
         formula: 'ZrSiO₄', tier: 3, color: 0xccaa77,
-        yields: [{ symbol: 'Zr', amount: 3, chance: 1.0 }, { symbol: 'Si', amount: 1, chance: 0.85 }, { symbol: 'O', amount: 2, chance: 0.6 }],
+        yields: [{ symbol: 'Zr', amount: 3, chance: 1.0 }, { symbol: 'Si', amount: 1, chance: 0.85 }, { symbol: 'O', amount: 2, chance: 0.6 }, { symbol: 'Hf', amount: 1, chance: 0.25 }],
         energyCost: 3, smeltingTime: 4, stackSize: 10,
-        desc: 'Robust silikatmineral. Rik zirkoniumkilde.'
+        desc: 'Robust silikatmineral. Rik zirkoniumkilde. Inneholder alltid spor av hafnium.'
     },
     pentlandite: {
         id: 'pentlandite', name: 'Pentlanditt', type: 'mineral', subtype: 'ore',
@@ -270,9 +270,9 @@ const MINERAL_DEFS = {
     molybdenite: {
         id: 'molybdenite', name: 'Molybdenitt', type: 'mineral', subtype: 'ore',
         formula: 'MoS\u2082', tier: 4, color: 0x667788,
-        yields: [{ symbol: 'Mo', amount: 2, chance: 1.0 }, { symbol: 'S', amount: 1, chance: 1.0 }],
+        yields: [{ symbol: 'Mo', amount: 2, chance: 1.0 }, { symbol: 'S', amount: 1, chance: 1.0 }, { symbol: 'Re', amount: 1, chance: 0.15 }],
         energyCost: 4, smeltingTime: 5, stackSize: 10,
-        desc: 'Sølvgrå, flisete krystaller. Molybdenkilde.'
+        desc: 'Sølvgrå, flisete krystaller. Molybdenkilde – inneholder sjelden også rhenium.'
     },
     barite: {
         id: 'barite', name: 'Barytt', type: 'mineral', subtype: 'ore',
@@ -433,6 +433,50 @@ const MINERAL_DEFS = {
         desc: 'Radioaktivt thoriummineral. Alternativ kjernebrensel.'
     },
 
+    // Trace-element sources: fill remaining naturally-occurring gaps
+    bismuthinite: {
+        id: 'bismuthinite', name: 'Bismutinitt', type: 'mineral', subtype: 'ore',
+        formula: 'Bi₂S₃', tier: 4, color: 0x9999aa,
+        yields: [{ symbol: 'Bi', amount: 2, chance: 1.0 }, { symbol: 'S', amount: 2, chance: 0.85 }],
+        energyCost: 3, smeltingTime: 4, stackSize: 10,
+        desc: 'Blygrå metallisk sulfid. Viktigste vismutkilde.'
+    },
+    clausthalite: {
+        id: 'clausthalite', name: 'Clausthalitt', type: 'mineral', subtype: 'ore',
+        formula: 'PbSe', tier: 4, color: 0x556677,
+        yields: [{ symbol: 'Pb', amount: 2, chance: 1.0 }, { symbol: 'Se', amount: 1, chance: 0.5 }],
+        energyCost: 3, smeltingTime: 4, stackSize: 10,
+        desc: 'Sjelden blyselenid. Den fremste mineralkilden til selen.'
+    },
+    lorandite: {
+        id: 'lorandite', name: 'Lorandit', type: 'mineral', subtype: 'ore',
+        formula: 'TlAsS₂', tier: 5, color: 0xbb3344,
+        yields: [{ symbol: 'Tl', amount: 1, chance: 1.0 }, { symbol: 'As', amount: 1, chance: 0.7 }, { symbol: 'S', amount: 2, chance: 0.5 }],
+        energyCost: 4, smeltingTime: 5, stackSize: 10,
+        desc: 'Skarlagensrøde krystaller. Eneste praktiske kilde til thallium.'
+    },
+    gadolinite: {
+        id: 'gadolinite', name: 'Gadolinitt', type: 'mineral', subtype: 'ore',
+        formula: '(Y,Ce)₂FeBe₂Si₂O₁₀', tier: 5, color: 0x335544,
+        yields: [{ symbol: 'Y', amount: 1, chance: 0.85 }, { symbol: 'Be', amount: 1, chance: 0.7 }, { symbol: 'Fe', amount: 1, chance: 0.55 }, { symbol: 'Tb', amount: 1, chance: 0.20 }, { symbol: 'Ho', amount: 1, chance: 0.15 }],
+        energyCost: 4, smeltingTime: 5, stackSize: 10,
+        desc: 'Sort silikatmalm fra Norge. Bærer av tunge sjeldne jordarter.'
+    },
+    euxenite: {
+        id: 'euxenite', name: 'Euxenitt', type: 'mineral', subtype: 'ore',
+        formula: '(Y,Ce,U)(Nb,Ta,Ti)₂O₆', tier: 5, color: 0x443322,
+        yields: [{ symbol: 'Y', amount: 1, chance: 0.85 }, { symbol: 'Nb', amount: 1, chance: 0.6 }, { symbol: 'Ti', amount: 1, chance: 0.5 }, { symbol: 'Eu', amount: 1, chance: 0.20 }, { symbol: 'Tm', amount: 1, chance: 0.15 }, { symbol: 'Lu', amount: 1, chance: 0.10 }],
+        energyCost: 4, smeltingTime: 6, stackSize: 10,
+        desc: 'Brunsort oksidmalm. Konsentrerer sjeldne tunge lantanider.'
+    },
+    bekblende: {
+        id: 'bekblende', name: 'Bekblende', type: 'mineral', subtype: 'ore',
+        formula: 'UO₂ (uren)', tier: 6, color: 0x221a22,
+        yields: [{ symbol: 'U', amount: 2, chance: 1.0 }, { symbol: 'O', amount: 2, chance: 0.85 }, { symbol: 'Ra', amount: 1, chance: 0.20 }, { symbol: 'Rn', amount: 1, chance: 0.15 }, { symbol: 'Po', amount: 1, chance: 0.10 }, { symbol: 'Pa', amount: 1, chance: 0.10 }, { symbol: 'Ac', amount: 1, chance: 0.08 }, { symbol: 'At', amount: 1, chance: 0.05 }, { symbol: 'Fr', amount: 1, chance: 0.05 }],
+        energyCost: 6, smeltingTime: 8, stackSize: 10,
+        desc: 'Uren uranmalm. Curiene utvant radium og polonium herfra. Spor av hele henfallskjeden.'
+    },
+
     // ── Crystals / Gemstones (subtype: 'crystal') ───────────────────────────
     clear_quartz: {
         id: 'clear_quartz', name: 'Klar kvarts', type: 'mineral', subtype: 'crystal',
@@ -514,11 +558,11 @@ const MINERAL_POOL = {
     1: ['quartz', 'hematite', 'magnetite', 'limestone', 'halite', 'bauxite', 'olivine', 'ice_crystal', 'sylvite'],
     2: ['pyrite', 'ilmenite', 'apatite', 'niter', 'borax', 'thortveitite', 'fluorite', 'pyrolusite'],
     3: ['chalcopyrite', 'malachite', 'sphalerite', 'chromite', 'zircon', 'pentlandite', 'spodumene', 'cobaltite', 'vanadinite', 'stibnite', 'celestine', 'barite', 'stannite', 'siegenite'],
-    4: ['galena', 'cassiterite', 'cinnabar', 'columbite', 'monazite', 'bastnaesite', 'greenockite', 'wolframite', 'molybdenite', 'bromargyryte', 'iodyrite', 'germanite', 'gallite', 'xenotime', 'indite_ore'],
-    5: ['argentite', 'native_gold', 'native_silver', 'pgm_ore', 'samarskite', 'pollucite', 'calaverite'],
+    4: ['galena', 'cassiterite', 'cinnabar', 'columbite', 'monazite', 'bastnaesite', 'greenockite', 'wolframite', 'molybdenite', 'bromargyryte', 'iodyrite', 'germanite', 'gallite', 'xenotime', 'indite_ore', 'bismuthinite', 'clausthalite'],
+    5: ['argentite', 'native_gold', 'native_silver', 'pgm_ore', 'samarskite', 'pollucite', 'calaverite', 'lorandite', 'gadolinite', 'euxenite'],
     // Tier 6 now contains varied minerals so high worlds don't drown the
     // player in Uraninite/Thorite (#182). Each entry is one of 5 picks.
-    6: ['uraninite', 'thorite', 'rhodochrosite', 'awaruite_ore'],
+    6: ['uraninite', 'thorite', 'rhodochrosite', 'awaruite_ore', 'bekblende'],
 };
 
 const CRYSTAL_POOL = {


### PR DESCRIPTION
Previously 22 naturally-occurring elements (Z 1-92, excl. synthetic Tc/Pm)
had no mineral listing them in `yields`, so they could never be discovered.

New minerals (geochemically realistic):
- bismuthinite (Bi2S3, T4) - bismuth
- clausthalite (PbSe, T4) - selenium as trace in lead selenide
- lorandite (TlAsS2, T5) - thallium
- gadolinite (T5) - heavy rare earths, traces of Tb and Ho
- euxenite (T5) - traces of Eu, Tm, Lu
- bekblende (impure UO2, T6) - U + decay-chain traces of Ra, Rn, Po, Pa,
  Ac, At, Fr (historic mineral the Curies used to isolate Ra and Po)

Existing minerals extended (real-world geochemistry):
- zircon now also yields trace Hf (always co-occurs with Zr in nature)
- molybdenite now also yields trace Re (IRL commercial byproduct)

Noble gases He/Ne/Ar/Kr/Xe remain covered by the existing gas_pocket
special room from world 10+; only Rn lacked a source and is now covered
by bekblende as a decay product.

Trace yields use low chance values (0.05-0.35) so rare elements stay rare.

https://claude.ai/code/session_01Lxs8JwtfqDDLLBqJAYxYHA