### PR TITLE
Add MIT license and update project metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gunstein Skomedal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -130,3 +130,8 @@ docs/
 - [Game Design Document](docs/GDD.md) – Full spillbeskrivelse og regler
 - [Endringslogg](docs/CHANGELOG.md) – Versjonshistorikk
 - [Elements-modifikasjon](docs/Elements-mod.md) – Det periodiske system i spillet
+
+## Lisens
+
+Utgitt under [MIT-lisensen](LICENSE) – © 2026 Gunstein Skomedal.
+Fri til bruk, modifisering og distribusjon så lenge lisens- og copyright-notisen følger med.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## v0.55 – 2026-05-15
 
+### Tekniske endringer
+- **MIT-lisens lagt til:** Nytt `LICENSE`-fil i repo-root, `license`- og `author`-felt i `package.json`, og lisensseksjon i `README.md`. Prosjektet er nå offisielt åpen kildekode under MIT © 2026 Gunstein Skomedal
+
 ### Nye funksjoner
 - **Selg varer hos handelsmann (#183):** `MerchantScene` har nå Kjøp/Selg-faner. Selgepris er ca. 30% av kjøpsprisen (samme formel som `_itemPrice` så salgsverdien skalerer med tier, sjeldenhet og verden). Nøkkel og hakke kan ikke selges
 - **Synsfelt følger korridorene på Normal/Vanskelig (#185):** `MapRenderer.updateFog` bruker Bresenham-line-of-sight innenfor radius, så vegger blokkerer sikten. Lett vanskelighet beholder den klassiske sirkulære radiusen

--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "license": "MIT",
+  "author": "Gunstein Skomedal",
   "devDependencies": {
     "playwright": "1.56.0"
   }


### PR DESCRIPTION
## Summary
This PR adds official open-source licensing to the project by introducing an MIT license file, updating package metadata, and documenting the licensing in the README and changelog.

## Changes
- **Added LICENSE file** – MIT license with copyright notice (© 2026 Gunstein Skomedal)
- **Updated package.json** – Added `license: "MIT"` and `author: "Gunstein Skomedal"` fields
- **Updated README.md** – Added "Lisens" section linking to the LICENSE file with usage terms
- **Updated CHANGELOG.md** – Documented the licensing addition under v0.55 technical changes

## Details
The project is now officially released under the MIT license, allowing free use, modification, and distribution as long as the license and copyright notice are included. All metadata has been updated to reflect this across the repository.

https://claude.ai/code/session_016JACMcZ6ynTiPuPRexqSf6