### PR TITLE
Activate global leaderboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,10 @@ build/
 # Temp
 *.tmp
 *.bak
+
+# Cloudflare Wrangler cache
+.wrangler/
+backend/.wrangler/
+
+# Cowork local state
+.claude/

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -4,6 +4,6 @@ compatibility_date = "2024-01-01"
 
 [[kv_namespaces]]
 binding = "LEADERBOARD"
-id = "<YOUR_KV_NAMESPACE_ID>"
+id = "467642b21efe4b478e647bb9b3b37a57"
 # Create with: wrangler kv namespace create LEADERBOARD
 # Then replace the id above with the output.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## v0.55 – 2026-05-15
 
 ### Tekniske endringer
+- **Global leaderboard aktivert:** Scores fra alle spillere lagres i Cloudflare KV og vises i Leaderboard-scenen sin Global-fane. Worker deployet til `https://labyrint-hero-leaderboard.gskomedal.workers.dev` med KV-namespace `LEADERBOARD`
 - **MIT-lisens lagt til:** Nytt `LICENSE`-fil i repo-root, `license`- og `author`-felt i `package.json`, og lisensseksjon i `README.md`. Prosjektet er nå offisielt åpen kildekode under MIT © 2026 Gunstein Skomedal
 
 ### Nye funksjoner

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1,6 +1,6 @@
 # Labyrint Hero – Game Design Document
 **Versjon:** 0.55
-**Sist oppdatert:** 2026-05-16 (v0.55)
+**Sist oppdatert:** 2026-05-21 (v0.55)
 
 ---
 
@@ -417,8 +417,9 @@ Aktiveres automatisk når helten har evner fra begge stier i et par. Noen synerg
 - Maks 50 innlegg, sortert etter verdener klarert → nivå → drap
 - Registrerer kun verdensklarering, ikke død
 
-### Global ledertavle (#64)
+### Global ledertavle (#64) – aktivert v0.55
 - Backend: Cloudflare Worker + KV-lagring (`backend/worker.js`)
+- Live på `https://labyrint-hero-leaderboard.gskomedal.workers.dev` (KV-namespace `LEADERBOARD`)
 - REST API: `POST /scores` for innsending, `GET /scores` for henting (topp 100)
 - Automatisk innsending ved verdensklarering (brann-og-glem, feiler stille)
 - Filtrering: rase og vanskelighetsgrad

--- a/src/utils/GlobalLeaderboard.js
+++ b/src/utils/GlobalLeaderboard.js
@@ -18,7 +18,7 @@
 
 const GlobalLeaderboard = {
     // ⬇ CHANGE THIS to your deployed Cloudflare Worker URL ⬇
-    API_URL: 'https://labyrint-hero-leaderboard.workers.dev',
+    API_URL: 'https://labyrint-hero-leaderboard.gskomedal.workers.dev',
 
     /**
      * Submit a score to the global leaderboard (fire-and-forget).


### PR DESCRIPTION
Configures Cloudflare Worker URL + KV namespace id. Verified via curl tests (POST 201, anti-cheat 422) and manual UI check.