### PR TITLE
Tone down Henrik birthday loadout to a generous head start

### DIFF
--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -191,7 +191,7 @@ class GameScene extends Phaser.Scene {
         return Date.now() < Date.parse('2026-06-01T00:00:00');
     }
 
-    /** Equip a mythic loadout and grant near-eternal life to the birthday hero. */
+    /** Equip a strong loadout and grant a generous head start to the birthday hero. */
     _applyBirthdayLoadout() {
         const h = this.hero;
         const equipMythic = (id) => {
@@ -203,16 +203,16 @@ class GameScene extends Phaser.Scene {
         };
         equipMythic('mithril_axe');    // mythic → +21 angrep
         equipMythic('mithril_armor');  // mythic → +15 forsvar, +3 hjerte
-        // Near-eternal life
-        h.maxHearts += 90;
+        // Significantly more life than normal – but not invincible
+        h.maxHearts += 14;
         h.hearts     = h.maxHearts;
-        // Extra power for the birthday boy
-        h.attack       += 8;
-        h.defense      += 4;
-        h.visionRadius += 3;
-        h.gold         += 500;
+        // A modest power boost for the birthday boy
+        h.attack       += 3;
+        h.defense      += 2;
+        h.visionRadius += 2;
+        h.gold         += 300;
         // A little treasure to start with
-        for (let i = 0; i < 5; i++) h.inventory.addItem(ITEM_DEFS.big_health_pot);
+        for (let i = 0; i < 3; i++) h.inventory.addItem(ITEM_DEFS.big_health_pot);
         h.inventory.addItem(ITEM_DEFS.heart_crystal);
     }
 


### PR DESCRIPTION
## Summary
Follow-up to #192. The birthday loadout for `henrik12` was effectively god-mode (near-eternal life), so this rebalances it to a strong but beatable head start. The "very good" mythic weapon and armor are kept, since those were explicitly requested.

## Changes
- **Max hearts:** +90 (~99 total) → **+14** (~20 total) — significantly more than normal, but no longer invincible
- **Flat attack bonus:** +8 → +3
- **Flat defense bonus:** +4 → +2
- **Vision radius:** +3 → +2
- **Gold:** +500 → +300
- **Starter big health potions:** 5 → 3
- Kept: mythic Mithril axe (+21 atk) and mythic Mithril armor (+15 def, +3 hearts), 1 heart crystal

Mythic gear, the 7-day expiry window, the popup and the full Happy Birthday fanfare from #192 are unchanged.

## Test plan
- [x] `node tests/ci-runner.js` — all 103 tests pass
- [ ] Start a new game as `henrik12` and confirm hero begins with ~20 hearts, mythic gear, and the loadout is strong but killable

https://claude.ai/code/session_01PLXWW8HCiDNnxBVh8Xhn1E

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLXWW8HCiDNnxBVh8Xhn1E)_